### PR TITLE
Fixes for assorted undocumented issues

### DIFF
--- a/content/inforss/inforss.js
+++ b/content/inforss/inforss.js
@@ -62,25 +62,15 @@ var gInforssSpacerEnd = null;
 var gInforssNewbox1 = null;
 var gInforssResizeTimeout = null;
 
-//if (navigator.vendor == "Linspire Inc.")
-//{
-//  window.setTimeout(inforssStartExtension, 4000);
-//}
 //-------------------------------------------------------------------------------------------------------------
 function inforssStartExtension()
 {
-  //dump("start\n");
   try
   {
-    //dump("start 0\n");
-    //if (window.opener != null) inforssInspect(window.opener);
-    //alert(window.opener + " / " + window.arguments + " / " + (window.arguments == "") + " / " + (window.arguments != null));
     if ((window.arguments != null) || (window.opener != null))
     {
-      //dump("start 1=" + window.arguments[0] + "\n");
       inforssCheckVersion();
       checkContentHandler();
-      //      installProtocol();
       var inforssObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
       inforssObserverService.addObserver(InforssObserver, "reload", false);
       inforssObserverService.addObserver(InforssObserver, "banned", false);
@@ -103,40 +93,29 @@ function inforssStartExtension()
       var box = document.getElementById("inforss.newsbox1");
       if (box != null)
       {
-        //dump("an event handler has been set for the mouse wheel\n");
         box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
       }
 
       if ((inforssGetNbWindow() == 1) && (serverInfo.autosync == true) && (navigator.userAgent.indexOf("Thunderbird") == -1) && (navigator.userAgent.indexOf("Linspire Inc.") == -1))
       {
-        //dump("start 2 didier\n");
         inforssCopyRemoteToLocal(serverInfo.protocol, serverInfo.server, serverInfo.directory, serverInfo.user, serverInfo.password, inforssStartExtension1);
-        //dump("start 3\n");
-        //        inforssStartExtension1();
       }
       else
       {
-        //dump("start 3\n");
         inforssStartExtension1();
       }
     }
     else
     {
-      //dump("start 4\n");
       if (document.getElementById("inforss.headlines") != null)
       {
         document.getElementById("inforss.headlines").setAttribute("collapsed", "true");
-        //dump("start 5\n");
       }
     }
-    //    var statusbar = document.getElementById("status-bar");
-    //    statusbar.addEventListener("DOMAttrModified", function(event) { dump('coucou ' + event.attrName + ' ' + event.prevValue + ' ' + event.newValue + '\n') }, false);
-    //    statusbar.addEventListener("onoverflow", function(event) { alert('coucou onoverflow') }, false);
-    //    statusbar.addEventListener("onunderflow", function(event) { alert('coucou onunderflow') }, false);
   }
   catch (e)
   {
-    //    alert(e);
+    //FIXME inforssDebug?
     dump(e + "\n");
   }
 }
@@ -146,68 +125,39 @@ function checkContentHandler()
 {
   try
   {
-    /*
-        netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
-        var wccr = Components.classes["@mozilla.org/embeddor.implemented/web-content-handler-registrar;1"].getService(Components.interfaces.nsIWebContentConverterService);
-        var handlers = wccr.getContentHandlers("application/vnd.mozilla.maybe.feed", {});
-        if (handlers.length == 0)
-          return;
-
-        for (var i = 0; i < handlers.length; ++i) {
-          dump(handlers[i].name + "\n");
-          dump(handlers[i].uri + "\n");
-        }
-        if (wccr.getWebContentHandlerByURI("application/vnd.mozilla.maybe.feed", "feed://%s") == null)
-        {
-          wccr.registerContentHandler("application/vnd.mozilla.maybe.feed", "feed://%s", "InfoRSS", document.contentWindow);
-        }
-    */
     var ps = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
     var i = 0;
     var found = false;
     var typeBranch = null;
+    //FIXME really?
     while (found == false)
     {
       typeBranch = ps.getBranch("browser.contentHandlers.types." + i + ".");
       try
       {
-        found = (typeBranch.getCharPref("title") == "InfoRSS")
-          ++i;
+        found = (typeBranch.getCharPref("title") == "InfoRSS");
+        ++i;
       }
-      catch (e)
+      catch (err)
       {
         // No more handlers
         break;
       }
     }
-    //    if (found == false)
+    if (typeBranch)
     {
-      if (typeBranch)
-      {
-        typeBranch.setCharPref("type", "application/vnd.mozilla.maybe.feed");
-        var pls = Components.classes["@mozilla.org/pref-localizedstring;1"].createInstance(Components.interfaces.nsIPrefLocalizedString);
-        pls.data = "chrome://inforss/content/inforssNewFeed.xul?feed=%s";
-        typeBranch.setComplexValue("uri", Components.interfaces.nsIPrefLocalizedString, pls);
-        pls.data = "InfoRSS";
-        typeBranch.setComplexValue("title", Components.interfaces.nsIPrefLocalizedString, pls);
-      }
+      typeBranch.setCharPref("type", "application/vnd.mozilla.maybe.feed");
+      var pls = Components.classes["@mozilla.org/pref-localizedstring;1"].createInstance(Components.interfaces.nsIPrefLocalizedString);
+      pls.data = "chrome://inforss/content/inforssNewFeed.xul?feed=%s";
+      typeBranch.setComplexValue("uri", Components.interfaces.nsIPrefLocalizedString, pls);
+      pls.data = "InfoRSS";
+      typeBranch.setComplexValue("title", Components.interfaces.nsIPrefLocalizedString, pls);
     }
-    /*
-        var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("browser.contentHandlers.types.");
-        prefs.setCharPref("3.title", "InfoRSS");
-        prefs.setCharPref("3.uri", "feed://%s");
-        prefs.setCharPref("3.type", "application/vnd.mozilla.maybe.feed");
-    */
   }
   catch (e)
   {
     alert(e);
   }
-}
-
-function testCall()
-{
-  dump("testCall\n");
 }
 
 //-------------------------------------------------------------------------------------------------------------
@@ -239,8 +189,6 @@ function inforssAddItemToLivemarkMenu(event)
           event.stopPropagation();
           return true;
         }, false);
-        //           menupopup.setAttribute("onpopupshowing","return inforssSubMenu(" + items.length + ");");
-        //           menupopup.setAttribute("onpopuphiding","return inforssSubMenu2();");
         var markinfo = null;
         for (var i = 0; i < livemarkLinks.length; i++)
         {
@@ -270,10 +218,9 @@ function inforssLivemarkCommand(event)
 {
   try
   {
-    rssSwitchAll(event.target.parentNode, event.target.getAttribute("data"), event.target.getAttribute("label"), null)
+    rssSwitchAll(event.target.parentNode, event.target.getAttribute("data"), event.target.getAttribute("label"), null);
     event.cancelBubble = true;
     event.stopPropagation();
-
   }
   catch (e)
   {
@@ -285,7 +232,6 @@ function inforssLivemarkCommand(event)
 //-------------------------------------------------------------------------------------------------------------
 function inforssStartExtension1(step, status)
 {
-  //dump("inforssStartExtension1\n");
   try
   {
     if ((step == null) || (step != "send"))
@@ -294,10 +240,8 @@ function inforssStartExtension1(step, status)
       {
         if (gInforssMediator == null)
         {
-          //dump("inforssStartExtension1 step2\n");
           gInforssRssBundle = document.getElementById("bundle_inforss");
           gInforssMediator = new inforssMediator();
-          //          gInforssMediator.init();
           inforssSetTimer(gInforssMediator, "init", 1200);
           if (document.getElementById("contentAreaContextMenu") != null)
           {
@@ -320,10 +264,6 @@ function inforssStartExtension1(step, status)
         }
       }
     }
-    else
-    {
-      //      alert(step + " " + status);
-    }
   }
   catch (e)
   {
@@ -344,7 +284,6 @@ function inforssStopExtension()
       {
         var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("inforss.");
         prefs.setBoolPref("toolbar.collapsed", ((bartop.getAttribute("collapsed") == null) ? false : (bartop.getAttribute("collapsed") == "true")));
-        //dump("collapsed=" + ((bartop.getAttribute("collapsed") == null)? false : bartop.getAttribute("collapsed")) + "\n");
       }
       var inforssObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
       inforssObserverService.removeObserver(InforssObserver, "reload");
@@ -363,7 +302,6 @@ function inforssStopExtension()
       if ((inforssGetNbWindow() == 0) && (serverInfo.autosync == true) && (navigator.vendor != "Thunderbird") && (navigator.vendor != "Linspire Inc."))
       {
         inforssCopyLocalToRemote(serverInfo.protocol, serverInfo.server, serverInfo.directory, serverInfo.user, serverInfo.password, inforssStopExtension1, false);
-        //      window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", "wait until finish");
       }
     }
   }
@@ -376,14 +314,6 @@ function inforssStopExtension()
 //-------------------------------------------------------------------------------------------------------------
 function inforssStopExtension1(step, status)
 {
-  try
-  {
-    //    dump("apres push " + step + " " + status + "\n");
-  }
-  catch (e)
-  {
-    inforssDebug(e);
-  }
 }
 
 //-------------------------------------------------------------------------------------------------------------
@@ -395,6 +325,7 @@ function inforssGetNbWindow()
     var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
     var windowManagerInterface = windowManager.QueryInterface(Components.interfaces.nsIWindowMediator);
     var enumerator = windowManagerInterface.getEnumerator(null);
+    //FIXME No better way of counting these?
     while (enumerator.hasMoreElements())
     {
       returnValue++;
@@ -405,7 +336,6 @@ function inforssGetNbWindow()
   {
     inforssDebug(e);
   }
-  //dump("inforssGetNbWindow=" + returnValue + "\n");
   return returnValue;
 }
 
@@ -423,46 +353,31 @@ var InforssObserver = {
 function inforssGetRss(url, callback, user, password)
 {
   inforssTraceIn();
-  //alert("getRss=" + url + "\n");
-  //dump("getRss: " + url + " / " + callback + "\n");
-  //dump("getRss=" + url);
   try
   {
-    //      netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
     if (gInforssXMLHttpRequest != null)
     {
-      //alert("abort");
       gInforssXMLHttpRequest.abort();
     }
 
-    //dump("  old=" + gInforssTimeout);
     if (gInforssTimeout != null)
     {
-      //alert("clearTimeout");
       window.clearTimeout(gInforssTimeout);
       gInforssTimeout = null;
     }
     gInforssTimeout = window.setTimeout("inforssHandleTimeout('" + url + "')", 10000);
-    //dump("  new=" + gInforssTimeout + "\n");
     gInforssUrl = url;
     gInforssXMLHttpRequest = new XMLHttpRequest();
-    //      gInforssXMLHttpRequest.onload = eval(callback);
-    //      gInforssXMLHttpRequest.onerror = inforssErrorMacNews;
     gInforssXMLHttpRequest.callback = callback;
     gInforssXMLHttpRequest.user = user;
     gInforssXMLHttpRequest.password = password;
     gInforssXMLHttpRequest.onreadystatechange = inforssProcessReqChange;
     gInforssXMLHttpRequest.open("GET", url, true, user, password);
-    //      gInforssXMLHttpRequest.setRequestHeader('Accept','application/rss+xml')
-    //      gInforssXMLHttpRequest.setRequestHeader('Cache-Control','no-cache')
-    //      gInforssXMLHttpRequest.setRequestHeader("Content-Length","0");
     gInforssXMLHttpRequest.overrideMimeType("application/xml");
     gInforssXMLHttpRequest.send(null);
-    //alert("send");
   }
   catch (e)
   {
-    //alert(e);
     inforssDebug(e + "/" + url + "/" + callback);
   }
   inforssTraceOut();
@@ -473,7 +388,6 @@ function inforssGetRss(url, callback, user, password)
 function inforssHandleTimeout(url)
 {
   inforssTraceIn();
-  //alert("handleTimeout=" + url + " timeout=" + gInforssTimeout + "\n");
   if (gInforssXMLHttpRequest != null)
   {
     gInforssXMLHttpRequest.abort();
@@ -487,25 +401,16 @@ function inforssHandleTimeout(url)
 function inforssProcessReqChange()
 {
   inforssTraceIn();
-  //dump("processReqChange=" + gInforssUrl + "\n");
-  //alert("processReqChange:" + gInforssXMLHttpRequest.readyState + "/" + gInforssXMLHttpRequest.status);
-  // only if req shows "loaded"
   try
   {
-    //dump("gInforssXMLHttpRequest.readyState =" + gInforssXMLHttpRequest.readyState + "\n");
     if (gInforssXMLHttpRequest.readyState == INFORSS_COMPLETED)
     {
-      //dump("gInforssXMLHttpRequest.status =" + gInforssXMLHttpRequest.status + "\n");
-      // only if "OK"
       if ((gInforssXMLHttpRequest.status == 200) ||
         (gInforssXMLHttpRequest.status == 201) ||
         (gInforssXMLHttpRequest.status == 202))
       {
-        //inforssAlert("ReqChange:" + gInforssUrl + "/" + gInforssCounter + "/" + gInforssCallbackFunction);
-        //gInforssCounter++;
         if (gInforssTimeout != null)
         {
-          //dump("processReqChange clearTimeout=" + gInforssTimeout + "\n");
           window.clearTimeout(gInforssTimeout);
           gInforssTimeout = null;
         }
@@ -515,7 +420,6 @@ function inforssProcessReqChange()
       {
         if (gInforssXMLHttpRequest.status == 302)
         {
-          //dump("Redirect=" + gInforssXMLHttpRequest.getResponseHeader("Location") + "\n");     
           var url = gInforssXMLHttpRequest.getResponseHeader("Location");
           if (url != null)
           {
@@ -541,7 +445,6 @@ function inforssErrorMacNews()
 {
   inforssTraceIn();
   inforssDebug("errorMacNews", "There was a problem retrieving the XML data:\n" + gInforssXMLHttpRequest.status + "/" + gInforssXMLHttpRequest.statusText + "\n" + gInforssUrl);
-  //    alert(gInforssXMLHttpRequest.responseText);
   delete gInforssXMLHttpRequest;
   gInforssXMLHttpRequest = null;
   inforssTraceOut();
@@ -709,32 +612,10 @@ function rssFillPopup(obj, event)
   inforssTraceIn();
   try
   {
-    //inforssAlert("rssFillPopup" + "/" + (gInforssCounter++) + "/" + event.target.getAttribute("id"));
-    //dump(navigator.userAgent + " " + event.button + " " + event.ctrlKey + "\n");
     var returnValue = true;
     var leftButton = inforssXMLRepository.getMouseEvent();
-    /*
-        if ((navigator.userAgent.indexOf("rv:1.8.0.2") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.3") == -1) &&
-            (navigator.userAgent.indexOf("rv:1.8.0.4") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.5") == -1) &&
-            (navigator.userAgent.indexOf("rv:1.8.0.6") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.7") == -1) &&
-            (navigator.userAgent.indexOf("rv:1.8.0.8") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.9") == -1) &&
-            (navigator.userAgent.indexOf("rv:1.8.1") == -1))
-        {
-            leftButton = ((navigator.userAgent.indexOf("Firefox/1.0+") == -1) &&
-                          (navigator.userAgent.indexOf("Firefox/1.4") == -1) &&
-                          (navigator.userAgent.indexOf("Firefox/1.5") == -1) &&
-                          (navigator.userAgent.indexOf("Thunderbird/1.5") == -1) &&
-                          (navigator.userAgent.indexOf("SeaMonkey") == -1) &&
-                          (navigator.userAgent.indexOf("rv:1.9") == -1) &&
-                          (navigator.userAgent.indexOf("rv:2.0") == -1) &&
-                          (navigator.userAgent.indexOf("rv:5.") == -1) &&
-                          (navigator.userAgent.indexOf("rv:1.8") == -1)) ? 0 : 65535;
-        }
-    */
-    //dump("leftButton=" + leftButton + "\n");
     if ((event.button == leftButton) && (event.ctrlKey == false)) // left button
     {
-      //dump("rssFillPopup\n");
       clearAddRSSPopupMenu();
       if (event.target.getAttribute("id") == "inforss-menupopup")
       {
@@ -742,6 +623,7 @@ function rssFillPopup(obj, event)
       }
       var menupopup = document.getElementById("inforss-menupopup");
       var nb = 0;
+      //FIXME This achieves what exactly?
       try
       {
         if (gBrowser == null)
@@ -803,39 +685,6 @@ function rssFillPopup(obj, event)
         catch (e)
         {}
       }
-      // Bookmarks use rdf's
-      //var rdf = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
-      // Get the built in datasource
-      //var bookmarks = Components.classes["@mozilla.org/rdf/datasource;1?name=bookmarks"].getService(Components.interfaces.nsIRDFDataSource);
-
-      // The RDF component utilities
-      //var RDFC = Components.classes['@mozilla.org/rdf/container-utils;1'].getService(Components.interfaces.nsIRDFContainerUtils);
-
-      // Wrap Url Predicate
-      //var urlPredicateResource = rdf.GetResource("http://home.netscape.com/NC-rdf#URL");
-      // Wrap Url Literal
-      //var urlTargetLiteral = rdf.GetLiteral('https://gmail.google.com/');
-      // Get source returns the resource
-      //var urlSubjectResource = bookmarks.GetSource(urlPredicateResource, urlTargetLiteral, true);
-      //if(urlSubjectResource)
-      //{
-      //alert('Founded: ' + urlSubjectResource);
-      // Wrap Name Predicate - case sensitive
-      //var titlePredicate = rdf.GetResource("http://home.netscape.com/NC-rdf#Name");
-      // Get target from subject and predicate
-      //var titleTargetLiteral = bookmarks.GetTarget(urlSubjectResource, titlePredicate, true);
-      // Want literal not resource
-      //if (titleTargetLiteral instanceof Components.interfaces.nsIRDFLiteral)
-      //{
-      // Display the title
-      //alert(titleTargetLiteral.Value);
-      //}
-      //}
-      //else
-      //{
-      //alert('Not found');
-      //}
-      //dump("Hello\n");
       if ((inforssXMLRepository.isLivemark() == true) && (gBrowser != null))
       {
         var RDF = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
@@ -845,10 +694,6 @@ function rssFillPopup(obj, event)
     else
     {
       returnValue = false;
-      if ((event.button == 2) || (event.ctrlKey == true))
-      {
-        //        window.openDialog("chrome://inforss/content/inforssOption.xul","_blank","chrome,centerscreen,resizable=yes, dialog=yes");
-      }
     }
   }
   catch (e)
@@ -888,6 +733,7 @@ function inforssDisplayOption1()
   var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
   var windowManagerInterface = windowManager.QueryInterface(Components.interfaces.nsIWindowMediator);
   var enumerator = windowManagerInterface.getEnumerator("inforssOption");
+  //FIXME Wouldn't it be easier to just check if it doesn't have more elements?
   while (enumerator.hasMoreElements())
   {
     nb++;
@@ -923,7 +769,6 @@ function inforssAddaAddSubMenu(nb, data, labelStr)
 //-------------------------------------------------------------------------------------------------------------
 function inforssWalk(node, nb)
 {
-  //dump("inforssWalk\n");
   inforssTraceIn();
   try
   {
@@ -940,30 +785,18 @@ function inforssWalk(node, nb)
     var kNC_FEEDURL = RDF.GetResource("http://home.netscape.com/NC-rdf#FeedURL");
     if ((Bookmarks != null) && (RDFC.IsContainer(Bookmarks, node)))
     {
-      //dump("it's a folder\n");
       // It's a folder
       var name = Bookmarks.GetTarget(node, kNC_Name, true);
       var url = Bookmarks.GetTarget(node, kNC_URL, true);
       var feedurl = Bookmarks.GetTarget(node, kNC_FEEDURL, true);
-      //if (name != null)
-      //  dump("folder title = " + name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-      //if (url != null)
-      //  dump("folder url = " + url.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
       if ((name != null) && (feedurl != null))
       {
-        // dump("ok name and feedurl != null\n");
         target = Bookmarks.GetTarget(node, RDF.GetResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), true);
         if (target != null)
         {
           type = target.QueryInterface(Components.interfaces.nsIRDFResource).Value;
-          //            dump("folder feedurl = " + feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-          //            dump("type = " + type + "\n");
           if (type == "http://home.netscape.com/NC-rdf#Livemark")
           {
-            //            dump("folder title = " + name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-            //            dump("folder url = " + url.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-            //            dump("folder feedurl = " + feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-            //            dump("type = " + type + "\n");
             inforssAddaAddSubMenu(nb, feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value, name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value);
             nb++;
           }
@@ -986,20 +819,6 @@ function inforssWalk(node, nb)
         }
       }
     }
-    else
-    {
-      // It's just a bookmark.
-      //var target = Bookmarks.GetTarget(node, kNC_URL, true);
-      //if (target != null)
-      //  dump("url = " + target.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-      //target = Bookmarks.GetTarget(node, kNC_Name, true);
-      //if (target != null)
-      //  dump("title = " + target.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-      //target = Bookmarks.GetTarget(node, RDF.GetResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), true);
-      //if (target != null)
-      //  dump("type = " + target.QueryInterface(Components.interfaces.nsIRDFResource).Value + "\n");
-      //        dump("type = " + Bookmarks.GetTarget(node, RDF.GetResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), true).QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-    }
   }
   catch (e)
   {
@@ -1013,14 +832,9 @@ function inforssWalk(node, nb)
 function rssSwitchAll(popup, url, label, target)
 {
   inforssTraceIn();
-  //inforssAlert("rssSwitchAll");
-  //alert(url + "/" + label);
   var items = popup.getElementsByTagName(inforssXMLRepository.getSubMenuType());
-  //  var j = 0;
   if (label.indexOf(gInforssRssBundle.getString("inforss.menuadd") + " ") == 0) // if the user clicked on the "Add ..." button
   {
-    //dump("url=" + url + "\n");
-
     if (inforssGetItemFromUrl(url) != null) // already exists
     {
       alert(gInforssRssBundle.getString("inforss.duplicate"));
@@ -1035,7 +849,6 @@ function rssSwitchAll(popup, url, label, target)
   }
   else
   {
-    //alert("step 01");
     var changed = true;
     if ((target == null) || ((target.getAttribute("data") == url) && (target.getAttribute("label") == label)))
     {
@@ -1046,9 +859,7 @@ function rssSwitchAll(popup, url, label, target)
       document.getElementById('newsbar1').label = null;
       document.getElementById('newsbar1').style.visibility = "hidden";
     }
-    //alert("step 02");
     inforssSave();
-    //alert("step 03");
   }
   inforssTraceOut();
 }
@@ -1063,40 +874,25 @@ var infoRSSObserver = {
   },
   onDragOver: function(evt, flavour, session)
   {
-    //    session.canDrag=true;
-    //  inforssAlert("drag=" + evt.target.localName + " x=" + evt.clientX + "-" + gInforssX + "=" + (evt.clientX - gInforssX));
     if (evt.target.localName == "menuitem")
     {
-      //inforssInspect(evt.target.parentNode);
-      //document.getElementById("statusbar-display").label=evt.clientX;
     }
   },
   onDragStart: function(evt, transferData, action)
   {
-    //  gInforssX = evt.clientX;
-    //  inforssAlert("start=" + evt.target.localName);
     evt.stopPropagation();
     if (evt.target.localName == "menuitem")
     {
-      //inforssInspect(evt.target.parentNode);
-      //document.getElementById("statusbar-display").label=evt.clientX;
     }
-    //inforssInspect(ect.currentTarget);
-    //inforssInspect(transferData);
-    //inforssInspect(action);
-    //evt.target.canDrag=true;
     var htmlText = "<strong>infoRSS</strong>";
     var plainText = "infoRSS";
 
     transferData.data = new TransferData();
     transferData.data.addDataForFlavour("text/html", htmlText);
     transferData.data.addDataForFlavour("text/unicode", evt.target.getAttribute("data"));
-    //alert("coucou1");
   },
   onDragExit: function(evt, session)
   {
-    //  inforssAlert("exit=" + evt.clientX);
-    //alert("drag exit");
   },
   onDrop: function(evt, dropdata, session)
   {
@@ -1170,21 +966,17 @@ var infoRSSObserver = {
 var infoRSSTrashObserver = {
   getSupportedFlavours: function()
   {
-    //alert("11");
     var flavours = new FlavourSet();
     flavours.appendFlavour("text/unicode");
     return flavours;
   },
   onDragOver: function(evt, flavour, session)
   {
-    //inforssInspect(flavour);
     session.canDrag = true;
 
   },
   onDragStart: function(evt, transferData, action)
   {
-    //alert("33");
-
     var htmlText = "<strong>Cabbage</strong>";
     var plainText = "Cabbage";
 
@@ -1194,12 +986,9 @@ var infoRSSTrashObserver = {
   },
   onDragExit: function(evt, session)
   {
-    //alert("44");
-
   },
   onDrop: function(evt, dropdata, session)
   {
-    //alert("55");
     gInforssMediator.deleteRss(dropdata.data);
   }
 };
@@ -1215,25 +1004,16 @@ var infoRSSBarObserver = {
   onDragOver: function(evt, flavour, session) {},
   onDragStart: function(evt, transferData, action)
   {
-    //  gInforssX = evt.clientX;
-    //  inforssAlert("start=" + evt.target.localName);
     evt.stopPropagation();
     if (evt.target.localName == "menuitem")
     {
-      //inforssInspect(evt.target.parentNode);
-      //document.getElementById("statusbar-display").label=evt.clientX;
     }
-    //inforssInspect(ect.currentTarget);
-    //inforssInspect(transferData);
-    //inforssInspect(action);
-    //evt.target.canDrag=true;
     var htmlText = "<strong>infoRSS</strong>";
     var plainText = "infoRSS";
 
     transferData.data = new TransferData();
     transferData.data.addDataForFlavour("text/html", htmlText);
     transferData.data.addDataForFlavour("text/unicode", evt.target.getAttribute("data"));
-    //alert("coucou");
   },
   onDragExit: function(evt, session) {},
   onDrop: function(evt, dropdata, session)
@@ -1248,7 +1028,6 @@ var infoRSSBarObserver = {
       (rss != null) && (rss.getAttribute("type") != "group") &&
       (selectedInfo.containsFeed(url) == false))
     {
-      //      if (confirm(gInforssRssBundle.getString("inforss.confirm.addtogroup") + selectedInfo.getUrl() + ")") == true)
       {
         selectedInfo.addNewFeed(url);
       }
@@ -1257,37 +1036,6 @@ var infoRSSBarObserver = {
     {
       window.openDialog("chrome://inforss/content/inforssAlert.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=no", gInforssRssBundle.getString("inforss.notagroup"));
     }
-    /*
-      if (evt.target.nodeName == "statusbarpanel")
-      {
-        var url = dropdata.data;
-        if (url.indexOf("\n") != -1)
-        {
-          url = url.substring(0, url.indexOf("\n"));
-        }
-        if (url != "")
-        {
-          if (((url.indexOf("file://") == -1) && (url.indexOf("http://") == -1)  && (url.indexOf("https://") == -1)))
-          {
-            evt.cancelBubble = true;
-            evt.stopPropagation();
-            window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("bundle_inforss").getString("inforss.malformedUrl"));
-          }
-          else
-          {
-            if (inforssGetItemFromUrl(url) != null)
-            {
-              window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("bundle_inforss").getString("inforss.duplicate"));
-            }
-            else
-            {
-              getInfoFromUrl(url);
-            }
-          }
-        }
-        inforssSave();
-      }
-      */
     evt.cancelBubble = true;
     evt.stopPropagation();
   }
@@ -1297,7 +1045,6 @@ var infoRSSBarObserver = {
 function inforssAddItemToRSSList(title, description, url, link, user, password, feedFlag)
 {
   inforssTraceIn();
-  //alert("start inforssAddItemToRSSList");
   var elem = null;
   try
   {
@@ -1306,7 +1053,6 @@ function inforssAddItemToRSSList(title, description, url, link, user, password, 
       RSSList = document.createElement("LIST-RSS");
     }
     elem = RSSList.createElement("RSS");
-    //alert(RSSList.firstChild.childNodes.length);
     elem.setAttribute("url", url);
     elem.setAttribute("title", title);
     elem.setAttribute("selected", "false");
@@ -1329,16 +1075,12 @@ function inforssAddItemToRSSList(title, description, url, link, user, password, 
     }
     elem.setAttribute("filter", "all");
     elem.setAttribute("type", ((feedFlag == true) ? "atom" : "rss"));
-    /**/
-    console.log("user", user, "attribute", elem.getAttribute("user"));
     RSSList.firstChild.appendChild(elem);
   }
   catch (e)
   {
-    //alert(e);
-    inforssDebug("addItemToRSSList", e)
+    inforssDebug(e)
   }
-  //alert(RSSList.firstChild.childNodes.length);
   inforssTraceOut();
   return elem;
 }
@@ -1372,7 +1114,7 @@ function inforssLocateMenuItem(title)
   }
   catch (e)
   {
-    inforssDebug("addItemToRSSList", e)
+    inforssDebug(e)
   }
   inforssTraceOut();
   return item;
@@ -1382,7 +1124,6 @@ function inforssLocateMenuItem(title)
 function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
 {
   inforssTraceIn();
-  //alert("start inforssAddItemToMenu");
   var menuItem = null;
   try
   {
@@ -1403,7 +1144,6 @@ function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
 
         menuItem.setAttribute("type", "radio");
         menuItem.setAttribute("label", rss.getAttribute("title"));
-        //alert("title=" + rss.getAttribute("title") + "\n");
         menuItem.setAttribute("value", rss.getAttribute("title"));
 
 
@@ -1441,19 +1181,14 @@ function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
           }
           menupopup.setAttribute("onpopuphiding", "return inforssSubMenu2();");
           menupopup.setAttribute("id", "inforss.menupopup-" + items.length);
-          //           menupopup.addEventListener("command", function() { mouseup(this, event); return true;}, false);
-          //           menupopup.setAttribute("disabled","true");
           inforssAddNoData(menupopup);
           menuItem.appendChild(menupopup);
-          //           menupopup.addEventListener("command", function() { alert('didier');  return false;}, false);
-          //           menupopup.addEventListener("mouseup", function() { alert('ernotte');  return false;}, false);
         }
 
         if (inforssXMLRepository.getSortedMenu() != "no")
         {
           var indexItem = inforssLocateMenuItem(rss.getAttribute("title"));
           document.getElementById("inforss-menupopup").insertBefore(menuItem, indexItem);
-          //dump("indexItem=" + indexItem + "\n");
         }
         else
         {
@@ -1463,12 +1198,7 @@ function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
         {
           document.getElementById("inforss-menupopup").selectedItem = menuItem;
         }
-        //if (rss.getAttribute("type") == "group")
-        //{
-        //dump("addItemToMenu GROUP " + rss.getAttribute("url") + " " + rss.getElementsByTagName("GROUP").length + "\n");
-        //}
       }
-      //alert("addFeed");
       gInforssMediator.addFeed(rss, menuItem, saveFlag);
       if (flagAlert == true)
       {
@@ -1478,7 +1208,6 @@ function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
   }
   catch (e)
   {
-    //alert(e);
     inforssDebug(e)
   }
   inforssTraceOut();
@@ -1491,19 +1220,20 @@ function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
 function inforssSubMenu(index)
 {
   inforssTraceIn();
-  //inforssAlert("toto:" + index);
   popup = document.getElementById("inforss.menupopup-" + index);
   inforssSubMenu2();
+  var res;
   if (inforssXMLRepository.getSubMenu() == "true")
   {
     gInforssCurrentMenuHandle = window.setTimeout("inforssSubMenu1(" + index + ")", 3000);
-    return true;
+    res = true;
   }
   else
   {
-    return false;
+    res = false;
   }
   inforssTraceOut();
+  return res;
 }
 
 //-------------------------------------------------------------------------------------------------------------
@@ -1512,13 +1242,11 @@ function inforssSubMenu1(index)
   inforssTraceIn();
   try
   {
-    //inforssAlert("toto1:" + index);
     gInforssCurrentMenuHandle = null;
     popup = document.getElementById("inforss.menupopup-" + index);
     item = document.getElementById("inforss.menuitem-" + index);
     url = item.getAttribute("url");
     var rss = inforssGetItemFromUrl(url);
-    //inforssAlert("toto1:" + url);
     popup.setAttribute("onpopupshowing", null);
     inforssResetPopup(popup);
     var xmlHttpRequest = new XMLHttpRequest();
@@ -1528,7 +1256,6 @@ function inforssSubMenu1(index)
 
     var fm = new FeedManager();
     fm.parse(xmlHttpRequest);
-    //inforssAlert("len=" + fm.rssFeeds.length);
     var max = INFORSS_MAX_SUBMENU;
     max = Math.min(max, fm.rssFeeds.length);
     for (var i = 0; i < max; i++)
@@ -1550,12 +1277,11 @@ function inforssSubMenu1(index)
         event.stopPropagation();
         return true;
       }, false);
-      //           newElem.addEventListener("mouseup", function(event) { alert('ernotte');  event.cancelBubble = true; event.stopPropagation(); return true;}, false);
     }
   }
   catch (e)
   {
-    //    alert("toto1: " + e)
+    inforssDebug(e)
   }
   inforssTraceOut();
 }
@@ -1576,7 +1302,6 @@ function inforssSubMenu2()
 //-------------------------------------------------------------------------------------------------------------
 function inforssSubMenu3()
 {
-  //inforssAlert("toto3" + "/" + (gInforssCounter++));
   return true;
 }
 
@@ -1612,7 +1337,6 @@ function inforssResetPopup(popup)
 }
 
 //-------------------------------------------------------------------------------------------------------------
-// gBrowser.addTab("http://www.mozdev.org");
 
 function openNewTabInForeground(href, linkNode, event, securityCheck, postData)
 {
@@ -1640,7 +1364,6 @@ function openNewTabInForeground(href, linkNode, event, securityCheck, postData)
 function getInfoFromUrl(url)
 {
   inforssTraceIn();
-  //inforssAlert("getInfoFromUrl:" + url);
   gInforssUser = null;
   gInforssPassword = null;
   var getFlag = true;
@@ -1666,11 +1389,8 @@ function getInfoFromUrl(url)
   }
   if (getFlag == true)
   {
-    //alert("avant");
     inforssGetRss(url, "inforssPopulateMenuItem", gInforssUser, gInforssPassword);
-    //alert("apres");
   }
-  //alert("end getInfoFromUrl");
   inforssTraceOut();
 }
 
@@ -1680,17 +1400,13 @@ function inforssPopulateMenuItem()
   inforssTraceIn();
   try
   {
-    //dump("Status=" + gInforssXMLHttpRequest.status + "\n");
     var objDOMParser = new DOMParser();
-    //dump(gInforssXMLHttpRequest.responseText + "\n");
     var objDoc = objDOMParser.parseFromString(gInforssXMLHttpRequest.responseText, "text/xml");
-    //dump("step1" + "\n");
     var str_description = null;
     var str_title = null;
     var str_link = null;
     var feed_flag = false;
     var validFormat = false;
-    //dump("step2" + "\n");
 
     var format = inforssGetFormat(objDoc);
     if (format == "feed")
@@ -1711,7 +1427,6 @@ function inforssPopulateMenuItem()
         validFormat = true;
       }
     }
-    //dump("step3: " + format + "\n");
 
     var titles = objDoc.getElementsByTagName(str_title);
     var links = objDoc.getElementsByTagName(str_link);
@@ -1720,17 +1435,10 @@ function inforssPopulateMenuItem()
     {
       descriptions = objDoc.getElementsByTagName("title");
     }
-    //dump("step4" + "\n");
-    //dump(format + " " + descriptions.length + " " + links.length + " " + titles.length + "\n");
 
     if ((descriptions.length > 0) && (links.length > 0) && (titles.length > 0))
     {
-      //dump("step5" + "\n");
-      /**/
-      console.log("got a new item", gInforssUrl, gInforssUser);
       var elem = inforssAddItemToRSSList(getNodeValue(titles), getNodeValue(descriptions), gInforssUrl, (feed_flag == true) ? getHref(links) : getNodeValue(links), gInforssUser, gInforssPassword, feed_flag);
-      /**/
-      console.log("elem is", elem)
       delete gInforssXMLHttpRequest;
       var urlIcon = inforssFindIcon(elem);
       if (urlIcon != null)
@@ -1755,11 +1463,6 @@ function inforssPopulateMenuItem()
   gInforssXMLHttpRequest = null;
   inforssTraceOut();
 }
-
-//  gIeViewBundle = document.getElementById("bundle_ieview");
-//gIeViewBundle.getString("ieview.cantFindExplorer");
-
-
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssMouseUp(menu, event)
@@ -1800,6 +1503,7 @@ function inforssMouseUp(menu, event)
 function inforssGetItemFromUrl(url)
 {
   inforssTraceIn();
+  //FIXME Seriously?
   var items = RSSList.getElementsByTagName("RSS");
   var find = false;
   var i = 0;
@@ -1822,6 +1526,7 @@ function inforssGetItemFromUrl(url)
 function getCurrentRSS()
 {
   inforssTraceIn();
+  //Nearly the same as above
   var items = RSSList.getElementsByTagName("RSS");
   var find = false;
   var i = 0;
@@ -1852,7 +1557,6 @@ function manageRSSChanged(subject, topic, data)
       {
         case "reload":
           {
-            //dump("reload\n");
             if (data != null)
             {
               var urls = data.split("|");
@@ -1930,8 +1634,6 @@ function manageRSSChanged(subject, topic, data)
           }
         case "addFeed":
           {
-            //dump("AddFeed: " + data + "\n");
-            //alert(data);
             inforssAddNewFeed(
             {
               inforssUrl: data
@@ -2004,11 +1706,9 @@ function inforssRelocateBar()
 
     if (inforssXMLRepository.getSeparateLine() == "false") // in the status bar
     {
-      //dump("inforssRelocateBar step 1\n");
       document.getElementById("inforss.resizer").setAttribute("collapsed", "false");
       if (container.getAttribute("id") != "addon-bar")
       {
-        //dump("inforssRelocateBar step 2\n");
         container.parentNode.removeChild(container);
         document.getElementById("addon-bar").appendChild(headlines);
         statuspanelNews.setAttribute("flex", "0");
@@ -2017,10 +1717,8 @@ function inforssRelocateBar()
         var box = document.getElementById("inforss.newsbox1");
         if (box != null)
         {
-          //dump("an event handler has been set for the mouse wheel\n");
           box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
         }
-        //dump("inforssRelocateBar step 3\n");
       }
     }
     else
@@ -2038,7 +1736,6 @@ function inforssRelocateBar()
           { // was in the status bar
             headlines.parentNode.removeChild(headlines);
           }
-          //		  var statusbar = document.createElement("hbox");
           var statusbar = document.createElement("toolbar");
           statusbar.setAttribute("persist", "collapsed");
           statusbar.setAttribute("id", "inforss-bar-top");
@@ -2052,9 +1749,7 @@ function inforssRelocateBar()
           {
             colla = prefs.getBoolPref("toolbar.collapsed");
           }
-          //dump("colla=" + colla + "\n");
           statusbar.setAttribute("collapsed", colla);
-          //alert(statusbar.getAttribute("collapsed") + "/" + statusbar.getAttribute("hidden"));
           statusbar.appendChild(headlines);
           var toolbox = document.getElementById("navigator-toolbox");
           if (toolbox == null)
@@ -2066,7 +1761,6 @@ function inforssRelocateBar()
           {
             toolbox.appendChild(statusbar);
           }
-          //		  toolbox.parentNode.insertBefore(statusbar, toolbox.nextSibling);
           statusbar.setAttribute("toolbarname", "InfoRSS");
           statuspanelNews.setAttribute("flex", "1");
           statuspanelNews.firstChild.setAttribute("flex", "1");
@@ -2074,7 +1768,6 @@ function inforssRelocateBar()
           var box = document.getElementById("inforss.newsbox1");
           if (box != null)
           {
-            //dump("an event handler has been set for the mouse wheel\n");
             box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
           }
         }
@@ -2102,7 +1795,6 @@ function inforssRelocateBar()
           var box = document.getElementById("inforss.newsbox1");
           if (box != null)
           {
-            //dump("an event handler has been set for the mouse wheel\n");
             box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
           }
         }
@@ -2120,7 +1812,6 @@ function inforssRelocateBar()
 function inforssDeleteTree(obj)
 {
   inforssTraceIn();
-  //alert("deletetree\n");
   while (obj.firstChild != null)
   {
     obj.removeChild(obj.firstChild);
@@ -2139,13 +1830,13 @@ function inforssEraseNews()
 //-----------------------------------------------------------------------------------------------------
 function inforssResizeHeadlines(event)
 {
-  dump("resize " + event.clientX + "\n");
+  //dump("resize " + event.clientX + "\n");
   try
   {
     if (gInforssCanResize == true)
     {
-      dump("event type=" + event.type + "\n");
-      dump("event which=" + event.which + "\n");
+      //dump("event type=" + event.type + "\n");
+      //dump("event which=" + event.which + "\n");
       {
         var delta = event.clientX - gInforssX;
         var hbox = document.getElementById('inforss.newsbox1');
@@ -2154,45 +1845,13 @@ function inforssResizeHeadlines(event)
           if ((hbox.getAttribute("width") != null) && (hbox.getAttribute("width") != ""))
           {
             var width = hbox.getAttribute("width");
-            dump("old width=" + width + "\n");
+            //dump("old width=" + width + "\n");
             var oldWidth = width
             var oldX = hbox.boxObject.screenX;
             width = eval(gInforssWidth) - delta;
-            dump("new width=" + width + "   event.clientX=" + event.clientX + "    gInforssX=" + gInforssX + "\n");
+            //dump("new width=" + width + "   event.clientX=" + event.clientX + "    gInforssX=" + gInforssX + "\n");
             if (width > 10)
             {
-              //              hbox.setAttribute("width", width);
-              //              hbox.style.width = width + "px";
-              /*              var newX = hbox.boxObject.screenX;
-                            if (newX == oldX)
-                            {
-                              var find = false;
-                              width--;
-                              while ((width > 0) && (find == false))
-                              {
-                                hbox.setAttribute("width", width);
-                                hbox.style.width = width + "px";
-                                newX = hbox.boxObject.screenX;
-                                if (newX == oldX)
-                                {
-                                  width--;
-                                }
-                                else
-                                {
-                                  find = true;
-                                }
-                              }
-                              width++;
-                              hbox.setAttribute("width",width);
-                              hbox.style.width = width + "px";
-
-              //dump("pas bouge\n");
-                            }
-                            else
-                            {
-              //              gInforssX = event.clientX;
-                            }
-              */
               inforssXMLRepository.setScrollingArea(width);
             }
           }
@@ -2207,21 +1866,18 @@ function inforssResizeHeadlines(event)
 }
 
 //-----------------------------------------------------------------------------------------------------
+/*
 function inforssRunnable(obj, func)
 {
+  //FIXME does this achieve anything?
   this.obj = obj;
   this.func = func;
   this.Run = function()
   {
     try
     {
-      //alert("coucou "  + "\n");
       var obj = this.obj;
       var func = this.func;
-      //      eval("obj." + this.func + "()");
-      //	netscape.security.PrivilegeManager.enablePrivilege("UniversalFileRead CapabilityPreferencesAccess UniversalPreferencesWrite UniversalPreferencesRead UniversalXPConnect UniversalBrowserRead UniversalBrowserWrite");
-      //	var consoleService = Components.classes["@mozilla.org/consoleservice;1"].getService(Components.interfaces.nsIConsoleService);
-      //	consoleService.logStringMessage("coucou\n");
     }
     catch (e)
     {
@@ -2229,27 +1885,17 @@ function inforssRunnable(obj, func)
     }
   };
 }
+*/
 //-----------------------------------------------------------------------------------------------------
 function inforssSetTimer(obj, func, timer)
 {
-  //inforssInspect(navigator, null, false);
-  //dump("setTimer: " + gInforssTimerList.length + " " + gInforssTimerCounter + "\n");
-  //for (var i = 0; i < gInforssTimerList.length; i++)
-  //{
-  //  dump("    " + gInforssTimerList[i].date + " " + gInforssTimerList[i].timerId + " " + gInforssTimerList[i].func + "\n");
-  //}
   try
   {
-    //    var timerObject = { obj : obj, func : func, timerId : inforssGetNewTimerId() , handle : null, date : new Date()};
-    //    gInforssTimerList.push(timerObject);
-    //    timerObject.handle = window.setTimeout("inforssHandleTimer(" + timerObject.timerId + ",'" + func + "')", timer);
-    //dump("fin setTimer " + timerObject.timerId + "\n");
   }
   catch (e)
   {
     inforssDebug(e);
   }
-  //  return timerObject.handle;
   return window.setTimeout(inforssHandleTimer, timer, obj, func);
 }
 
@@ -2284,103 +1930,28 @@ function inforssGetNewTimerId()
 //-----------------------------------------------------------------------------------------------------
 function inforssHandleTimer(obj, func)
 {
-  //  const thread1 = Components.classes["@mozilla.org/thread;1"].getService(Components.interfaces.nsIThread);
-  //dump("debut handleTimer: " + timerId + "\n");
   try
   {
-    /*    var find = false;
-        var i = 0;
-        while ((i < gInforssTimerList.length) && (find == false))
-        {
-    //dump("avant premier\n");
-          if (gInforssTimerList[i].timerId == timerId)
-          {
-            find = true;
-          }
-          else
-          {
-            i++;
-          }
-        }
-        if (find == true)
-        {
-    //dump("avant deuxieme " + i + " " + gInforssTimerList.length + " " + gInforssTimerList[i] + "\n");
-          var func = gInforssTimerList[i].func;
-          var obj = gInforssTimerList[i].obj;
-    //dump("apres deuxieme " + i + " " + gInforssTimerList.length + " " + gInforssTimerList[i] + "\n");
-          gInforssTimerList[i].obj = null;
-          gInforssTimerList[i].func = null;
-          delete gInforssTimerList[i];
-          gInforssTimerList.splice(i,1);
-    //if (func != func1)
-    //{
-    //alert("pas bonne fonction" + func + " " + func1);
-    //}
-
-    // lancement du process
-    //       thread.init(thread, 0,
-    //     thread1.init(new inforssRunnable(obj, func), 0,
-    //                 Components.interfaces.nsIThread.PRIORITY_NORMAL,
-    //                  Components.interfaces.nsIThread.SCOPE_GLOBAL,
-    //                  Components.interfaces.nsIThread.STATE_JOINABLE);
-    //      thread1.join();
-    */
     eval("obj." + func + "()");
-    //    }
-    //    else
-    //    {
-    //      dump("pas trouve func=" + func1 + "\n");
-    //    }
   }
   catch (e)
   {
     inforssDebug(e);
   }
-  //dump("fin handleTimer\n");
 }
 
 
 //-----------------------------------------------------------------------------------------------------
 function inforssClearTimer(handle)
 {
-  //dump("debut handleTimer: " + timerId + "\n");
-  /*  try
-    {
-      var find = false;
-      var i = 0;
-      while ((i < gInforssTimerList.length) && (find == false))
-      {
-        if (gInforssTimerList[i].handle == handle)
-        {
-          find = true;
-        }
-        else
-        {
-          i++;
-        }
-      }
-      if (find == true)
-      {
-  	  gInforssTimerList[i].obj = null;
-  	  delete gInforssTimerList[i];
-        gInforssTimerList.splice(i,1);
-      }
-    }
-    catch(e)
-    {
-      inforssDebug(e);
-    }*/
-  //dump("fin handleTimer\n");
 }
 
 //-----------------------------------------------------------------------------------------------------
 function inforssAddNewFeed(menuItem)
 {
-  //alert("inforssAddNewFeed\n");
   try
   {
     var url = menuItem.inforssUrl;
-    //alert(url);
     if (inforssGetItemFromUrl(url) != null) // already exists
     {
       alert(gInforssRssBundle.getString("inforss.duplicate"));
@@ -2389,7 +1960,6 @@ function inforssAddNewFeed(menuItem)
     {
       if (gInforssXMLHttpRequest == null)
       {
-        //alert("go");
         getInfoFromUrl(url); // search for the general information of the feed: title, ...
       }
     }
@@ -2398,13 +1968,11 @@ function inforssAddNewFeed(menuItem)
   {
     inforssDebug(e);
   }
-  //dump("fin inforssAddNewFeed\n");
 }
 
 //-----------------------------------------------------------------------------------------------------
 function onAddNewFeedPopup()
 {
-  //dump("onAddNewFeedPopup\n");
   try
   {
     var selectedText = inforssGetMenuSelectedText();
@@ -2434,14 +2002,11 @@ function onAddNewFeedPopup()
   {
     inforssDebug(e);
   }
-  //dump("fin onAddNewFeedPopup\n");
 }
 
 //-----------------------------------------------------------------------------------------------------
 function inforssGetMenuSelectedText(concationationChar)
 {
-  //dump("dictionarySearchGetSelectedText()");
-
   var node = document.popupNode;
   var selection = "";
   var nodeLocalName = "";
@@ -2499,7 +2064,6 @@ function inforssMouseScroll(event)
 {
   try
   {
-    //dump("inforssMouseScroll event.detail=" + event.detail + "\n");
     gInforssMediator.handleMouseScroll(event.detail);
   }
   catch (e)
@@ -2528,12 +2092,12 @@ function inforssCheckVersion()
     }
     if (display == true)
     {
-      //      window.openDialog("chrome://inforss/content/inforssWelcome.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", "Welcome");
       prefs.setCharPref("installed.version", INFORSS_VERSION_NUMBER);
     }
   }
   catch (e)
   {
-    //    inforssDebug(e);
+      //FIXME debug?
+      dump(e);
   }
 }

--- a/content/inforss/inforss.js
+++ b/content/inforss/inforss.js
@@ -69,31 +69,31 @@ var gInforssResizeTimeout = null;
 //-------------------------------------------------------------------------------------------------------------
 function inforssStartExtension()
 {
-//dump("start\n");
+  //dump("start\n");
   try
   {
-//dump("start 0\n");
-//if (window.opener != null) inforssInspect(window.opener);
-//alert(window.opener + " / " + window.arguments + " / " + (window.arguments == "") + " / " + (window.arguments != null));
+    //dump("start 0\n");
+    //if (window.opener != null) inforssInspect(window.opener);
+    //alert(window.opener + " / " + window.arguments + " / " + (window.arguments == "") + " / " + (window.arguments != null));
     if ((window.arguments != null) || (window.opener != null))
     {
-//dump("start 1=" + window.arguments[0] + "\n");
+      //dump("start 1=" + window.arguments[0] + "\n");
       inforssCheckVersion();
       checkContentHandler();
-//      installProtocol();
+      //      installProtocol();
       var inforssObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-      inforssObserverService.addObserver(InforssObserver,"reload",false);
-      inforssObserverService.addObserver(InforssObserver,"banned",false);
-      inforssObserverService.addObserver(InforssObserver,"viewed",false);
-      inforssObserverService.addObserver(InforssObserver,"sync",false);
-      inforssObserverService.addObserver(InforssObserver,"syncBack",false);
-      inforssObserverService.addObserver(InforssObserver,"ack",false);
-      inforssObserverService.addObserver(InforssObserver,"popup",false);
-      inforssObserverService.addObserver(InforssObserver,"newRDF",false);
-      inforssObserverService.addObserver(InforssObserver,"purgeRdf",false);
-      inforssObserverService.addObserver(InforssObserver,"clearRdf",false);
-      inforssObserverService.addObserver(InforssObserver,"rssChanged",false);
-      inforssObserverService.addObserver(InforssObserver,"addFeed",false);
+      inforssObserverService.addObserver(InforssObserver, "reload", false);
+      inforssObserverService.addObserver(InforssObserver, "banned", false);
+      inforssObserverService.addObserver(InforssObserver, "viewed", false);
+      inforssObserverService.addObserver(InforssObserver, "sync", false);
+      inforssObserverService.addObserver(InforssObserver, "syncBack", false);
+      inforssObserverService.addObserver(InforssObserver, "ack", false);
+      inforssObserverService.addObserver(InforssObserver, "popup", false);
+      inforssObserverService.addObserver(InforssObserver, "newRDF", false);
+      inforssObserverService.addObserver(InforssObserver, "purgeRdf", false);
+      inforssObserverService.addObserver(InforssObserver, "clearRdf", false);
+      inforssObserverService.addObserver(InforssObserver, "rssChanged", false);
+      inforssObserverService.addObserver(InforssObserver, "addFeed", false);
       var serverInfo = inforssXMLRepository.getServerInfo();
       var lb = document.getElementById("livemark-button");
       if (lb != null)
@@ -103,41 +103,41 @@ function inforssStartExtension()
       var box = document.getElementById("inforss.newsbox1");
       if (box != null)
       {
-//dump("an event handler has been set for the mouse wheel\n");
+        //dump("an event handler has been set for the mouse wheel\n");
         box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
       }
 
       if ((inforssGetNbWindow() == 1) && (serverInfo.autosync == true) && (navigator.userAgent.indexOf("Thunderbird") == -1) && (navigator.userAgent.indexOf("Linspire Inc.") == -1))
       {
-//dump("start 2 didier\n");
+        //dump("start 2 didier\n");
         inforssCopyRemoteToLocal(serverInfo.protocol, serverInfo.server, serverInfo.directory, serverInfo.user, serverInfo.password, inforssStartExtension1);
-//dump("start 3\n");
-//        inforssStartExtension1();
+        //dump("start 3\n");
+        //        inforssStartExtension1();
       }
       else
       {
-//dump("start 3\n");
+        //dump("start 3\n");
         inforssStartExtension1();
       }
     }
     else
     {
-//dump("start 4\n");
+      //dump("start 4\n");
       if (document.getElementById("inforss.headlines") != null)
       {
-        document.getElementById("inforss.headlines").setAttribute("collapsed","true");
-//dump("start 5\n");
+        document.getElementById("inforss.headlines").setAttribute("collapsed", "true");
+        //dump("start 5\n");
       }
     }
-//    var statusbar = document.getElementById("status-bar");
-//    statusbar.addEventListener("DOMAttrModified", function(event) { dump('coucou ' + event.attrName + ' ' + event.prevValue + ' ' + event.newValue + '\n') }, false);
-//    statusbar.addEventListener("onoverflow", function(event) { alert('coucou onoverflow') }, false);
-//    statusbar.addEventListener("onunderflow", function(event) { alert('coucou onunderflow') }, false);
+    //    var statusbar = document.getElementById("status-bar");
+    //    statusbar.addEventListener("DOMAttrModified", function(event) { dump('coucou ' + event.attrName + ' ' + event.prevValue + ' ' + event.newValue + '\n') }, false);
+    //    statusbar.addEventListener("onoverflow", function(event) { alert('coucou onoverflow') }, false);
+    //    statusbar.addEventListener("onunderflow", function(event) { alert('coucou onunderflow') }, false);
   }
-  catch(e)
+  catch (e)
   {
-//    alert(e);
-  	dump(e + "\n");
+    //    alert(e);
+    dump(e + "\n");
   }
 }
 
@@ -146,42 +146,43 @@ function checkContentHandler()
 {
   try
   {
-/*
-    netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
-    var wccr = Components.classes["@mozilla.org/embeddor.implemented/web-content-handler-registrar;1"].getService(Components.interfaces.nsIWebContentConverterService);
-    var handlers = wccr.getContentHandlers("application/vnd.mozilla.maybe.feed", {});
-    if (handlers.length == 0)
-      return;
+    /*
+        netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
+        var wccr = Components.classes["@mozilla.org/embeddor.implemented/web-content-handler-registrar;1"].getService(Components.interfaces.nsIWebContentConverterService);
+        var handlers = wccr.getContentHandlers("application/vnd.mozilla.maybe.feed", {});
+        if (handlers.length == 0)
+          return;
 
-    for (var i = 0; i < handlers.length; ++i) {
-      dump(handlers[i].name + "\n");
-      dump(handlers[i].uri + "\n");
-    }
-    if (wccr.getWebContentHandlerByURI("application/vnd.mozilla.maybe.feed", "feed://%s") == null)
-    {
-      wccr.registerContentHandler("application/vnd.mozilla.maybe.feed", "feed://%s", "InfoRSS", document.contentWindow);
-    }
-*/
+        for (var i = 0; i < handlers.length; ++i) {
+          dump(handlers[i].name + "\n");
+          dump(handlers[i].uri + "\n");
+        }
+        if (wccr.getWebContentHandlerByURI("application/vnd.mozilla.maybe.feed", "feed://%s") == null)
+        {
+          wccr.registerContentHandler("application/vnd.mozilla.maybe.feed", "feed://%s", "InfoRSS", document.contentWindow);
+        }
+    */
     var ps = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
     var i = 0;
     var found = false;
     var typeBranch = null;
-    while (found == false) 
+    while (found == false)
     {
       typeBranch = ps.getBranch("browser.contentHandlers.types." + i + ".");
-      try 
+      try
       {
         found = (typeBranch.getCharPref("title") == "InfoRSS")
-        ++i;
+          ++i;
       }
-      catch (e) {
+      catch (e)
+      {
         // No more handlers
         break;
       }
     }
-//    if (found == false)
+    //    if (found == false)
     {
-      if (typeBranch) 
+      if (typeBranch)
       {
         typeBranch.setCharPref("type", "application/vnd.mozilla.maybe.feed");
         var pls = Components.classes["@mozilla.org/pref-localizedstring;1"].createInstance(Components.interfaces.nsIPrefLocalizedString);
@@ -191,14 +192,14 @@ function checkContentHandler()
         typeBranch.setComplexValue("title", Components.interfaces.nsIPrefLocalizedString, pls);
       }
     }
-/*
-    var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("browser.contentHandlers.types.");
-    prefs.setCharPref("3.title", "InfoRSS");
-    prefs.setCharPref("3.uri", "feed://%s");
-    prefs.setCharPref("3.type", "application/vnd.mozilla.maybe.feed");
-*/
+    /*
+        var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("browser.contentHandlers.types.");
+        prefs.setCharPref("3.title", "InfoRSS");
+        prefs.setCharPref("3.uri", "feed://%s");
+        prefs.setCharPref("3.type", "application/vnd.mozilla.maybe.feed");
+    */
   }
-  catch(e)
+  catch (e)
   {
     alert(e);
   }
@@ -217,7 +218,7 @@ function inforssAddItemToLivemarkMenu(event)
     var menupopup = event.target;
     var element = null;
     if (gBrowser != null && gBrowser.mCurrentBrowser != null && gBrowser.mCurrentBrowser.livemarkLinks != null)
-	{
+    {
       var livemarkLinks = gBrowser.mCurrentBrowser.livemarkLinks;
       if (livemarkLinks == null)
       {
@@ -228,32 +229,37 @@ function inforssAddItemToLivemarkMenu(event)
         element = document.createElement("menuseparator");
         menupopup.appendChild(element);
         element = document.createElement("menu");
-        element.setAttribute("label",gInforssRssBundle.getString("inforss.menuadd1"));
+        element.setAttribute("label", gInforssRssBundle.getString("inforss.menuadd1"));
         menupopup.appendChild(element);
         menupopup = document.createElement("menupopup");
         element.appendChild(menupopup);
-        menupopup.addEventListener("popupshowing", function(event) {event.cancelBubble = true;event.stopPropagation(); return true;}, false);
-//           menupopup.setAttribute("onpopupshowing","return inforssSubMenu(" + items.length + ");");
-//           menupopup.setAttribute("onpopuphiding","return inforssSubMenu2();");
+        menupopup.addEventListener("popupshowing", function(event)
+        {
+          event.cancelBubble = true;
+          event.stopPropagation();
+          return true;
+        }, false);
+        //           menupopup.setAttribute("onpopupshowing","return inforssSubMenu(" + items.length + ");");
+        //           menupopup.setAttribute("onpopuphiding","return inforssSubMenu2();");
         var markinfo = null;
-	    for (var i = 0; i < livemarkLinks.length; i++)
-	    {
-	      markinfo = livemarkLinks[i];
-          if ((markinfo.type == "application/rss+xml") || (markinfo.type == "application/xml") || 
-              (markinfo.type == "application/atom+xml") || (markinfo.type == "text/xml"))
-	      {
+        for (var i = 0; i < livemarkLinks.length; i++)
+        {
+          markinfo = livemarkLinks[i];
+          if ((markinfo.type == "application/rss+xml") || (markinfo.type == "application/xml") ||
+            (markinfo.type == "application/atom+xml") || (markinfo.type == "text/xml"))
+          {
             element = document.createElement("menuitem");
-            element.setAttribute("label",gInforssRssBundle.getString("inforss.menuadd") + " " + markinfo.title + "(" + markinfo.href + ")");
-            element.setAttribute("tooltiptext",markinfo.href);
-            element.setAttribute("data",markinfo.href);
+            element.setAttribute("label", gInforssRssBundle.getString("inforss.menuadd") + " " + markinfo.title + "(" + markinfo.href + ")");
+            element.setAttribute("tooltiptext", markinfo.href);
+            element.setAttribute("data", markinfo.href);
             menupopup.appendChild(element);
             element.addEventListener("command", inforssLivemarkCommand, false);
-	      }
-	    }
-	  }
-	}
+          }
+        }
+      }
+    }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -267,9 +273,9 @@ function inforssLivemarkCommand(event)
     rssSwitchAll(event.target.parentNode, event.target.getAttribute("data"), event.target.getAttribute("label"), null)
     event.cancelBubble = true;
     event.stopPropagation();
-    
+
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -279,35 +285,35 @@ function inforssLivemarkCommand(event)
 //-------------------------------------------------------------------------------------------------------------
 function inforssStartExtension1(step, status)
 {
-//dump("inforssStartExtension1\n");
+  //dump("inforssStartExtension1\n");
   try
   {
     if ((step == null) || (step != "send"))
     {
-	  if (document.getElementById("inforss.headlines") != null) // only if the page is loaded
-	  {
+      if (document.getElementById("inforss.headlines") != null) // only if the page is loaded
+      {
         if (gInforssMediator == null)
         {
-//dump("inforssStartExtension1 step2\n");
+          //dump("inforssStartExtension1 step2\n");
           gInforssRssBundle = document.getElementById("bundle_inforss");
           gInforssMediator = new inforssMediator();
-//          gInforssMediator.init();
+          //          gInforssMediator.init();
           inforssSetTimer(gInforssMediator, "init", 1200);
           if (document.getElementById("contentAreaContextMenu") != null)
           {
-            document.getElementById("contentAreaContextMenu").addEventListener("popupshowing", onAddNewFeedPopup,false);
+            document.getElementById("contentAreaContextMenu").addEventListener("popupshowing", onAddNewFeedPopup, false);
           }
           else
           {
             if (document.getElementById("messagePaneContext") != null)
             {
-              document.getElementById("messagePaneContext").addEventListener("popupshowing", onAddNewFeedPopup,false);
+              document.getElementById("messagePaneContext").addEventListener("popupshowing", onAddNewFeedPopup, false);
             }
             else
             {
               if (document.getElementById("msgComposeContext") != null)
               {
-                document.getElementById("msgComposeContext").addEventListener("popupshowing",onAddNewFeedPopup,false);
+                document.getElementById("msgComposeContext").addEventListener("popupshowing", onAddNewFeedPopup, false);
               }
             }
           }
@@ -316,10 +322,10 @@ function inforssStartExtension1(step, status)
     }
     else
     {
-//      alert(step + " " + status);
+      //      alert(step + " " + status);
     }
   }
-  catch(e)
+  catch (e)
   {
     alert(e);
   }
@@ -337,31 +343,31 @@ function inforssStopExtension()
       if (bartop != null)
       {
         var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("inforss.");
-        prefs.setBoolPref("toolbar.collapsed", ((bartop.getAttribute("collapsed") == null)? false : (bartop.getAttribute("collapsed") == "true")));
-//dump("collapsed=" + ((bartop.getAttribute("collapsed") == null)? false : bartop.getAttribute("collapsed")) + "\n");
+        prefs.setBoolPref("toolbar.collapsed", ((bartop.getAttribute("collapsed") == null) ? false : (bartop.getAttribute("collapsed") == "true")));
+        //dump("collapsed=" + ((bartop.getAttribute("collapsed") == null)? false : bartop.getAttribute("collapsed")) + "\n");
       }
       var inforssObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-      inforssObserverService.removeObserver(InforssObserver,"reload");
-      inforssObserverService.removeObserver(InforssObserver,"banned");
-      inforssObserverService.removeObserver(InforssObserver,"viewed");
-      inforssObserverService.removeObserver(InforssObserver,"sync");
-      inforssObserverService.removeObserver(InforssObserver,"syncBack");
-      inforssObserverService.removeObserver(InforssObserver,"ack");
-      inforssObserverService.removeObserver(InforssObserver,"popup");
-      inforssObserverService.removeObserver(InforssObserver,"newRDF");
-      inforssObserverService.removeObserver(InforssObserver,"purgeRdf");
-      inforssObserverService.removeObserver(InforssObserver,"clearRdf");
-      inforssObserverService.removeObserver(InforssObserver,"rssChanged");
-      inforssObserverService.removeObserver(InforssObserver,"addFeed");
+      inforssObserverService.removeObserver(InforssObserver, "reload");
+      inforssObserverService.removeObserver(InforssObserver, "banned");
+      inforssObserverService.removeObserver(InforssObserver, "viewed");
+      inforssObserverService.removeObserver(InforssObserver, "sync");
+      inforssObserverService.removeObserver(InforssObserver, "syncBack");
+      inforssObserverService.removeObserver(InforssObserver, "ack");
+      inforssObserverService.removeObserver(InforssObserver, "popup");
+      inforssObserverService.removeObserver(InforssObserver, "newRDF");
+      inforssObserverService.removeObserver(InforssObserver, "purgeRdf");
+      inforssObserverService.removeObserver(InforssObserver, "clearRdf");
+      inforssObserverService.removeObserver(InforssObserver, "rssChanged");
+      inforssObserverService.removeObserver(InforssObserver, "addFeed");
       var serverInfo = inforssXMLRepository.getServerInfo();
-      if ((inforssGetNbWindow() == 0) && (serverInfo.autosync == true) && (navigator.vendor != "Thunderbird")  && (navigator.vendor != "Linspire Inc."))
+      if ((inforssGetNbWindow() == 0) && (serverInfo.autosync == true) && (navigator.vendor != "Thunderbird") && (navigator.vendor != "Linspire Inc."))
       {
         inforssCopyLocalToRemote(serverInfo.protocol, serverInfo.server, serverInfo.directory, serverInfo.user, serverInfo.password, inforssStopExtension1, false);
-//      window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", "wait until finish");
+        //      window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", "wait until finish");
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -372,9 +378,9 @@ function inforssStopExtension1(step, status)
 {
   try
   {
-//    dump("apres push " + step + " " + status + "\n");
+    //    dump("apres push " + step + " " + status + "\n");
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -387,7 +393,7 @@ function inforssGetNbWindow()
   try
   {
     var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
-    var windowManagerInterface = windowManager.QueryInterface( Components.interfaces.nsIWindowMediator);
+    var windowManagerInterface = windowManager.QueryInterface(Components.interfaces.nsIWindowMediator);
     var enumerator = windowManagerInterface.getEnumerator(null);
     while (enumerator.hasMoreElements())
     {
@@ -395,19 +401,18 @@ function inforssGetNbWindow()
       enumerator.getNext();
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
-//dump("inforssGetNbWindow=" + returnValue + "\n");
+  //dump("inforssGetNbWindow=" + returnValue + "\n");
   return returnValue;
 }
 
 
 //-------------------------------------------------------------------------------------------------------------
-var InforssObserver =
-{
-  observe : function(subject, topic, data)
+var InforssObserver = {
+  observe: function(subject, topic, data)
   {
     manageRSSChanged(subject, topic, data);
   }
@@ -418,48 +423,48 @@ var InforssObserver =
 function inforssGetRss(url, callback, user, password)
 {
   inforssTraceIn();
-//alert("getRss=" + url + "\n");
-//dump("getRss: " + url + " / " + callback + "\n");
-//dump("getRss=" + url);
-    try
+  //alert("getRss=" + url + "\n");
+  //dump("getRss: " + url + " / " + callback + "\n");
+  //dump("getRss=" + url);
+  try
+  {
+    //      netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
+    if (gInforssXMLHttpRequest != null)
     {
-//      netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
-      if (gInforssXMLHttpRequest != null)
-      {
-//alert("abort");
-        gInforssXMLHttpRequest.abort();
-      }
+      //alert("abort");
+      gInforssXMLHttpRequest.abort();
+    }
 
-//dump("  old=" + gInforssTimeout);
-	  if (gInforssTimeout != null)
-	  {
-//alert("clearTimeout");
-	    window.clearTimeout(gInforssTimeout);
-	    gInforssTimeout = null;
-	  }
-	  gInforssTimeout = window.setTimeout("inforssHandleTimeout('" + url + "')", 10000);
-//dump("  new=" + gInforssTimeout + "\n");
-      gInforssUrl = url;
-      gInforssXMLHttpRequest = new XMLHttpRequest();
-//      gInforssXMLHttpRequest.onload = eval(callback);
-//      gInforssXMLHttpRequest.onerror = inforssErrorMacNews;
-      gInforssXMLHttpRequest.callback = callback;
-      gInforssXMLHttpRequest.user = user;
-      gInforssXMLHttpRequest.password = password;
-      gInforssXMLHttpRequest.onreadystatechange = inforssProcessReqChange;
-      gInforssXMLHttpRequest.open("GET", url, true, user, password);
-//      gInforssXMLHttpRequest.setRequestHeader('Accept','application/rss+xml')
-//      gInforssXMLHttpRequest.setRequestHeader('Cache-Control','no-cache')
-//      gInforssXMLHttpRequest.setRequestHeader("Content-Length","0");
-	  gInforssXMLHttpRequest.overrideMimeType("application/xml");
-	  gInforssXMLHttpRequest.send(null);
-//alert("send");
-    }
-    catch(e)
+    //dump("  old=" + gInforssTimeout);
+    if (gInforssTimeout != null)
     {
-//alert(e);
-      inforssDebug(e + "/" + url + "/" + callback);
+      //alert("clearTimeout");
+      window.clearTimeout(gInforssTimeout);
+      gInforssTimeout = null;
     }
+    gInforssTimeout = window.setTimeout("inforssHandleTimeout('" + url + "')", 10000);
+    //dump("  new=" + gInforssTimeout + "\n");
+    gInforssUrl = url;
+    gInforssXMLHttpRequest = new XMLHttpRequest();
+    //      gInforssXMLHttpRequest.onload = eval(callback);
+    //      gInforssXMLHttpRequest.onerror = inforssErrorMacNews;
+    gInforssXMLHttpRequest.callback = callback;
+    gInforssXMLHttpRequest.user = user;
+    gInforssXMLHttpRequest.password = password;
+    gInforssXMLHttpRequest.onreadystatechange = inforssProcessReqChange;
+    gInforssXMLHttpRequest.open("GET", url, true, user, password);
+    //      gInforssXMLHttpRequest.setRequestHeader('Accept','application/rss+xml')
+    //      gInforssXMLHttpRequest.setRequestHeader('Cache-Control','no-cache')
+    //      gInforssXMLHttpRequest.setRequestHeader("Content-Length","0");
+    gInforssXMLHttpRequest.overrideMimeType("application/xml");
+    gInforssXMLHttpRequest.send(null);
+    //alert("send");
+  }
+  catch (e)
+  {
+    //alert(e);
+    inforssDebug(e + "/" + url + "/" + callback);
+  }
   inforssTraceOut();
 }
 
@@ -468,7 +473,7 @@ function inforssGetRss(url, callback, user, password)
 function inforssHandleTimeout(url)
 {
   inforssTraceIn();
-//alert("handleTimeout=" + url + " timeout=" + gInforssTimeout + "\n");
+  //alert("handleTimeout=" + url + " timeout=" + gInforssTimeout + "\n");
   if (gInforssXMLHttpRequest != null)
   {
     gInforssXMLHttpRequest.abort();
@@ -482,49 +487,49 @@ function inforssHandleTimeout(url)
 function inforssProcessReqChange()
 {
   inforssTraceIn();
-//dump("processReqChange=" + gInforssUrl + "\n");
-//alert("processReqChange:" + gInforssXMLHttpRequest.readyState + "/" + gInforssXMLHttpRequest.status);
-    // only if req shows "loaded"
+  //dump("processReqChange=" + gInforssUrl + "\n");
+  //alert("processReqChange:" + gInforssXMLHttpRequest.readyState + "/" + gInforssXMLHttpRequest.status);
+  // only if req shows "loaded"
   try
   {
-//dump("gInforssXMLHttpRequest.readyState =" + gInforssXMLHttpRequest.readyState + "\n");
+    //dump("gInforssXMLHttpRequest.readyState =" + gInforssXMLHttpRequest.readyState + "\n");
     if (gInforssXMLHttpRequest.readyState == INFORSS_COMPLETED)
     {
-//dump("gInforssXMLHttpRequest.status =" + gInforssXMLHttpRequest.status + "\n");
-        // only if "OK"
-        if ((gInforssXMLHttpRequest.status == 200) ||
-            (gInforssXMLHttpRequest.status == 201) ||
-            (gInforssXMLHttpRequest.status == 202))
+      //dump("gInforssXMLHttpRequest.status =" + gInforssXMLHttpRequest.status + "\n");
+      // only if "OK"
+      if ((gInforssXMLHttpRequest.status == 200) ||
+        (gInforssXMLHttpRequest.status == 201) ||
+        (gInforssXMLHttpRequest.status == 202))
+      {
+        //inforssAlert("ReqChange:" + gInforssUrl + "/" + gInforssCounter + "/" + gInforssCallbackFunction);
+        //gInforssCounter++;
+        if (gInforssTimeout != null)
         {
-//inforssAlert("ReqChange:" + gInforssUrl + "/" + gInforssCounter + "/" + gInforssCallbackFunction);
-//gInforssCounter++;
-          if (gInforssTimeout != null)
+          //dump("processReqChange clearTimeout=" + gInforssTimeout + "\n");
+          window.clearTimeout(gInforssTimeout);
+          gInforssTimeout = null;
+        }
+        eval(gInforssXMLHttpRequest.callback + "()");
+      }
+      else
+      {
+        if (gInforssXMLHttpRequest.status == 302)
+        {
+          //dump("Redirect=" + gInforssXMLHttpRequest.getResponseHeader("Location") + "\n");     
+          var url = gInforssXMLHttpRequest.getResponseHeader("Location");
+          if (url != null)
           {
-//dump("processReqChange clearTimeout=" + gInforssTimeout + "\n");
-            window.clearTimeout(gInforssTimeout);
-            gInforssTimeout = null;
+            inforssGetRss(url, gInforssXMLHttpRequest.callback, gInforssXMLHttpRequest.user, gInforssXMLHttpRequest.password);
           }
-          eval(gInforssXMLHttpRequest.callback + "()");
         }
         else
         {
-          if (gInforssXMLHttpRequest.status == 302)
-          {
-//dump("Redirect=" + gInforssXMLHttpRequest.getResponseHeader("Location") + "\n");     
-            var url = gInforssXMLHttpRequest.getResponseHeader("Location");    
-            if (url != null)
-            {
-              inforssGetRss(url, gInforssXMLHttpRequest.callback, gInforssXMLHttpRequest.user, gInforssXMLHttpRequest.password);
-            }
-          }
-          else
-          {
-            inforssDebug("processReqChange" , "There was a problem retrieving the XML data:\n" + gInforssXMLHttpRequest.statusText + "/" + gInforssXMLHttpRequest.status + "\nUrl=" + gInforssUrl);
-          }
+          inforssDebug("processReqChange", "There was a problem retrieving the XML data:\n" + gInforssXMLHttpRequest.statusText + "/" + gInforssXMLHttpRequest.status + "\nUrl=" + gInforssUrl);
         }
+      }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -535,10 +540,10 @@ function inforssProcessReqChange()
 function inforssErrorMacNews()
 {
   inforssTraceIn();
-    inforssDebug("errorMacNews", "There was a problem retrieving the XML data:\n" + gInforssXMLHttpRequest.status + "/" + gInforssXMLHttpRequest.statusText + "\n" + gInforssUrl);
-//    alert(gInforssXMLHttpRequest.responseText);
-    delete gInforssXMLHttpRequest;
-    gInforssXMLHttpRequest = null;
+  inforssDebug("errorMacNews", "There was a problem retrieving the XML data:\n" + gInforssXMLHttpRequest.status + "/" + gInforssXMLHttpRequest.statusText + "\n" + gInforssUrl);
+  //    alert(gInforssXMLHttpRequest.responseText);
+  delete gInforssXMLHttpRequest;
+  gInforssXMLHttpRequest = null;
   inforssTraceOut();
 }
 
@@ -568,7 +573,7 @@ function inforssClearPopupMenu()
         if (found == true)
         {
           nextChild = child.nextSibling;
-	      menupopup.removeChild(child);
+          menupopup.removeChild(child);
           child = nextChild;
         }
         else
@@ -578,7 +583,7 @@ function inforssClearPopupMenu()
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -623,8 +628,8 @@ function clearAddRSSPopupMenu()
             else
             {
               nextChild = child.nextSibling;
-	          menupopup.removeChild(child);
-	          delete child;
+              menupopup.removeChild(child);
+              delete child;
               child = nextChild;
             }
           }
@@ -636,7 +641,7 @@ function clearAddRSSPopupMenu()
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -655,12 +660,12 @@ function inforssResetSubMenu()
     {
       var subElement = document.getAnonymousNodes(child);
 
-      if ((subElement != null) && (subElement.length > 0) && (subElement[0] != null) && (subElement[0].firstChild != null) && (subElement[0].firstChild.localName =="image"))
+      if ((subElement != null) && (subElement.length > 0) && (subElement[0] != null) && (subElement[0].firstChild != null) && (subElement[0].firstChild.localName == "image"))
       {
-        subElement[0].firstChild.setAttribute("maxwidth","16");
-        subElement[0].firstChild.setAttribute("maxheight","16");
-        subElement[0].firstChild.setAttribute("minwidth","16");
-        subElement[0].firstChild.setAttribute("minheight","16");
+        subElement[0].firstChild.setAttribute("maxwidth", "16");
+        subElement[0].firstChild.setAttribute("maxheight", "16");
+        subElement[0].firstChild.setAttribute("minwidth", "16");
+        subElement[0].firstChild.setAttribute("minheight", "16");
 
 
         subElement[0].firstChild.style.maxWidth = "16px";
@@ -678,11 +683,11 @@ function inforssResetSubMenu()
           var index = id.indexOf("-");
           if ((menupopup.getAttribute("type") == "rss") || (menupopup.getAttribute("type") == "atom"))
           {
-            menupopup.setAttribute("onpopupshowing","return inforssSubMenu(" + id.substring(index+1) + ");");
+            menupopup.setAttribute("onpopupshowing", "return inforssSubMenu(" + id.substring(index + 1) + ");");
           }
           else
           {
-            menupopup.setAttribute("onpopupshowing","return false");
+            menupopup.setAttribute("onpopupshowing", "return false");
           }
           inforssResetPopup(menupopup);
           inforssAddNoData(menupopup);
@@ -691,7 +696,7 @@ function inforssResetSubMenu()
       child = child.nextSibling;
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -704,32 +709,32 @@ function rssFillPopup(obj, event)
   inforssTraceIn();
   try
   {
-//inforssAlert("rssFillPopup" + "/" + (gInforssCounter++) + "/" + event.target.getAttribute("id"));
-//dump(navigator.userAgent + " " + event.button + " " + event.ctrlKey + "\n");
+    //inforssAlert("rssFillPopup" + "/" + (gInforssCounter++) + "/" + event.target.getAttribute("id"));
+    //dump(navigator.userAgent + " " + event.button + " " + event.ctrlKey + "\n");
     var returnValue = true;
     var leftButton = inforssXMLRepository.getMouseEvent();
-/*
-    if ((navigator.userAgent.indexOf("rv:1.8.0.2") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.3") == -1) &&
-        (navigator.userAgent.indexOf("rv:1.8.0.4") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.5") == -1) &&
-        (navigator.userAgent.indexOf("rv:1.8.0.6") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.7") == -1) &&
-        (navigator.userAgent.indexOf("rv:1.8.0.8") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.9") == -1) &&
-        (navigator.userAgent.indexOf("rv:1.8.1") == -1))
-    {
-        leftButton = ((navigator.userAgent.indexOf("Firefox/1.0+") == -1) &&
-                      (navigator.userAgent.indexOf("Firefox/1.4") == -1) &&
-                      (navigator.userAgent.indexOf("Firefox/1.5") == -1) &&
-                      (navigator.userAgent.indexOf("Thunderbird/1.5") == -1) &&
-                      (navigator.userAgent.indexOf("SeaMonkey") == -1) &&
-                      (navigator.userAgent.indexOf("rv:1.9") == -1) &&
-                      (navigator.userAgent.indexOf("rv:2.0") == -1) &&
-                      (navigator.userAgent.indexOf("rv:5.") == -1) &&
-                      (navigator.userAgent.indexOf("rv:1.8") == -1)) ? 0 : 65535;
-    }
-*/
-//dump("leftButton=" + leftButton + "\n");
+    /*
+        if ((navigator.userAgent.indexOf("rv:1.8.0.2") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.3") == -1) &&
+            (navigator.userAgent.indexOf("rv:1.8.0.4") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.5") == -1) &&
+            (navigator.userAgent.indexOf("rv:1.8.0.6") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.7") == -1) &&
+            (navigator.userAgent.indexOf("rv:1.8.0.8") == -1) && (navigator.userAgent.indexOf("rv:1.8.0.9") == -1) &&
+            (navigator.userAgent.indexOf("rv:1.8.1") == -1))
+        {
+            leftButton = ((navigator.userAgent.indexOf("Firefox/1.0+") == -1) &&
+                          (navigator.userAgent.indexOf("Firefox/1.4") == -1) &&
+                          (navigator.userAgent.indexOf("Firefox/1.5") == -1) &&
+                          (navigator.userAgent.indexOf("Thunderbird/1.5") == -1) &&
+                          (navigator.userAgent.indexOf("SeaMonkey") == -1) &&
+                          (navigator.userAgent.indexOf("rv:1.9") == -1) &&
+                          (navigator.userAgent.indexOf("rv:2.0") == -1) &&
+                          (navigator.userAgent.indexOf("rv:5.") == -1) &&
+                          (navigator.userAgent.indexOf("rv:1.8") == -1)) ? 0 : 65535;
+        }
+    */
+    //dump("leftButton=" + leftButton + "\n");
     if ((event.button == leftButton) && (event.ctrlKey == false)) // left button
     {
-//dump("rssFillPopup\n");
+      //dump("rssFillPopup\n");
       clearAddRSSPopupMenu();
       if (event.target.getAttribute("id") == "inforss-menupopup")
       {
@@ -740,15 +745,14 @@ function rssFillPopup(obj, event)
       try
       {
         if (gBrowser == null)
-        {
-        }
+        {}
       }
-      catch(e)
+      catch (e)
       {
         gBrowser = null;
       }
-      if (gBrowser != null && gBrowser.mCurrentBrowser != null && 
-          ((gBrowser.mCurrentBrowser.livemarkLinks != null) || (gBrowser.mCurrentBrowser.feeds != null)))
+      if (gBrowser != null && gBrowser.mCurrentBrowser != null &&
+        ((gBrowser.mCurrentBrowser.livemarkLinks != null) || (gBrowser.mCurrentBrowser.feeds != null)))
       {
         if (inforssXMLRepository.isCurrentFeed() == true)
         {
@@ -761,8 +765,8 @@ function rssFillPopup(obj, event)
           {
             var markinfo = livemarkLinks[i];
 
-            if ((markinfo.type == "application/rss+xml") || (markinfo.type == "application/xml") || 
-                (markinfo.type == "application/atom+xml") || (markinfo.type == "text/xml"))
+            if ((markinfo.type == "application/rss+xml") || (markinfo.type == "application/xml") ||
+              (markinfo.type == "application/atom+xml") || (markinfo.type == "text/xml"))
             {
               var baseTitle = markinfo.title + " (" + markinfo.href + ")";
               inforssAddaAddSubMenu(nb, markinfo.href, baseTitle);
@@ -781,61 +785,60 @@ function rssFillPopup(obj, event)
         {
           clipboard.getData(xferable, Components.interfaces.nsIClipboard.kGlobalClipboard);
 
-          var flavour = { };
-          var data    = { };
-          var length  = { };
+          var flavour = {};
+          var data = {};
+          var length = {};
           xferable.getAnyTransferData(flavour, data, length);
           var items, name, url;
           data = data.value.QueryInterface(Components.interfaces.nsISupportsString).data;
           if ((data != null) && ((data.indexOf("http://") == 0) ||
-                                 (data.indexOf("file://") == 0) ||
-                                 (data.indexOf("https://") == 0))
-                             && (data.length < 60))
+              (data.indexOf("file://") == 0) ||
+              (data.indexOf("https://") == 0)) &&
+            (data.length < 60))
           {
             inforssAddaAddSubMenu(nb, data, data);
             nb++;
           }
         }
-        catch(e)
-        {
-        }
+        catch (e)
+        {}
       }
-    // Bookmarks use rdf's
-	//var rdf = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
-	// Get the built in datasource
-	//var bookmarks = Components.classes["@mozilla.org/rdf/datasource;1?name=bookmarks"].getService(Components.interfaces.nsIRDFDataSource);
+      // Bookmarks use rdf's
+      //var rdf = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
+      // Get the built in datasource
+      //var bookmarks = Components.classes["@mozilla.org/rdf/datasource;1?name=bookmarks"].getService(Components.interfaces.nsIRDFDataSource);
 
-    // The RDF component utilities
-    //var RDFC = Components.classes['@mozilla.org/rdf/container-utils;1'].getService(Components.interfaces.nsIRDFContainerUtils);
+      // The RDF component utilities
+      //var RDFC = Components.classes['@mozilla.org/rdf/container-utils;1'].getService(Components.interfaces.nsIRDFContainerUtils);
 
-	// Wrap Url Predicate
-	//var urlPredicateResource = rdf.GetResource("http://home.netscape.com/NC-rdf#URL");
-	// Wrap Url Literal
-	//var urlTargetLiteral = rdf.GetLiteral('https://gmail.google.com/');
-	// Get source returns the resource
-	//var urlSubjectResource = bookmarks.GetSource(urlPredicateResource, urlTargetLiteral, true);
-	//if(urlSubjectResource)
-	//{
-		//alert('Founded: ' + urlSubjectResource);
-		// Wrap Name Predicate - case sensitive
-		//var titlePredicate = rdf.GetResource("http://home.netscape.com/NC-rdf#Name");
-		// Get target from subject and predicate
-		//var titleTargetLiteral = bookmarks.GetTarget(urlSubjectResource, titlePredicate, true);
-		// Want literal not resource
-		//if (titleTargetLiteral instanceof Components.interfaces.nsIRDFLiteral)
-		//{
-			// Display the title
-			//alert(titleTargetLiteral.Value);
-		//}
-	//}
-	//else
-	//{
-		//alert('Not found');
-	//}
-//dump("Hello\n");
+      // Wrap Url Predicate
+      //var urlPredicateResource = rdf.GetResource("http://home.netscape.com/NC-rdf#URL");
+      // Wrap Url Literal
+      //var urlTargetLiteral = rdf.GetLiteral('https://gmail.google.com/');
+      // Get source returns the resource
+      //var urlSubjectResource = bookmarks.GetSource(urlPredicateResource, urlTargetLiteral, true);
+      //if(urlSubjectResource)
+      //{
+      //alert('Founded: ' + urlSubjectResource);
+      // Wrap Name Predicate - case sensitive
+      //var titlePredicate = rdf.GetResource("http://home.netscape.com/NC-rdf#Name");
+      // Get target from subject and predicate
+      //var titleTargetLiteral = bookmarks.GetTarget(urlSubjectResource, titlePredicate, true);
+      // Want literal not resource
+      //if (titleTargetLiteral instanceof Components.interfaces.nsIRDFLiteral)
+      //{
+      // Display the title
+      //alert(titleTargetLiteral.Value);
+      //}
+      //}
+      //else
+      //{
+      //alert('Not found');
+      //}
+      //dump("Hello\n");
       if ((inforssXMLRepository.isLivemark() == true) && (gBrowser != null))
       {
-	    var RDF = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
+        var RDF = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
         inforssWalk(RDF.GetResource("NC:BookmarksRoot"), nb);
       }
     }
@@ -844,11 +847,11 @@ function rssFillPopup(obj, event)
       returnValue = false;
       if ((event.button == 2) || (event.ctrlKey == true))
       {
-//        window.openDialog("chrome://inforss/content/inforssOption.xul","_blank","chrome,centerscreen,resizable=yes, dialog=yes");
+        //        window.openDialog("chrome://inforss/content/inforssOption.xul","_blank","chrome,centerscreen,resizable=yes, dialog=yes");
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -863,15 +866,15 @@ function inforssDisplayOption(event)
   inforssTraceIn();
   try
   {
-      if ((event.button == 2) || (event.ctrlKey == true))
+    if ((event.button == 2) || (event.ctrlKey == true))
+    {
+      if (event.target.localName == "statusbarpanel")
       {
-        if (event.target.localName == "statusbarpanel")
-        {
-          inforssDisplayOption1();
-        }
+        inforssDisplayOption1();
       }
+    }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -881,19 +884,19 @@ function inforssDisplayOption(event)
 //-------------------------------------------------------------------------------------------------------------
 function inforssDisplayOption1()
 {
-    var nb = 0;
-    var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
-    var windowManagerInterface = windowManager.QueryInterface( Components.interfaces.nsIWindowMediator);
-    var enumerator = windowManagerInterface.getEnumerator("inforssOption");
-    while (enumerator.hasMoreElements())
-    {
-      nb++;
-      enumerator.getNext();
-    }
-    if (nb == 0)
-    {
-      window.openDialog("chrome://inforss/content/inforssOption.xul","_blank","chrome,centerscreen,resizable=yes,dialog=no");
-    }
+  var nb = 0;
+  var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
+  var windowManagerInterface = windowManager.QueryInterface(Components.interfaces.nsIWindowMediator);
+  var enumerator = windowManagerInterface.getEnumerator("inforssOption");
+  while (enumerator.hasMoreElements())
+  {
+    nb++;
+    enumerator.getNext();
+  }
+  if (nb == 0)
+  {
+    window.openDialog("chrome://inforss/content/inforssOption.xul", "_blank", "chrome,centerscreen,resizable=yes,dialog=no");
+  }
 }
 
 //-------------------------------------------------------------------------------------------------------------
@@ -911,7 +914,7 @@ function inforssAddaAddSubMenu(nb, data, labelStr)
   menuItem.setAttribute("tooltiptext", data);
   if (separators.length == 1)
   {
-    menupopup.insertBefore(document.createElement("menuseparator"),separator);
+    menupopup.insertBefore(document.createElement("menuseparator"), separator);
   }
   menupopup.insertBefore(menuItem, separator);
   inforssTraceOut();
@@ -920,12 +923,12 @@ function inforssAddaAddSubMenu(nb, data, labelStr)
 //-------------------------------------------------------------------------------------------------------------
 function inforssWalk(node, nb)
 {
-//dump("inforssWalk\n");
+  //dump("inforssWalk\n");
   inforssTraceIn();
   try
   {
     var RDFC = Components.classes['@mozilla.org/rdf/container-utils;1'].getService(Components.interfaces.nsIRDFContainerUtils);
-	var RDF = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
+    var RDF = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
 
     // The bookmarks service
     var Bookmarks = Components.classes['@mozilla.org/browser/bookmarks-service;1'];
@@ -933,34 +936,34 @@ function inforssWalk(node, nb)
 
 
     var kNC_Name = RDF.GetResource("http://home.netscape.com/NC-rdf#Name");
-    var kNC_URL  = RDF.GetResource("http://home.netscape.com/NC-rdf#URL");
-    var kNC_FEEDURL  = RDF.GetResource("http://home.netscape.com/NC-rdf#FeedURL");
+    var kNC_URL = RDF.GetResource("http://home.netscape.com/NC-rdf#URL");
+    var kNC_FEEDURL = RDF.GetResource("http://home.netscape.com/NC-rdf#FeedURL");
     if ((Bookmarks != null) && (RDFC.IsContainer(Bookmarks, node)))
     {
-//dump("it's a folder\n");
+      //dump("it's a folder\n");
       // It's a folder
       var name = Bookmarks.GetTarget(node, kNC_Name, true);
       var url = Bookmarks.GetTarget(node, kNC_URL, true);
       var feedurl = Bookmarks.GetTarget(node, kNC_FEEDURL, true);
-//if (name != null)
-//  dump("folder title = " + name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-//if (url != null)
-//  dump("folder url = " + url.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
+      //if (name != null)
+      //  dump("folder title = " + name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
+      //if (url != null)
+      //  dump("folder url = " + url.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
       if ((name != null) && (feedurl != null))
       {
-// dump("ok name and feedurl != null\n");
+        // dump("ok name and feedurl != null\n");
         target = Bookmarks.GetTarget(node, RDF.GetResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), true);
         if (target != null)
         {
           type = target.QueryInterface(Components.interfaces.nsIRDFResource).Value;
-//            dump("folder feedurl = " + feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-//            dump("type = " + type + "\n");
+          //            dump("folder feedurl = " + feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
+          //            dump("type = " + type + "\n");
           if (type == "http://home.netscape.com/NC-rdf#Livemark")
           {
-//            dump("folder title = " + name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-//            dump("folder url = " + url.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-//            dump("folder feedurl = " + feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
-//            dump("type = " + type + "\n");
+            //            dump("folder title = " + name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
+            //            dump("folder url = " + url.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
+            //            dump("folder feedurl = " + feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
+            //            dump("type = " + type + "\n");
             inforssAddaAddSubMenu(nb, feedurl.QueryInterface(Components.interfaces.nsIRDFLiteral).Value, name.QueryInterface(Components.interfaces.nsIRDFLiteral).Value);
             nb++;
           }
@@ -995,10 +998,10 @@ function inforssWalk(node, nb)
       //target = Bookmarks.GetTarget(node, RDF.GetResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), true);
       //if (target != null)
       //  dump("type = " + target.QueryInterface(Components.interfaces.nsIRDFResource).Value + "\n");
-//        dump("type = " + Bookmarks.GetTarget(node, RDF.GetResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), true).QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
+      //        dump("type = " + Bookmarks.GetTarget(node, RDF.GetResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), true).QueryInterface(Components.interfaces.nsIRDFLiteral).Value + "\n");
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1010,15 +1013,15 @@ function inforssWalk(node, nb)
 function rssSwitchAll(popup, url, label, target)
 {
   inforssTraceIn();
-//inforssAlert("rssSwitchAll");
-//alert(url + "/" + label);
+  //inforssAlert("rssSwitchAll");
+  //alert(url + "/" + label);
   var items = popup.getElementsByTagName(inforssXMLRepository.getSubMenuType());
-//  var j = 0;
-  if (label.indexOf(gInforssRssBundle.getString("inforss.menuadd") + " ") == 0)  // if the user clicked on the "Add ..." button
+  //  var j = 0;
+  if (label.indexOf(gInforssRssBundle.getString("inforss.menuadd") + " ") == 0) // if the user clicked on the "Add ..." button
   {
-//dump("url=" + url + "\n");
+    //dump("url=" + url + "\n");
 
-  	if (inforssGetItemFromUrl(url) != null)  // already exists
+    if (inforssGetItemFromUrl(url) != null) // already exists
     {
       alert(gInforssRssBundle.getString("inforss.duplicate"));
     }
@@ -1026,55 +1029,54 @@ function rssSwitchAll(popup, url, label, target)
     {
       if (gInforssXMLHttpRequest == null)
       {
-        getInfoFromUrl(url);   // search for the general information of the feed: title, ...
+        getInfoFromUrl(url); // search for the general information of the feed: title, ...
       }
     }
   }
   else
   {
-//alert("step 01");
-  	var changed = true;
+    //alert("step 01");
+    var changed = true;
     if ((target == null) || ((target.getAttribute("data") == url) && (target.getAttribute("label") == label)))
     {
       changed = gInforssMediator.setSelected(url);
     }
     if ((changed == true) || (inforssXMLRepository.isActive() == true))
     {
-      document.getElementById('newsbar1').label=null;
-      document.getElementById('newsbar1').style.visibility="hidden";
+      document.getElementById('newsbar1').label = null;
+      document.getElementById('newsbar1').style.visibility = "hidden";
     }
-//alert("step 02");
+    //alert("step 02");
     inforssSave();
-//alert("step 03");
+    //alert("step 03");
   }
   inforssTraceOut();
 }
 
 //-------------------------------------------------------------------------------------------------------------
-var infoRSSObserver =
-{
-  getSupportedFlavours : function ()
+var infoRSSObserver = {
+  getSupportedFlavours: function()
   {
     var flavours = new FlavourSet();
     flavours.appendFlavour("text/unicode");
     return flavours;
   },
-  onDragOver: function (evt,flavour,session)
+  onDragOver: function(evt, flavour, session)
   {
-//    session.canDrag=true;
-//  inforssAlert("drag=" + evt.target.localName + " x=" + evt.clientX + "-" + gInforssX + "=" + (evt.clientX - gInforssX));
-    if(evt.target.localName == "menuitem")
+    //    session.canDrag=true;
+    //  inforssAlert("drag=" + evt.target.localName + " x=" + evt.clientX + "-" + gInforssX + "=" + (evt.clientX - gInforssX));
+    if (evt.target.localName == "menuitem")
     {
       //inforssInspect(evt.target.parentNode);
       //document.getElementById("statusbar-display").label=evt.clientX;
     }
   },
-  onDragStart: function (evt , transferData, action)
+  onDragStart: function(evt, transferData, action)
   {
-//  gInforssX = evt.clientX;
-//  inforssAlert("start=" + evt.target.localName);
+    //  gInforssX = evt.clientX;
+    //  inforssAlert("start=" + evt.target.localName);
     evt.stopPropagation();
-    if(evt.target.localName == "menuitem")
+    if (evt.target.localName == "menuitem")
     {
       //inforssInspect(evt.target.parentNode);
       //document.getElementById("statusbar-display").label=evt.clientX;
@@ -1083,20 +1085,20 @@ var infoRSSObserver =
     //inforssInspect(transferData);
     //inforssInspect(action);
     //evt.target.canDrag=true;
-    var htmlText="<strong>infoRSS</strong>";
-    var plainText="infoRSS";
+    var htmlText = "<strong>infoRSS</strong>";
+    var plainText = "infoRSS";
 
-    transferData.data=new TransferData();
-    transferData.data.addDataForFlavour("text/html",htmlText);
-    transferData.data.addDataForFlavour("text/unicode",evt.target.getAttribute("data"));
-//alert("coucou1");
+    transferData.data = new TransferData();
+    transferData.data.addDataForFlavour("text/html", htmlText);
+    transferData.data.addDataForFlavour("text/unicode", evt.target.getAttribute("data"));
+    //alert("coucou1");
   },
-  onDragExit: function (evt, session)
+  onDragExit: function(evt, session)
   {
-//  inforssAlert("exit=" + evt.clientX);
+    //  inforssAlert("exit=" + evt.clientX);
     //alert("drag exit");
   },
-  onDrop: function (evt, dropdata, session)
+  onDrop: function(evt, dropdata, session)
   {
     try
     {
@@ -1109,17 +1111,17 @@ var infoRSSObserver =
         }
         if (url != "")
         {
-          if (((url.indexOf("file://") == -1) && (url.indexOf("http://") == -1)  && (url.indexOf("https://") == -1)  && (url.indexOf("news://") == -1)))
+          if (((url.indexOf("file://") == -1) && (url.indexOf("http://") == -1) && (url.indexOf("https://") == -1) && (url.indexOf("news://") == -1)))
           {
             evt.cancelBubble = true;
             evt.stopPropagation();
-            window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", gInforssRssBundle.getString("inforss.malformedUrl"));
+            window.openDialog("chrome://inforss/content/inforssAlert.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=no", gInforssRssBundle.getString("inforss.malformedUrl"));
           }
           else
           {
             if (inforssGetItemFromUrl(url) != null)
             {
-              window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", gInforssRssBundle.getString("inforss.duplicate"));
+              window.openDialog("chrome://inforss/content/inforssAlert.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=no", gInforssRssBundle.getString("inforss.duplicate"));
             }
             else
             {
@@ -1147,7 +1149,7 @@ var infoRSSObserver =
                 {
                   info.addNewFeed(url);
                   var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-                  observerService.notifyObservers(null,"reload",null);
+                  observerService.notifyObservers(null, "reload", null);
                 }
               }
             }
@@ -1155,9 +1157,9 @@ var infoRSSObserver =
         }
       }
     }
-    catch(e)
+    catch (e)
     {
-    alert(e);
+      alert(e);
     }
     evt.cancelBubble = true;
     evt.stopPropagation();
@@ -1165,62 +1167,58 @@ var infoRSSObserver =
 };
 
 //-------------------------------------------------------------------------------------------------------------
-var infoRSSTrashObserver =
-{
-  getSupportedFlavours : function ()
+var infoRSSTrashObserver = {
+  getSupportedFlavours: function()
   {
-//alert("11");
+    //alert("11");
     var flavours = new FlavourSet();
     flavours.appendFlavour("text/unicode");
     return flavours;
   },
-  onDragOver: function (evt, flavour, session)
+  onDragOver: function(evt, flavour, session)
   {
-//inforssInspect(flavour);
+    //inforssInspect(flavour);
     session.canDrag = true;
 
   },
-  onDragStart: function (evt , transferData, action)
+  onDragStart: function(evt, transferData, action)
   {
-//alert("33");
+    //alert("33");
 
-    var htmlText="<strong>Cabbage</strong>";
-    var plainText="Cabbage";
+    var htmlText = "<strong>Cabbage</strong>";
+    var plainText = "Cabbage";
 
-    transferData.data=new TransferData();
-    transferData.data.addDataForFlavour("text/html",htmlText);
-    transferData.data.addDataForFlavour("text/unicode",plainText);
+    transferData.data = new TransferData();
+    transferData.data.addDataForFlavour("text/html", htmlText);
+    transferData.data.addDataForFlavour("text/unicode", plainText);
   },
-  onDragExit: function (evt, session)
+  onDragExit: function(evt, session)
   {
-//alert("44");
+    //alert("44");
 
   },
-  onDrop: function (evt, dropdata, session)
+  onDrop: function(evt, dropdata, session)
   {
-//alert("55");
+    //alert("55");
     gInforssMediator.deleteRss(dropdata.data);
   }
 };
 
 //-------------------------------------------------------------------------------------------------------------
-var infoRSSBarObserver =
-{
-  getSupportedFlavours : function ()
+var infoRSSBarObserver = {
+  getSupportedFlavours: function()
   {
     var flavours = new FlavourSet();
     flavours.appendFlavour("text/unicode");
     return flavours;
   },
-  onDragOver: function (evt,flavour,session)
+  onDragOver: function(evt, flavour, session) {},
+  onDragStart: function(evt, transferData, action)
   {
-  },
-  onDragStart: function (evt , transferData, action)
-  {
-//  gInforssX = evt.clientX;
-//  inforssAlert("start=" + evt.target.localName);
+    //  gInforssX = evt.clientX;
+    //  inforssAlert("start=" + evt.target.localName);
     evt.stopPropagation();
-    if(evt.target.localName == "menuitem")
+    if (evt.target.localName == "menuitem")
     {
       //inforssInspect(evt.target.parentNode);
       //document.getElementById("statusbar-display").label=evt.clientX;
@@ -1229,19 +1227,17 @@ var infoRSSBarObserver =
     //inforssInspect(transferData);
     //inforssInspect(action);
     //evt.target.canDrag=true;
-    var htmlText="<strong>infoRSS</strong>";
-    var plainText="infoRSS";
+    var htmlText = "<strong>infoRSS</strong>";
+    var plainText = "infoRSS";
 
-    transferData.data=new TransferData();
-    transferData.data.addDataForFlavour("text/html",htmlText);
-    transferData.data.addDataForFlavour("text/unicode",evt.target.getAttribute("data"));
-//alert("coucou");
+    transferData.data = new TransferData();
+    transferData.data.addDataForFlavour("text/html", htmlText);
+    transferData.data.addDataForFlavour("text/unicode", evt.target.getAttribute("data"));
+    //alert("coucou");
   },
-  onDragExit: function (evt, session)
+  onDragExit: function(evt, session) {},
+  onDrop: function(evt, dropdata, session)
   {
-  },
-  onDrop: function (evt, dropdata, session)
-  { 
     evt.cancelBubble = true;
     evt.stopPropagation();
     document.getElementById("inforss-menupopup").hidePopup();
@@ -1249,49 +1245,49 @@ var infoRSSBarObserver =
     var rss = inforssGetItemFromUrl(url);
     var selectedInfo = gInforssMediator.getSelectedInfo(true);
     if ((selectedInfo != null) && (selectedInfo.getType() == "group") &&
-        (rss != null) && (rss.getAttribute("type") != "group") &&
-        (selectedInfo.containsFeed(url) == false))
+      (rss != null) && (rss.getAttribute("type") != "group") &&
+      (selectedInfo.containsFeed(url) == false))
     {
-//      if (confirm(gInforssRssBundle.getString("inforss.confirm.addtogroup") + selectedInfo.getUrl() + ")") == true)
+      //      if (confirm(gInforssRssBundle.getString("inforss.confirm.addtogroup") + selectedInfo.getUrl() + ")") == true)
       {
         selectedInfo.addNewFeed(url);
       }
     }
     else
     {
-      window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", gInforssRssBundle.getString("inforss.notagroup"));
+      window.openDialog("chrome://inforss/content/inforssAlert.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=no", gInforssRssBundle.getString("inforss.notagroup"));
     }
-  /*
-    if (evt.target.nodeName == "statusbarpanel")
-    {
-      var url = dropdata.data;
-      if (url.indexOf("\n") != -1)
+    /*
+      if (evt.target.nodeName == "statusbarpanel")
       {
-        url = url.substring(0, url.indexOf("\n"));
-      }
-      if (url != "")
-      {
-        if (((url.indexOf("file://") == -1) && (url.indexOf("http://") == -1)  && (url.indexOf("https://") == -1)))
+        var url = dropdata.data;
+        if (url.indexOf("\n") != -1)
         {
-          evt.cancelBubble = true;
-          evt.stopPropagation();
-          window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("bundle_inforss").getString("inforss.malformedUrl"));
+          url = url.substring(0, url.indexOf("\n"));
         }
-        else
+        if (url != "")
         {
-          if (inforssGetItemFromUrl(url) != null)
+          if (((url.indexOf("file://") == -1) && (url.indexOf("http://") == -1)  && (url.indexOf("https://") == -1)))
           {
-            window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("bundle_inforss").getString("inforss.duplicate"));
+            evt.cancelBubble = true;
+            evt.stopPropagation();
+            window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("bundle_inforss").getString("inforss.malformedUrl"));
           }
           else
           {
-            getInfoFromUrl(url);
+            if (inforssGetItemFromUrl(url) != null)
+            {
+              window.openDialog("chrome://inforss/content/inforssAlert.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("bundle_inforss").getString("inforss.duplicate"));
+            }
+            else
+            {
+              getInfoFromUrl(url);
+            }
           }
         }
+        inforssSave();
       }
-      inforssSave();
-    }
-    */
+      */
     evt.cancelBubble = true;
     evt.stopPropagation();
   }
@@ -1301,46 +1297,48 @@ var infoRSSBarObserver =
 function inforssAddItemToRSSList(title, description, url, link, user, password, feedFlag)
 {
   inforssTraceIn();
-//alert("start inforssAddItemToRSSList");
+  //alert("start inforssAddItemToRSSList");
   var elem = null;
   try
   {
-      if (RSSList == null)
-      {
-        RSSList = document.createElement("LIST-RSS");
-      }
-      elem = RSSList.createElement("RSS");
-//alert(RSSList.firstChild.childNodes.length);
-      elem.setAttribute("url",url);
-      elem.setAttribute("title",title);
-      elem.setAttribute("selected","false");
-      elem.setAttribute("nbItem", inforssXMLRepository.getDefaultNbItem());
-      elem.setAttribute("lengthItem", inforssXMLRepository.getDefaultLengthItem());
-      elem.setAttribute("playPodcast", inforssXMLRepository.getDefaultPlayPodcast());
-      elem.setAttribute("savePodcastLocation", inforssXMLRepository.getSavePodcastLocation());
-      elem.setAttribute("purgeHistory", inforssXMLRepository.getDefaultPurgeHistory());
-      elem.setAttribute("browserHistory", inforssXMLRepository.getDefaultBrowserHistory());
-      elem.setAttribute("filterCaseSensitive","true");
-      elem.setAttribute("link",link);
-      elem.setAttribute("description",((description == null) || (description == ""))? title : description);
-      elem.setAttribute("icon","");
-      elem.setAttribute("refresh",inforssXMLRepository.getDefaultRefresh());
-      elem.setAttribute("user",user);
-      elem.setAttribute("activity","true");
-      if ((user != null) && (user != ""))
-      {
-        inforssXMLRepository.storePassword(url, user, password);
-      }
-      elem.setAttribute("filter","all");
-      elem.setAttribute("type", ((feedFlag == true)? "atom" : "rss"));
-      RSSList.firstChild.appendChild(elem);
+    if (RSSList == null)
+    {
+      RSSList = document.createElement("LIST-RSS");
+    }
+    elem = RSSList.createElement("RSS");
+    //alert(RSSList.firstChild.childNodes.length);
+    elem.setAttribute("url", url);
+    elem.setAttribute("title", title);
+    elem.setAttribute("selected", "false");
+    elem.setAttribute("nbItem", inforssXMLRepository.getDefaultNbItem());
+    elem.setAttribute("lengthItem", inforssXMLRepository.getDefaultLengthItem());
+    elem.setAttribute("playPodcast", inforssXMLRepository.getDefaultPlayPodcast());
+    elem.setAttribute("savePodcastLocation", inforssXMLRepository.getSavePodcastLocation());
+    elem.setAttribute("purgeHistory", inforssXMLRepository.getDefaultPurgeHistory());
+    elem.setAttribute("browserHistory", inforssXMLRepository.getDefaultBrowserHistory());
+    elem.setAttribute("filterCaseSensitive", "true");
+    elem.setAttribute("link", link);
+    elem.setAttribute("description", ((description == null) || (description == "")) ? title : description);
+    elem.setAttribute("icon", "");
+    elem.setAttribute("refresh", inforssXMLRepository.getDefaultRefresh());
+    elem.setAttribute("activity", "true");
+    if ((user != null) && (user != ""))
+    {
+      elem.setAttribute("user", user);
+      inforssXMLRepository.storePassword(url, user, password);
+    }
+    elem.setAttribute("filter", "all");
+    elem.setAttribute("type", ((feedFlag == true) ? "atom" : "rss"));
+    /**/
+    console.log("user", user, "attribute", elem.getAttribute("user"));
+    RSSList.firstChild.appendChild(elem);
   }
-  catch(e)
-  { 
-//alert(e);
-    inforssDebug("addItemToRSSList" , e)
+  catch (e)
+  {
+    //alert(e);
+    inforssDebug("addItemToRSSList", e)
   }
-//alert(RSSList.firstChild.childNodes.length);
+  //alert(RSSList.firstChild.childNodes.length);
   inforssTraceOut();
   return elem;
 }
@@ -1360,8 +1358,8 @@ function inforssLocateMenuItem(title)
     while ((obj != null) && (stop == false))
     {
       if ((obj.nodeName == "menuseparator") ||
-          ((inforssXMLRepository.getSortedMenu() == "asc") && (title > obj.getAttribute("label").toLowerCase())) ||
-          ((inforssXMLRepository.getSortedMenu() == "des") && (title < obj.getAttribute("label").toLowerCase())))
+        ((inforssXMLRepository.getSortedMenu() == "asc") && (title > obj.getAttribute("label").toLowerCase())) ||
+        ((inforssXMLRepository.getSortedMenu() == "des") && (title < obj.getAttribute("label").toLowerCase())))
       {
         stop = true;
         item = obj.nextSibling;
@@ -1372,9 +1370,9 @@ function inforssLocateMenuItem(title)
       }
     }
   }
-  catch(e)
+  catch (e)
   {
-    inforssDebug("addItemToRSSList" , e)
+    inforssDebug("addItemToRSSList", e)
   }
   inforssTraceOut();
   return item;
@@ -1384,103 +1382,103 @@ function inforssLocateMenuItem(title)
 function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
 {
   inforssTraceIn();
-//alert("start inforssAddItemToMenu");
+  //alert("start inforssAddItemToMenu");
   var menuItem = null;
   try
   {
-     if (document.getElementById("inforss-menupopup") != null)
-     {
-       if ((rss.getAttribute("groupAssociated") == "false") || (inforssXMLRepository.isIncludeAssociated() == true))
-       {
-         var typeObject = inforssXMLRepository.getSubMenuType();
-         var items = document.getElementById("inforss-menupopup").getElementsByTagName(typeObject);
-         if (preSelected == true)
-         {
-           for (var i=0; i<items.length; i++)
-           {
-             items[i].setAttribute("checked", false);
-           }
-         }
-         menuItem = document.createElement(typeObject);
+    if (document.getElementById("inforss-menupopup") != null)
+    {
+      if ((rss.getAttribute("groupAssociated") == "false") || (inforssXMLRepository.isIncludeAssociated() == true))
+      {
+        var typeObject = inforssXMLRepository.getSubMenuType();
+        var items = document.getElementById("inforss-menupopup").getElementsByTagName(typeObject);
+        if (preSelected == true)
+        {
+          for (var i = 0; i < items.length; i++)
+          {
+            items[i].setAttribute("checked", false);
+          }
+        }
+        menuItem = document.createElement(typeObject);
 
-         menuItem.setAttribute("type", "radio");
-         menuItem.setAttribute("label", rss.getAttribute("title"));
-//alert("title=" + rss.getAttribute("title") + "\n");
-         menuItem.setAttribute("value", rss.getAttribute("title"));
+        menuItem.setAttribute("type", "radio");
+        menuItem.setAttribute("label", rss.getAttribute("title"));
+        //alert("title=" + rss.getAttribute("title") + "\n");
+        menuItem.setAttribute("value", rss.getAttribute("title"));
 
 
-         menuItem.setAttribute("data", rss.getAttribute("url"));
-         menuItem.setAttribute("url", rss.getAttribute("url"));
-         menuItem.setAttribute("checked", preSelected);
-         menuItem.setAttribute("autocheck", false);
-         if ((rss.getAttribute("description") != null) && (rss.getAttribute("description") != ""))
-         {
-           menuItem.setAttribute("tooltiptext",rss.getAttribute("description"));
-         }
-         menuItem.setAttribute("tooltip", null);
-         menuItem.setAttribute("image",rss.getAttribute("icon"));
-         menuItem.setAttribute("validate", "never");
-         menuItem.setAttribute("id","inforss.menuitem-" + items.length);
-         menuItem.setAttribute("inforsstype", rss.getAttribute("type"));
+        menuItem.setAttribute("data", rss.getAttribute("url"));
+        menuItem.setAttribute("url", rss.getAttribute("url"));
+        menuItem.setAttribute("checked", preSelected);
+        menuItem.setAttribute("autocheck", false);
+        if ((rss.getAttribute("description") != null) && (rss.getAttribute("description") != ""))
+        {
+          menuItem.setAttribute("tooltiptext", rss.getAttribute("description"));
+        }
+        menuItem.setAttribute("tooltip", null);
+        menuItem.setAttribute("image", rss.getAttribute("icon"));
+        menuItem.setAttribute("validate", "never");
+        menuItem.setAttribute("id", "inforss.menuitem-" + items.length);
+        menuItem.setAttribute("inforsstype", rss.getAttribute("type"));
 
-         menuItem.setAttribute("class", typeObject + "-iconic");
-         if (rss.getAttribute("activity") == "false")
-         {
-           menuItem.setAttribute("disabled", "true");
-         }
+        menuItem.setAttribute("class", typeObject + "-iconic");
+        if (rss.getAttribute("activity") == "false")
+        {
+          menuItem.setAttribute("disabled", "true");
+        }
 
-         if ((inforssXMLRepository.getSubMenu() == "true") && ((rss.getAttribute("type") == "rss") || (rss.getAttribute("type") == "atom") || (rss.getAttribute("type") == "group") || (rss.getAttribute("type") == "html")))
-         {
-           var menupopup = document.createElement("menupopup");
-           menupopup.setAttribute("type", rss.getAttribute("type"));
-           if ((rss.getAttribute("type") == "rss") || (rss.getAttribute("type") == "atom"))
-           {
-             menupopup.setAttribute("onpopupshowing","return inforssSubMenu(" + items.length + ");");
-           }
-           else
-           {
-             menupopup.setAttribute("onpopupshowing","return false");
-           }
-           menupopup.setAttribute("onpopuphiding","return inforssSubMenu2();");
-           menupopup.setAttribute("id","inforss.menupopup-" + items.length);
-//           menupopup.addEventListener("command", function() { mouseup(this, event); return true;}, false);
-//           menupopup.setAttribute("disabled","true");
-           inforssAddNoData(menupopup);
-           menuItem.appendChild(menupopup);
-//           menupopup.addEventListener("command", function() { alert('didier');  return false;}, false);
-//           menupopup.addEventListener("mouseup", function() { alert('ernotte');  return false;}, false);
-         }
+        if ((inforssXMLRepository.getSubMenu() == "true") && ((rss.getAttribute("type") == "rss") || (rss.getAttribute("type") == "atom") || (rss.getAttribute("type") == "group") || (rss.getAttribute("type") == "html")))
+        {
+          var menupopup = document.createElement("menupopup");
+          menupopup.setAttribute("type", rss.getAttribute("type"));
+          if ((rss.getAttribute("type") == "rss") || (rss.getAttribute("type") == "atom"))
+          {
+            menupopup.setAttribute("onpopupshowing", "return inforssSubMenu(" + items.length + ");");
+          }
+          else
+          {
+            menupopup.setAttribute("onpopupshowing", "return false");
+          }
+          menupopup.setAttribute("onpopuphiding", "return inforssSubMenu2();");
+          menupopup.setAttribute("id", "inforss.menupopup-" + items.length);
+          //           menupopup.addEventListener("command", function() { mouseup(this, event); return true;}, false);
+          //           menupopup.setAttribute("disabled","true");
+          inforssAddNoData(menupopup);
+          menuItem.appendChild(menupopup);
+          //           menupopup.addEventListener("command", function() { alert('didier');  return false;}, false);
+          //           menupopup.addEventListener("mouseup", function() { alert('ernotte');  return false;}, false);
+        }
 
-         if (inforssXMLRepository.getSortedMenu() != "no")
-         {
-           var indexItem = inforssLocateMenuItem(rss.getAttribute("title"));
-           document.getElementById("inforss-menupopup").insertBefore(menuItem, indexItem);
-//dump("indexItem=" + indexItem + "\n");
-         }
-         else
-         {
-           document.getElementById("inforss-menupopup").appendChild(menuItem);
-         }
-         if (preSelected == true)
-         {
-           document.getElementById("inforss-menupopup").selectedItem = menuItem;
-         }
-//if (rss.getAttribute("type") == "group")
-//{
-//dump("addItemToMenu GROUP " + rss.getAttribute("url") + " " + rss.getElementsByTagName("GROUP").length + "\n");
-//}
-       }
-//alert("addFeed");
-       gInforssMediator.addFeed(rss, menuItem, saveFlag);
-       if (flagAlert == true)
-       {
-         window.openDialog("chrome://inforss/content/inforssAdd.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("inforss-menupopup"), rss);
-       }
-     }
+        if (inforssXMLRepository.getSortedMenu() != "no")
+        {
+          var indexItem = inforssLocateMenuItem(rss.getAttribute("title"));
+          document.getElementById("inforss-menupopup").insertBefore(menuItem, indexItem);
+          //dump("indexItem=" + indexItem + "\n");
+        }
+        else
+        {
+          document.getElementById("inforss-menupopup").appendChild(menuItem);
+        }
+        if (preSelected == true)
+        {
+          document.getElementById("inforss-menupopup").selectedItem = menuItem;
+        }
+        //if (rss.getAttribute("type") == "group")
+        //{
+        //dump("addItemToMenu GROUP " + rss.getAttribute("url") + " " + rss.getElementsByTagName("GROUP").length + "\n");
+        //}
+      }
+      //alert("addFeed");
+      gInforssMediator.addFeed(rss, menuItem, saveFlag);
+      if (flagAlert == true)
+      {
+        window.openDialog("chrome://inforss/content/inforssAdd.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=no", document.getElementById("inforss-menupopup"), rss);
+      }
+    }
   }
-  catch(e)
-  { 
-//alert(e);
+  catch (e)
+  {
+    //alert(e);
     inforssDebug(e)
   }
   inforssTraceOut();
@@ -1493,13 +1491,13 @@ function inforssAddItemToMenu(rss, flagAlert, preSelected, saveFlag)
 function inforssSubMenu(index)
 {
   inforssTraceIn();
-//inforssAlert("toto:" + index);
+  //inforssAlert("toto:" + index);
   popup = document.getElementById("inforss.menupopup-" + index);
   inforssSubMenu2();
   if (inforssXMLRepository.getSubMenu() == "true")
   {
-     gInforssCurrentMenuHandle = window.setTimeout("inforssSubMenu1(" + index + ")", 3000);
-     return true;
+    gInforssCurrentMenuHandle = window.setTimeout("inforssSubMenu1(" + index + ")", 3000);
+    return true;
   }
   else
   {
@@ -1514,30 +1512,30 @@ function inforssSubMenu1(index)
   inforssTraceIn();
   try
   {
-//inforssAlert("toto1:" + index);
+    //inforssAlert("toto1:" + index);
     gInforssCurrentMenuHandle = null;
     popup = document.getElementById("inforss.menupopup-" + index);
     item = document.getElementById("inforss.menuitem-" + index);
     url = item.getAttribute("url");
     var rss = inforssGetItemFromUrl(url);
-//inforssAlert("toto1:" + url);
-    popup.setAttribute("onpopupshowing",null);
+    //inforssAlert("toto1:" + url);
+    popup.setAttribute("onpopupshowing", null);
     inforssResetPopup(popup);
     var xmlHttpRequest = new XMLHttpRequest();
     xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-	xmlHttpRequest.overrideMimeType("application/xml");
-	xmlHttpRequest.send(null);
+    xmlHttpRequest.overrideMimeType("application/xml");
+    xmlHttpRequest.send(null);
 
     var fm = new FeedManager();
     fm.parse(xmlHttpRequest);
-//inforssAlert("len=" + fm.rssFeeds.length);
+    //inforssAlert("len=" + fm.rssFeeds.length);
     var max = INFORSS_MAX_SUBMENU;
     max = Math.min(max, fm.rssFeeds.length);
-    for (var i=0; i<max; i++)
+    for (var i = 0; i < max; i++)
     {
       var newElem = document.createElement("menuitem");
       var newTitle = inforssFeed.htmlFormatConvert(fm.rssFeeds[i].title);
-      var re = new RegExp ('\n', 'gi') ;
+      var re = new RegExp('\n', 'gi');
       if (newTitle != null)
       {
         newTitle = newTitle.replace(re, ' ');
@@ -1546,13 +1544,18 @@ function inforssSubMenu1(index)
       newElem.setAttribute("url", fm.rssFeeds[i].link);
       newElem.setAttribute("tooltiptext", inforssFeed.htmlFormatConvert(fm.rssFeeds[i].description));
       popup.appendChild(newElem);
-      newElem.addEventListener("command", function(event) {  event.cancelBubble = true; event.stopPropagation(); return true;}, false);
-//           newElem.addEventListener("mouseup", function(event) { alert('ernotte');  event.cancelBubble = true; event.stopPropagation(); return true;}, false);
+      newElem.addEventListener("command", function(event)
+      {
+        event.cancelBubble = true;
+        event.stopPropagation();
+        return true;
+      }, false);
+      //           newElem.addEventListener("mouseup", function(event) { alert('ernotte');  event.cancelBubble = true; event.stopPropagation(); return true;}, false);
     }
   }
-  catch(e)
+  catch (e)
   {
-//    alert("toto1: " + e)
+    //    alert("toto1: " + e)
   }
   inforssTraceOut();
 }
@@ -1573,7 +1576,7 @@ function inforssSubMenu2()
 //-------------------------------------------------------------------------------------------------------------
 function inforssSubMenu3()
 {
-//inforssAlert("toto3" + "/" + (gInforssCounter++));
+  //inforssAlert("toto3" + "/" + (gInforssCounter++));
   return true;
 }
 
@@ -1587,7 +1590,7 @@ function inforssAddNoData(popup)
     item.setAttribute("label", gInforssRssBundle.getString("inforss.noData"));
     popup.appendChild(item);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1637,30 +1640,37 @@ function openNewTabInForeground(href, linkNode, event, securityCheck, postData)
 function getInfoFromUrl(url)
 {
   inforssTraceIn();
-//inforssAlert("getInfoFromUrl:" + url);
+  //inforssAlert("getInfoFromUrl:" + url);
   gInforssUser = null;
   gInforssPassword = null;
   var getFlag = true;
   if (url.indexOf("https://") == 0)
   {
     var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
-    var windowManagerInterface = windowManager.QueryInterface( Components.interfaces.nsIWindowMediator);
+    var windowManagerInterface = windowManager.QueryInterface(Components.interfaces.nsIWindowMediator);
     var topWindow = windowManagerInterface.getMostRecentWindow("navigator:browser");
 
-    var gUser = { value: gInforssUser };
-    var gPassword = { value: gInforssPassword };
+    var gUser = {
+      value: gInforssUser
+    };
+    var gPassword = {
+      value: gInforssPassword
+    };
     var dialog = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].createInstance(Components.interfaces.nsIPromptService);
-    getFlag = dialog.promptUsernameAndPassword(topWindow, null , gInforssRssBundle.getString("inforss.account") + " " + url , gUser  , gPassword  , null , { value: true });
+    getFlag = dialog.promptUsernameAndPassword(topWindow, null, gInforssRssBundle.getString("inforss.account") + " " + url, gUser, gPassword, null,
+    {
+      value: true
+    });
     gInforssUser = gUser.value;
     gInforssPassword = gPassword.value;
   }
   if (getFlag == true)
   {
-//alert("avant");
+    //alert("avant");
     inforssGetRss(url, "inforssPopulateMenuItem", gInforssUser, gInforssPassword);
-//alert("apres");
+    //alert("apres");
   }
-//alert("end getInfoFromUrl");
+  //alert("end getInfoFromUrl");
   inforssTraceOut();
 }
 
@@ -1670,17 +1680,17 @@ function inforssPopulateMenuItem()
   inforssTraceIn();
   try
   {
-//dump("Status=" + gInforssXMLHttpRequest.status + "\n");
+    //dump("Status=" + gInforssXMLHttpRequest.status + "\n");
     var objDOMParser = new DOMParser();
-//dump(gInforssXMLHttpRequest.responseText + "\n");
+    //dump(gInforssXMLHttpRequest.responseText + "\n");
     var objDoc = objDOMParser.parseFromString(gInforssXMLHttpRequest.responseText, "text/xml");
-//dump("step1" + "\n");
+    //dump("step1" + "\n");
     var str_description = null;
     var str_title = null;
     var str_link = null;
     var feed_flag = false;
     var validFormat = false;
-//dump("step2" + "\n");
+    //dump("step2" + "\n");
 
     var format = inforssGetFormat(objDoc);
     if (format == "feed")
@@ -1701,7 +1711,7 @@ function inforssPopulateMenuItem()
         validFormat = true;
       }
     }
-//dump("step3: " + format + "\n");
+    //dump("step3: " + format + "\n");
 
     var titles = objDoc.getElementsByTagName(str_title);
     var links = objDoc.getElementsByTagName(str_link);
@@ -1710,31 +1720,35 @@ function inforssPopulateMenuItem()
     {
       descriptions = objDoc.getElementsByTagName("title");
     }
-//dump("step4" + "\n");
-//dump(format + " " + descriptions.length + " " + links.length + " " + titles.length + "\n");
+    //dump("step4" + "\n");
+    //dump(format + " " + descriptions.length + " " + links.length + " " + titles.length + "\n");
 
     if ((descriptions.length > 0) && (links.length > 0) && (titles.length > 0))
     {
-//dump("step5" + "\n");
-    	var elem = inforssAddItemToRSSList(getNodeValue(titles), getNodeValue(descriptions), gInforssUrl, (feed_flag == true)? getHref(links) : getNodeValue(links), gInforssUser, gInforssPassword, feed_flag);
-        delete gInforssXMLHttpRequest;
-        var urlIcon = inforssFindIcon(elem);
-        if (urlIcon != null)
-        {
-          elem.setAttribute("icon",urlIcon);
-        }
-    	inforssAddItemToMenu(elem, true, false, true);
+      //dump("step5" + "\n");
+      /**/
+      console.log("got a new item", gInforssUrl, gInforssUser);
+      var elem = inforssAddItemToRSSList(getNodeValue(titles), getNodeValue(descriptions), gInforssUrl, (feed_flag == true) ? getHref(links) : getNodeValue(links), gInforssUser, gInforssPassword, feed_flag);
+      /**/
+      console.log("elem is", elem)
+      delete gInforssXMLHttpRequest;
+      var urlIcon = inforssFindIcon(elem);
+      if (urlIcon != null)
+      {
+        elem.setAttribute("icon", urlIcon);
+      }
+      inforssAddItemToMenu(elem, true, false, true);
     }
     else
     {
-	  alert(gInforssRssBundle.getString("inforss.feed.issue"));
-	}
+      alert(gInforssRssBundle.getString("inforss.feed.issue"));
+    }
 
     delete xmlStr;
     delete objDOMParser;
     delete objDoc;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1775,7 +1789,7 @@ function inforssMouseUp(menu, event)
     {
       if (event.type == "mouseup")
       {
-        window.openDialog("chrome://inforss/content/inforssSettings.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", event.target);
+        window.openDialog("chrome://inforss/content/inforssSettings.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=no", event.target);
       }
     }
   }
@@ -1801,7 +1815,7 @@ function inforssGetItemFromUrl(url)
     }
   }
   inforssTraceOut();
-  return (find == true)? items[i] : null;
+  return (find == true) ? items[i] : null;
 }
 
 //-------------------------------------------------------------------------------------------------------------
@@ -1823,7 +1837,7 @@ function getCurrentRSS()
     }
   }
   inforssTraceOut();
-  return (find == true)? items[i] : null;
+  return (find == true) ? items[i] : null;
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -1834,97 +1848,100 @@ function manageRSSChanged(subject, topic, data)
   {
     if (gInforssMediator != null)
     {
-      switch(topic)
+      switch (topic)
       {
         case "reload":
-        {
-//dump("reload\n");
-          if (data != null)
           {
-            var urls = data.split("|");
-            for (i = 0; i < (urls.length - 1); i++)
+            //dump("reload\n");
+            if (data != null)
             {
-              gInforssMediator.deleteRss(urls[i], false);
+              var urls = data.split("|");
+              for (i = 0; i < (urls.length - 1); i++)
+              {
+                gInforssMediator.deleteRss(urls[i], false);
+              }
             }
+            delete RSSList;
+            inforssClearPopupMenu();
+            window.setTimeout("gInforssMediator.init()", 0);
+            break;
           }
-          delete RSSList;
-          inforssClearPopupMenu();
-          window.setTimeout("gInforssMediator.init()",0);
-          break;
-        }
         case "rssChanged":
-        {
-          gInforssMediator.deleteAllRss();
-          delete RSSList;
-          inforssClearPopupMenu();
-          window.setTimeout("gInforssMediator.init()",0);
-          break;
-        }
+          {
+            gInforssMediator.deleteAllRss();
+            delete RSSList;
+            inforssClearPopupMenu();
+            window.setTimeout("gInforssMediator.init()", 0);
+            break;
+          }
         case "viewed":
-        {
-          var index = data.indexOf("__SEP__");
-          var title = data.substring(0,index);
-          var link = data.substring(index + 7);
-          gInforssMediator.setViewed(title , link);
-          break;
-        }
+          {
+            var index = data.indexOf("__SEP__");
+            var title = data.substring(0, index);
+            var link = data.substring(index + 7);
+            gInforssMediator.setViewed(title, link);
+            break;
+          }
         case "banned":
-        {
-          var index = data.indexOf("__SEP__");
-          var title = data.substring(0,index);
-          var link = data.substring(index + 7);
-          gInforssMediator.setBanned(title , link);
-          break;
-        }
+          {
+            var index = data.indexOf("__SEP__");
+            var title = data.substring(0, index);
+            var link = data.substring(index + 7);
+            gInforssMediator.setBanned(title, link);
+            break;
+          }
         case "sync":
-        {
-          gInforssMediator.sync(data);
-          break;
-        }
+          {
+            gInforssMediator.sync(data);
+            break;
+          }
         case "syncBack":
-        {
-          gInforssMediator.syncBack(data);
-          break;
-        }
+          {
+            gInforssMediator.syncBack(data);
+            break;
+          }
         case "ack":
-        {
-          gInforssMediator.ack(data);
-          break;
-        }
+          {
+            gInforssMediator.ack(data);
+            break;
+          }
         case "popup":
-        {
-          var index = data.indexOf("__SEP__");
-          var url = data.substring(0,index);
-          var flag = data.substring(index + 7);
-          gInforssMediator.setPopup(url, (flag == "true"));
-          break;
-        }
+          {
+            var index = data.indexOf("__SEP__");
+            var url = data.substring(0, index);
+            var flag = data.substring(index + 7);
+            gInforssMediator.setPopup(url, (flag == "true"));
+            break;
+          }
         case "newRDF":
-        {
-          gInforssMediator.newRDF();
-          break;
-        }
+          {
+            gInforssMediator.newRDF();
+            break;
+          }
         case "purgeRdf":
-        {
-          gInforssMediator.purgeRdf();
-          break;
-        }
+          {
+            gInforssMediator.purgeRdf();
+            break;
+          }
         case "clearRdf":
-        {
-          gInforssMediator.clearRdf();
-          break;
-        }
+          {
+            gInforssMediator.clearRdf();
+            break;
+          }
         case "addFeed":
-        {
-//dump("AddFeed: " + data + "\n");
-//alert(data);
-          inforssAddNewFeed({inforssUrl: data});
-          break;
-        }
+          {
+            //dump("AddFeed: " + data + "\n");
+            //alert(data);
+            inforssAddNewFeed(
+            {
+              inforssUrl: data
+            });
+            break;
+          }
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1939,11 +1956,11 @@ function inforssResizeWindow1(event)
   {
     if (gInforssResizeTimeout != null)
     {
-	  window.clearTimeout(gInforssResizeTimeout);
-	}
-	gInforssResizeTimeout = window.setTimeout(inforssResizeWindow, 1000, event);
+      window.clearTimeout(gInforssResizeTimeout);
+    }
+    gInforssResizeTimeout = window.setTimeout(inforssResizeWindow, 1000, event);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1962,7 +1979,7 @@ function inforssResizeWindow(event)
       gInforssMediator.resizedWindow();
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1974,57 +1991,57 @@ function inforssRelocateBar()
 {
   inforssTraceIn();
   try
-  { 
-	var statuspanelIcon = document.getElementById("inforss-icon");
-	var statuspanelNews = document.getElementById("inforss-hbox");
-	var headlines = document.getElementById("inforss.headlines");
-	var container = headlines.parentNode;
-	if (container.getAttribute("id") == "inforss-bar-top")
-	{
-      var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("inforss.");
-      prefs.setBoolPref("toolbar.collapsed", ((container.getAttribute("collapsed") == null)? false : (container.getAttribute("collapsed") == "true")));
-	}
-	
-	if (inforssXMLRepository.getSeparateLine() == "false")  // in the status bar
+  {
+    var statuspanelIcon = document.getElementById("inforss-icon");
+    var statuspanelNews = document.getElementById("inforss-hbox");
+    var headlines = document.getElementById("inforss.headlines");
+    var container = headlines.parentNode;
+    if (container.getAttribute("id") == "inforss-bar-top")
     {
-//dump("inforssRelocateBar step 1\n");
-	  document.getElementById("inforss.resizer").setAttribute("collapsed","false");
+      var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("inforss.");
+      prefs.setBoolPref("toolbar.collapsed", ((container.getAttribute("collapsed") == null) ? false : (container.getAttribute("collapsed") == "true")));
+    }
+
+    if (inforssXMLRepository.getSeparateLine() == "false") // in the status bar
+    {
+      //dump("inforssRelocateBar step 1\n");
+      document.getElementById("inforss.resizer").setAttribute("collapsed", "false");
       if (container.getAttribute("id") != "addon-bar")
-	  {
-//dump("inforssRelocateBar step 2\n");
-	    container.parentNode.removeChild(container);
-	    document.getElementById("addon-bar").appendChild(headlines);
-	    statuspanelNews.setAttribute("flex","0");
-	    statuspanelNews.firstChild.setAttribute("flex","0");
-	    headlines.setAttribute("flex","0");
+      {
+        //dump("inforssRelocateBar step 2\n");
+        container.parentNode.removeChild(container);
+        document.getElementById("addon-bar").appendChild(headlines);
+        statuspanelNews.setAttribute("flex", "0");
+        statuspanelNews.firstChild.setAttribute("flex", "0");
+        headlines.setAttribute("flex", "0");
         var box = document.getElementById("inforss.newsbox1");
         if (box != null)
         {
-//dump("an event handler has been set for the mouse wheel\n");
+          //dump("an event handler has been set for the mouse wheel\n");
           box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
         }
-//dump("inforssRelocateBar step 3\n");
-	  }
-	}
-	else
-	{
-	  document.getElementById("inforss.resizer").setAttribute("collapsed","true");
+        //dump("inforssRelocateBar step 3\n");
+      }
+    }
+    else
+    {
+      document.getElementById("inforss.resizer").setAttribute("collapsed", "true");
       if (inforssXMLRepository.getLinePosition() == "top")
-	  {
-	    if (container.getAttribute("id") != "inforss-bar-top")
-		{
-		  if (container.getAttribute("id") == "inforss-bar-bottom")
-		  {  // was in the bottom bar
-			container.parentNode.removeChild(container);
-		  }
-		  else
-		  { // was in the status bar
-		    headlines.parentNode.removeChild(headlines);
-		  }
-//		  var statusbar = document.createElement("hbox");
-		  var statusbar = document.createElement("toolbar");
-		  statusbar.setAttribute("persist" , "collapsed");
-		  statusbar.setAttribute("id","inforss-bar-top");
+      {
+        if (container.getAttribute("id") != "inforss-bar-top")
+        {
+          if (container.getAttribute("id") == "inforss-bar-bottom")
+          { // was in the bottom bar
+            container.parentNode.removeChild(container);
+          }
+          else
+          { // was in the status bar
+            headlines.parentNode.removeChild(headlines);
+          }
+          //		  var statusbar = document.createElement("hbox");
+          var statusbar = document.createElement("toolbar");
+          statusbar.setAttribute("persist", "collapsed");
+          statusbar.setAttribute("id", "inforss-bar-top");
           var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("inforss.");
           var colla = false;
           if (prefs.prefHasUserValue("toolbar.collapsed") == false)
@@ -2035,64 +2052,64 @@ function inforssRelocateBar()
           {
             colla = prefs.getBoolPref("toolbar.collapsed");
           }
-//dump("colla=" + colla + "\n");
-		  statusbar.setAttribute("collapsed", colla);
-//alert(statusbar.getAttribute("collapsed") + "/" + statusbar.getAttribute("hidden"));
-		  statusbar.appendChild(headlines);
-		  var toolbox = document.getElementById("navigator-toolbox");
-		  if (toolbox == null)
-		  {
-		    toolbox = document.getElementById("addon-bar").previousSibling;
-		    toolbox.parentNode.insertBefore(statusbar, toolbox);
-		  }
-		  else
-		  {
-		    toolbox.appendChild(statusbar);
-		  }
-//		  toolbox.parentNode.insertBefore(statusbar, toolbox.nextSibling);
+          //dump("colla=" + colla + "\n");
+          statusbar.setAttribute("collapsed", colla);
+          //alert(statusbar.getAttribute("collapsed") + "/" + statusbar.getAttribute("hidden"));
+          statusbar.appendChild(headlines);
+          var toolbox = document.getElementById("navigator-toolbox");
+          if (toolbox == null)
+          {
+            toolbox = document.getElementById("addon-bar").previousSibling;
+            toolbox.parentNode.insertBefore(statusbar, toolbox);
+          }
+          else
+          {
+            toolbox.appendChild(statusbar);
+          }
+          //		  toolbox.parentNode.insertBefore(statusbar, toolbox.nextSibling);
           statusbar.setAttribute("toolbarname", "InfoRSS");
-		  statuspanelNews.setAttribute("flex","1");
-		  statuspanelNews.firstChild.setAttribute("flex","1");
-		  headlines.setAttribute("flex","1");
+          statuspanelNews.setAttribute("flex", "1");
+          statuspanelNews.firstChild.setAttribute("flex", "1");
+          headlines.setAttribute("flex", "1");
           var box = document.getElementById("inforss.newsbox1");
           if (box != null)
           {
-//dump("an event handler has been set for the mouse wheel\n");
+            //dump("an event handler has been set for the mouse wheel\n");
             box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
           }
-  	    }
-	  }
-	  else
-	  {
-	    if (container.getAttribute("id") != "inforss-bar-bottom")
-	    {
-	  	  if (container.getAttribute("id") == "inforss-bar-top")
-		  { // was in the top bar
-		    container.parentNode.removeChild(container);
-		  }
-		  else
-		  { // was in the status bar
-			headlines.parentNode.removeChild(headlines);
-		  }
-		  var statusbar = document.createElement("hbox");
-		  statusbar.setAttribute("id","inforss-bar-bottom");
-		  statusbar.appendChild(headlines);
-		  var toolbar = document.getElementById("addon-bar");
-		  toolbar.parentNode.insertBefore(statusbar, toolbar);
-		  statuspanelNews.setAttribute("flex","1");
-		  statuspanelNews.firstChild.setAttribute("flex","1");
-		  headlines.setAttribute("flex","1");
+        }
+      }
+      else
+      {
+        if (container.getAttribute("id") != "inforss-bar-bottom")
+        {
+          if (container.getAttribute("id") == "inforss-bar-top")
+          { // was in the top bar
+            container.parentNode.removeChild(container);
+          }
+          else
+          { // was in the status bar
+            headlines.parentNode.removeChild(headlines);
+          }
+          var statusbar = document.createElement("hbox");
+          statusbar.setAttribute("id", "inforss-bar-bottom");
+          statusbar.appendChild(headlines);
+          var toolbar = document.getElementById("addon-bar");
+          toolbar.parentNode.insertBefore(statusbar, toolbar);
+          statuspanelNews.setAttribute("flex", "1");
+          statuspanelNews.firstChild.setAttribute("flex", "1");
+          headlines.setAttribute("flex", "1");
           var box = document.getElementById("inforss.newsbox1");
           if (box != null)
           {
-//dump("an event handler has been set for the mouse wheel\n");
+            //dump("an event handler has been set for the mouse wheel\n");
             box.addEventListener("DOMMouseScroll", inforssMouseScroll, false);
           }
-		}
-	  }
-	}
+        }
+      }
+    }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2103,7 +2120,7 @@ function inforssRelocateBar()
 function inforssDeleteTree(obj)
 {
   inforssTraceIn();
-//alert("deletetree\n");
+  //alert("deletetree\n");
   while (obj.firstChild != null)
   {
     obj.removeChild(obj.firstChild);
@@ -2122,13 +2139,13 @@ function inforssEraseNews()
 //-----------------------------------------------------------------------------------------------------
 function inforssResizeHeadlines(event)
 {
-dump("resize " + event.clientX + "\n");
+  dump("resize " + event.clientX + "\n");
   try
   {
     if (gInforssCanResize == true)
     {
-dump("event type=" + event.type + "\n");
-dump("event which=" + event.which + "\n");
+      dump("event type=" + event.type + "\n");
+      dump("event which=" + event.which + "\n");
       {
         var delta = event.clientX - gInforssX;
         var hbox = document.getElementById('inforss.newsbox1');
@@ -2137,52 +2154,53 @@ dump("event which=" + event.which + "\n");
           if ((hbox.getAttribute("width") != null) && (hbox.getAttribute("width") != ""))
           {
             var width = hbox.getAttribute("width");
-dump("old width=" + width + "\n");
+            dump("old width=" + width + "\n");
             var oldWidth = width
             var oldX = hbox.boxObject.screenX;
             width = eval(gInforssWidth) - delta;
-dump("new width=" + width + "   event.clientX=" + event.clientX + "    gInforssX=" + gInforssX + "\n");
+            dump("new width=" + width + "   event.clientX=" + event.clientX + "    gInforssX=" + gInforssX + "\n");
             if (width > 10)
             {
-//              hbox.setAttribute("width", width);
-//              hbox.style.width = width + "px";
-/*              var newX = hbox.boxObject.screenX;
-              if (newX == oldX)
-              {
-                var find = false;
-                width--;
-                while ((width > 0) && (find == false))
-                {
-                  hbox.setAttribute("width", width);
-                  hbox.style.width = width + "px";
-                  newX = hbox.boxObject.screenX;
-                  if (newX == oldX)
-                  {
-                    width--;
-                  }
-                  else
-                  {
-                    find = true;
-                  }
-                }
-                width++;
-                hbox.setAttribute("width",width);
-                hbox.style.width = width + "px";
+              //              hbox.setAttribute("width", width);
+              //              hbox.style.width = width + "px";
+              /*              var newX = hbox.boxObject.screenX;
+                            if (newX == oldX)
+                            {
+                              var find = false;
+                              width--;
+                              while ((width > 0) && (find == false))
+                              {
+                                hbox.setAttribute("width", width);
+                                hbox.style.width = width + "px";
+                                newX = hbox.boxObject.screenX;
+                                if (newX == oldX)
+                                {
+                                  width--;
+                                }
+                                else
+                                {
+                                  find = true;
+                                }
+                              }
+                              width++;
+                              hbox.setAttribute("width",width);
+                              hbox.style.width = width + "px";
 
-//dump("pas bouge\n");
-              }
-              else
-              {
-//              gInforssX = event.clientX;
-              }
-*/              inforssXMLRepository.setScrollingArea(width);
+              //dump("pas bouge\n");
+                            }
+                            else
+                            {
+              //              gInforssX = event.clientX;
+                            }
+              */
+              inforssXMLRepository.setScrollingArea(width);
             }
           }
         }
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2197,15 +2215,15 @@ function inforssRunnable(obj, func)
   {
     try
     {
-//alert("coucou "  + "\n");
+      //alert("coucou "  + "\n");
       var obj = this.obj;
       var func = this.func;
-//      eval("obj." + this.func + "()");
-//	netscape.security.PrivilegeManager.enablePrivilege("UniversalFileRead CapabilityPreferencesAccess UniversalPreferencesWrite UniversalPreferencesRead UniversalXPConnect UniversalBrowserRead UniversalBrowserWrite");
-//	var consoleService = Components.classes["@mozilla.org/consoleservice;1"].getService(Components.interfaces.nsIConsoleService);
-//	consoleService.logStringMessage("coucou\n");
-	}
-    catch(e)
+      //      eval("obj." + this.func + "()");
+      //	netscape.security.PrivilegeManager.enablePrivilege("UniversalFileRead CapabilityPreferencesAccess UniversalPreferencesWrite UniversalPreferencesRead UniversalXPConnect UniversalBrowserRead UniversalBrowserWrite");
+      //	var consoleService = Components.classes["@mozilla.org/consoleservice;1"].getService(Components.interfaces.nsIConsoleService);
+      //	consoleService.logStringMessage("coucou\n");
+    }
+    catch (e)
     {
       dump(e);
     }
@@ -2214,25 +2232,25 @@ function inforssRunnable(obj, func)
 //-----------------------------------------------------------------------------------------------------
 function inforssSetTimer(obj, func, timer)
 {
-//inforssInspect(navigator, null, false);
-//dump("setTimer: " + gInforssTimerList.length + " " + gInforssTimerCounter + "\n");
-//for (var i = 0; i < gInforssTimerList.length; i++)
-//{
-//  dump("    " + gInforssTimerList[i].date + " " + gInforssTimerList[i].timerId + " " + gInforssTimerList[i].func + "\n");
-//}
+  //inforssInspect(navigator, null, false);
+  //dump("setTimer: " + gInforssTimerList.length + " " + gInforssTimerCounter + "\n");
+  //for (var i = 0; i < gInforssTimerList.length; i++)
+  //{
+  //  dump("    " + gInforssTimerList[i].date + " " + gInforssTimerList[i].timerId + " " + gInforssTimerList[i].func + "\n");
+  //}
   try
   {
-//    var timerObject = { obj : obj, func : func, timerId : inforssGetNewTimerId() , handle : null, date : new Date()};
-//    gInforssTimerList.push(timerObject);
-//    timerObject.handle = window.setTimeout("inforssHandleTimer(" + timerObject.timerId + ",'" + func + "')", timer);
-//dump("fin setTimer " + timerObject.timerId + "\n");
+    //    var timerObject = { obj : obj, func : func, timerId : inforssGetNewTimerId() , handle : null, date : new Date()};
+    //    gInforssTimerList.push(timerObject);
+    //    timerObject.handle = window.setTimeout("inforssHandleTimer(" + timerObject.timerId + ",'" + func + "')", timer);
+    //dump("fin setTimer " + timerObject.timerId + "\n");
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
-//  return timerObject.handle;
-    return window.setTimeout(inforssHandleTimer, timer, obj, func);
+  //  return timerObject.handle;
+  return window.setTimeout(inforssHandleTimer, timer, obj, func);
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -2266,103 +2284,104 @@ function inforssGetNewTimerId()
 //-----------------------------------------------------------------------------------------------------
 function inforssHandleTimer(obj, func)
 {
-//  const thread1 = Components.classes["@mozilla.org/thread;1"].getService(Components.interfaces.nsIThread);
-//dump("debut handleTimer: " + timerId + "\n");
+  //  const thread1 = Components.classes["@mozilla.org/thread;1"].getService(Components.interfaces.nsIThread);
+  //dump("debut handleTimer: " + timerId + "\n");
   try
   {
-/*    var find = false;
-    var i = 0;
-    while ((i < gInforssTimerList.length) && (find == false))
-    {
-//dump("avant premier\n");
-      if (gInforssTimerList[i].timerId == timerId)
-      {
-        find = true;
-      }
-      else
-      {
-        i++;
-      }
-    }
-    if (find == true)
-    {
-//dump("avant deuxieme " + i + " " + gInforssTimerList.length + " " + gInforssTimerList[i] + "\n");
-      var func = gInforssTimerList[i].func;
-      var obj = gInforssTimerList[i].obj;
-//dump("apres deuxieme " + i + " " + gInforssTimerList.length + " " + gInforssTimerList[i] + "\n");
-      gInforssTimerList[i].obj = null;
-      gInforssTimerList[i].func = null;
-      delete gInforssTimerList[i];
-      gInforssTimerList.splice(i,1);
-//if (func != func1)
-//{
-//alert("pas bonne fonction" + func + " " + func1);
-//}
+    /*    var find = false;
+        var i = 0;
+        while ((i < gInforssTimerList.length) && (find == false))
+        {
+    //dump("avant premier\n");
+          if (gInforssTimerList[i].timerId == timerId)
+          {
+            find = true;
+          }
+          else
+          {
+            i++;
+          }
+        }
+        if (find == true)
+        {
+    //dump("avant deuxieme " + i + " " + gInforssTimerList.length + " " + gInforssTimerList[i] + "\n");
+          var func = gInforssTimerList[i].func;
+          var obj = gInforssTimerList[i].obj;
+    //dump("apres deuxieme " + i + " " + gInforssTimerList.length + " " + gInforssTimerList[i] + "\n");
+          gInforssTimerList[i].obj = null;
+          gInforssTimerList[i].func = null;
+          delete gInforssTimerList[i];
+          gInforssTimerList.splice(i,1);
+    //if (func != func1)
+    //{
+    //alert("pas bonne fonction" + func + " " + func1);
+    //}
 
-// lancement du process
-//       thread.init(thread, 0,
-//     thread1.init(new inforssRunnable(obj, func), 0,
-//                 Components.interfaces.nsIThread.PRIORITY_NORMAL,
-//                  Components.interfaces.nsIThread.SCOPE_GLOBAL,
-//                  Components.interfaces.nsIThread.STATE_JOINABLE);
-//      thread1.join();
-*/      eval("obj." + func + "()");
-//    }
-//    else
-//    {
-//      dump("pas trouve func=" + func1 + "\n");
-//    }
+    // lancement du process
+    //       thread.init(thread, 0,
+    //     thread1.init(new inforssRunnable(obj, func), 0,
+    //                 Components.interfaces.nsIThread.PRIORITY_NORMAL,
+    //                  Components.interfaces.nsIThread.SCOPE_GLOBAL,
+    //                  Components.interfaces.nsIThread.STATE_JOINABLE);
+    //      thread1.join();
+    */
+    eval("obj." + func + "()");
+    //    }
+    //    else
+    //    {
+    //      dump("pas trouve func=" + func1 + "\n");
+    //    }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
-//dump("fin handleTimer\n");
+  //dump("fin handleTimer\n");
 }
 
 
 //-----------------------------------------------------------------------------------------------------
 function inforssClearTimer(handle)
 {
-//dump("debut handleTimer: " + timerId + "\n");
-/*  try
-  {
-    var find = false;
-    var i = 0;
-    while ((i < gInforssTimerList.length) && (find == false))
+  //dump("debut handleTimer: " + timerId + "\n");
+  /*  try
     {
-      if (gInforssTimerList[i].handle == handle)
+      var find = false;
+      var i = 0;
+      while ((i < gInforssTimerList.length) && (find == false))
       {
-        find = true;
+        if (gInforssTimerList[i].handle == handle)
+        {
+          find = true;
+        }
+        else
+        {
+          i++;
+        }
       }
-      else
+      if (find == true)
       {
-        i++;
+  	  gInforssTimerList[i].obj = null;
+  	  delete gInforssTimerList[i];
+        gInforssTimerList.splice(i,1);
       }
     }
-    if (find == true)
+    catch(e)
     {
-	  gInforssTimerList[i].obj = null;
-	  delete gInforssTimerList[i];
-      gInforssTimerList.splice(i,1);
-    }
-  }
-  catch(e)
-  {
-    inforssDebug(e);
-  }*/
-//dump("fin handleTimer\n");
+      inforssDebug(e);
+    }*/
+  //dump("fin handleTimer\n");
 }
 
 //-----------------------------------------------------------------------------------------------------
 function inforssAddNewFeed(menuItem)
 {
-//alert("inforssAddNewFeed\n");
+  //alert("inforssAddNewFeed\n");
   try
   {
     var url = menuItem.inforssUrl;
-//alert(url);
-    if (inforssGetItemFromUrl(url) != null)  // already exists
+    //alert(url);
+    if (inforssGetItemFromUrl(url) != null) // already exists
     {
       alert(gInforssRssBundle.getString("inforss.duplicate"));
     }
@@ -2370,22 +2389,22 @@ function inforssAddNewFeed(menuItem)
     {
       if (gInforssXMLHttpRequest == null)
       {
-//alert("go");
-        getInfoFromUrl(url);   // search for the general information of the feed: title, ...
+        //alert("go");
+        getInfoFromUrl(url); // search for the general information of the feed: title, ...
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
-//dump("fin inforssAddNewFeed\n");
+  //dump("fin inforssAddNewFeed\n");
 }
 
 //-----------------------------------------------------------------------------------------------------
 function onAddNewFeedPopup()
 {
-//dump("onAddNewFeedPopup\n");
+  //dump("onAddNewFeedPopup\n");
   try
   {
     var selectedText = inforssGetMenuSelectedText();
@@ -2394,7 +2413,7 @@ function onAddNewFeedPopup()
       var index = selectedText.indexOf(" ");
       if (index != -1)
       {
-        selectedText = selectedText.substring(0,index);
+        selectedText = selectedText.substring(0, index);
       }
     }
     var menuItem = document.getElementById("inforss.popup.addfeed");
@@ -2402,76 +2421,76 @@ function onAddNewFeedPopup()
     {
       if ((selectedText.indexOf("http://") != -1) || (selectedText.indexOf("https://") != -1))
       {
-        menuItem.setAttribute("collapsed","false");
+        menuItem.setAttribute("collapsed", "false");
         menuItem.inforssUrl = selectedText;
       }
       else
       {
-        menuItem.setAttribute("collapsed","true");
+        menuItem.setAttribute("collapsed", "true");
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
-//dump("fin onAddNewFeedPopup\n");
+  //dump("fin onAddNewFeedPopup\n");
 }
 
 //-----------------------------------------------------------------------------------------------------
 function inforssGetMenuSelectedText(concationationChar)
 {
-//dump("dictionarySearchGetSelectedText()");
+  //dump("dictionarySearchGetSelectedText()");
 
-    var node = document.popupNode;
-    var selection = "";
-    var nodeLocalName = "";
-    if ((node != null) && (node.localName != null))
+  var node = document.popupNode;
+  var selection = "";
+  var nodeLocalName = "";
+  if ((node != null) && (node.localName != null))
+  {
+    nodeLocalName = node.localName.toUpperCase();
+    if ((nodeLocalName == "TEXTAREA") || (nodeLocalName == "INPUT" && node.type == "text"))
     {
-      nodeLocalName = node.localName.toUpperCase();
-      if ((nodeLocalName == "TEXTAREA") || (nodeLocalName == "INPUT" && node.type == "text"))
-      {
-        selection = node.value.substring(node.selectionStart, node.selectionEnd);
-      }
-      else
-      {
-        if (nodeLocalName == "A")
-        {
-          selection = node.href;
-        }
-        else
-        {
-          if (nodeLocalName == "IMG")
-          {
-            if ((node.parentNode != null) && (node.parentNode.nodeName == "A"))
-            {
-              selection = node.parentNode.href;
-            }
-          }
-          else
-          {
-            var focusedWindow = new XPCNativeWrapper(document.commandDispatcher.focusedWindow, 'document', 'getSelection()');
-            selection = focusedWindow.getSelection().toString();
-          }
-        }
-      }
+      selection = node.value.substring(node.selectionStart, node.selectionEnd);
     }
     else
     {
-            var focusedWindow = new XPCNativeWrapper(document.commandDispatcher.focusedWindow, 'document', 'getSelection()');
-            selection = focusedWindow.getSelection().toString();
+      if (nodeLocalName == "A")
+      {
+        selection = node.href;
+      }
+      else
+      {
+        if (nodeLocalName == "IMG")
+        {
+          if ((node.parentNode != null) && (node.parentNode.nodeName == "A"))
+          {
+            selection = node.parentNode.href;
+          }
+        }
+        else
+        {
+          var focusedWindow = new XPCNativeWrapper(document.commandDispatcher.focusedWindow, 'document', 'getSelection()');
+          selection = focusedWindow.getSelection().toString();
+        }
+      }
     }
+  }
+  else
+  {
+    var focusedWindow = new XPCNativeWrapper(document.commandDispatcher.focusedWindow, 'document', 'getSelection()');
+    selection = focusedWindow.getSelection().toString();
+  }
 
-    // Limit length to 150 to optimize performance. Longer does not make sense
-    if (selection.length >= 150)
-    {
-      selection = selection.substring(0, 149);
-    }
-    selection = selection.replace(/(\n|\r|\t)+/g, " ");
-    // Strip spaces at start and end.
-    selection = selection.replace(/(^\s+)|(\s+$)/g, "");
+  // Limit length to 150 to optimize performance. Longer does not make sense
+  if (selection.length >= 150)
+  {
+    selection = selection.substring(0, 149);
+  }
+  selection = selection.replace(/(\n|\r|\t)+/g, " ");
+  // Strip spaces at start and end.
+  selection = selection.replace(/(^\s+)|(\s+$)/g, "");
 
-    return selection;
+  return selection;
 }
 
 
@@ -2480,10 +2499,10 @@ function inforssMouseScroll(event)
 {
   try
   {
-//dump("inforssMouseScroll event.detail=" + event.detail + "\n");
+    //dump("inforssMouseScroll event.detail=" + event.detail + "\n");
     gInforssMediator.handleMouseScroll(event.detail);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2497,7 +2516,7 @@ function inforssCheckVersion()
     var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("inforss.");
     if (prefs.prefHasUserValue("installed.version") == true)
     {
-      var version = prefs.getCharPref("installed.version").replace(/0.9./,"0.09.").replace(/0.8./,"0.08.");
+      var version = prefs.getCharPref("installed.version").replace(/0.9./, "0.09.").replace(/0.8./, "0.08.");
       if (version < INFORSS_VERSION_NUMBER)
       {
         display = true;
@@ -2509,16 +2528,12 @@ function inforssCheckVersion()
     }
     if (display == true)
     {
-//      window.openDialog("chrome://inforss/content/inforssWelcome.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", "Welcome");
+      //      window.openDialog("chrome://inforss/content/inforssWelcome.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", "Welcome");
       prefs.setCharPref("installed.version", INFORSS_VERSION_NUMBER);
     }
   }
-  catch(e)
+  catch (e)
   {
-//    inforssDebug(e);
+    //    inforssDebug(e);
   }
 }
-
-
-
-

--- a/content/inforss/inforss.js
+++ b/content/inforss/inforss.js
@@ -451,7 +451,6 @@ function inforssGetRss(url, callback, user, password)
 //      gInforssXMLHttpRequest.setRequestHeader('Accept','application/rss+xml')
 //      gInforssXMLHttpRequest.setRequestHeader('Cache-Control','no-cache')
 //      gInforssXMLHttpRequest.setRequestHeader("Content-Length","0");
-	  gInforssXMLHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
 	  gInforssXMLHttpRequest.overrideMimeType("application/xml");
 	  gInforssXMLHttpRequest.send(null);
 //alert("send");
@@ -1526,7 +1525,6 @@ function inforssSubMenu1(index)
     inforssResetPopup(popup);
     var xmlHttpRequest = new XMLHttpRequest();
     xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-	xmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
 	xmlHttpRequest.overrideMimeType("application/xml");
 	xmlHttpRequest.send(null);
 

--- a/content/inforss/inforssDebug.js
+++ b/content/inforss/inforssDebug.js
@@ -135,7 +135,7 @@ function inforssDebug(except, obj)
     {
       var time = new Date();
       var time_string = time.getHours() + ":" + time.getMinutes() + ":" + time.getSeconds();
-      console.log("[infoRSS " + time_string + "]: " + meth + "/" + except + "\n");
+      console.log("[infoRSS " + time_string + "]: exception in " + meth, except);
     }
 
     if (repository.firstChild.getAttribute("statusbar") == "true")

--- a/content/inforss/inforssDebug.js
+++ b/content/inforss/inforssDebug.js
@@ -52,7 +52,7 @@ function inforssInspect(obj, filter, functionFlag)
   }
 
   var temp = "";
-  for (x in obj)
+  for (var x in obj)
   {
     if ((filter == null) || (x.indexOf(filter) == 0))
     {

--- a/content/inforss/inforssDebug.js
+++ b/content/inforss/inforssDebug.js
@@ -162,7 +162,8 @@ function inforssTraceIn(obj)
     }
     if (gInforssTrace == true)
     {
-      dump(">>> " + "                ".substring(0, gInforssDebugLevel) + inforssFunctionName(inforssTraceIn.caller, obj) + "(");
+      var caller = (new Error()).stack.split("\n")[1];
+      dump("inforss: >>> " + "                ".substring(0, gInforssDebugLevel) + " " + caller + " " + inforssFunctionName(inforssTraceIn.caller, obj) + "(");
       for (var i = 0; i < inforssTraceIn.caller.arguments.length; i++)
       {
         if (i != 0)
@@ -192,7 +193,8 @@ function inforssTraceOut(obj)
     }
     if (gInforssTrace == true)
     {
-      dump("<<< " + "                ".substring(0, gInforssDebugLevel) + inforssFunctionName(inforssTraceOut.caller, obj) + "\n");
+      var caller = (new Error()).stack.split("\n")[1];
+      dump("inforss: <<< " + "                ".substring(0, gInforssDebugLevel) + " " + caller + " " + inforssFunctionName(inforssTraceOut.caller, obj) + "\n");
     }
   }
   catch (e)

--- a/content/inforss/inforssDebug.js
+++ b/content/inforss/inforssDebug.js
@@ -43,45 +43,46 @@ var gInforssPrefs = null;
 var gInforssTrace = null;
 var gInforssDebugLevel = 0;
 //-----------------------------------------------------------------------------------------------------
-function inforssInspect( obj, filter, functionFlag )
+function inforssInspect(obj, filter, functionFlag)
 {
-  if ( ! obj )
+  if (!obj)
   {
-    ret = prompt ("Enter object", "document");
+    ret = prompt("Enter object", "document");
     obj = eval(ret);
   }
 
   var temp = "";
   for (x in obj)
   {
-    if (( filter == null) || (x.indexOf(filter) == 0))
+    if ((filter == null) || (x.indexOf(filter) == 0))
     {
       if ((functionFlag == null) || (functionFlag == true) || ((functionFlag == false) && (typeof(obj[x]) != "function")))
       {
         temp += x + ": " + obj[x] + "\n";
-        if ( temp.length > 500 )
+        if (temp.length > 500)
         {
-          alert(temp);temp='';
+          alert(temp);
+          temp = '';
         }
       }
     }
   }
-  alert (temp);
+  alert(temp);
 }
 
 //-----------------------------------------------------------------------------------------------------
-function inforssInspectDump( obj, filter, functionFlag )
+function inforssInspectDump(obj, filter, functionFlag)
 {
-  if ( ! obj )
+  if (!obj)
   {
-    ret = prompt ("Enter object", "document");
+    ret = prompt("Enter object", "document");
     obj = eval(ret);
   }
 
   var temp = "";
   for (x in obj)
   {
-    if (( filter == null) || (x.indexOf(filter) == 0))
+    if ((filter == null) || (x.indexOf(filter) == 0))
     {
       if ((functionFlag == null) || (functionFlag == true) || ((functionFlag == false) && (typeof(obj[x]) != "function")))
       {
@@ -107,7 +108,7 @@ function inforssBigAlert(str)
   {
     if (str.length > 500)
     {
-      alert(str.substring(0,500));
+      alert(str.substring(0, 500));
       str = str.substring(500);
     }
     else
@@ -123,12 +124,8 @@ function inforssDebug(except, obj)
 {
   try
   {
-  // browser.dom.window.dump.enabled
-    var meth = inforssFunctionName(inforssDebug.caller, obj);
-    prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("browser.");
-    prefs.setBoolPref("dom.window.dump.enabled",true);
-
     var repository = inforssGetRepositoryAsDom();
+    var meth = inforssFunctionName(inforssDebug.caller, obj);
     if (repository.firstChild.getAttribute("debug") == "true")
     {
       alert(meth + " : " + except);
@@ -138,8 +135,7 @@ function inforssDebug(except, obj)
     {
       var time = new Date();
       var time_string = time.getHours() + ":" + time.getMinutes() + ":" + time.getSeconds();
-
-      window.dump("[infoRSS " + time_string + "]: " + meth + "/" + except + "\n");
+      console.log("[infoRSS " + time_string + "]: " + meth + "/" + except + "\n");
     }
 
     if (repository.firstChild.getAttribute("statusbar") == "true")
@@ -147,9 +143,9 @@ function inforssDebug(except, obj)
       inforssAlert(meth + " : " + except);
     }
   }
-  catch(e)
+  catch (e)
   {
-    dump("Debug: " + e);
+    console.log("InfoRSS Debug generated exception", e, "for", except, obj);
   }
 }
 
@@ -162,7 +158,7 @@ function inforssTraceIn(obj)
     if (gInforssPrefs == null)
     {
       gInforssPrefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch(null);
-      gInforssTrace = (gInforssPrefs.prefHasUserValue("inforss.traceinconsole") == false)? false : gInforssPrefs.getBoolPref("inforss.traceinconsole");
+      gInforssTrace = (gInforssPrefs.prefHasUserValue("inforss.traceinconsole") == false) ? false : gInforssPrefs.getBoolPref("inforss.traceinconsole");
     }
     if (gInforssTrace == true)
     {
@@ -178,7 +174,7 @@ function inforssTraceIn(obj)
       dump(")\n");
     }
   }
-  catch(e)
+  catch (e)
   {
     dump("inforssTraceIn: " + e + "\n");
   }
@@ -192,14 +188,14 @@ function inforssTraceOut(obj)
     if (gInforssPrefs == null)
     {
       gInforssPrefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch(null);
-      gInforssTrace = (gInforssPrefs.prefHasUserValue("inforss.traceinconsole") == false)? false : gInforssPrefs.getBoolPref("inforss.traceinconsole");
+      gInforssTrace = (gInforssPrefs.prefHasUserValue("inforss.traceinconsole") == false) ? false : gInforssPrefs.getBoolPref("inforss.traceinconsole");
     }
     if (gInforssTrace == true)
     {
-      dump("<<< " + "                ".substring(0,gInforssDebugLevel) + inforssFunctionName(inforssTraceOut.caller, obj) + "\n");
+      dump("<<< " + "                ".substring(0, gInforssDebugLevel) + inforssFunctionName(inforssTraceOut.caller, obj) + "\n");
     }
   }
-  catch(e)
+  catch (e)
   {
     dump("inforssTraceOut: " + e + "\n");
   }
@@ -213,7 +209,7 @@ function inforssFunctionName(f, obj)
   try
   {
     s = f.toString().match(/function (\w*)/)[1];
-    if ((s == null) || (s.length==0))
+    if ((s == null) || (s.length == 0))
     {
       if (obj != null)
       {
@@ -225,13 +221,13 @@ function inforssFunctionName(f, obj)
           }
         }
       }
-      if ((s == null) || (s.length==0))
+      if ((s == null) || (s.length == 0))
       {
         s = "annonymous";
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     dump("funcname: " + e);
   }
@@ -242,10 +238,10 @@ function inforssFunctionName(f, obj)
 function inforssStackTrace()
 {
   var s = "";
-//alert(inforssFunctionName(stacktrace.caller.caller));
-  for (var a = arguments.caller; a !=null; a = a.caller)
+  //alert(inforssFunctionName(stacktrace.caller.caller));
+  for (var a = arguments.caller; a != null; a = a.caller)
   {
-    s += "->"+inforssFunctionName(a.callee) + "\n";
+    s += "->" + inforssFunctionName(a.callee) + "\n";
     if (a.caller == a)
     {
       s += "*";

--- a/content/inforss/inforssFeed.js
+++ b/content/inforss/inforssFeed.js
@@ -329,7 +329,6 @@ function inforssFeed(feedXML, manager, menuItem)
 //      xmlHttpRequest.setRequestHeader('Accept','application/rss+xml')
 //      xmlHttpRequest.setRequestHeader('Cache-Control','no-cache')
 //      xmlHttpRequest.setRequestHeader("Content-Length","0");
-            this.xmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
 //            this.xmlHttpRequest.setRequestHeader("If-Modified-Since", "Wed, 2 Aug 2006 23:30:00 GMT");
             if (this.getType() != "html")
             {

--- a/content/inforss/inforssIO.js
+++ b/content/inforss/inforssIO.js
@@ -1140,7 +1140,6 @@ function inforssFindIcon(rss)
      {
        url = inforssGetFavicon(rss.getAttribute("link"));
        xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-	   xmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
 //	   xmlHttpRequest.overrideMimeType("image/ico");
 	   xmlHttpRequest.send("");
 	 }
@@ -1154,7 +1153,6 @@ function inforssFindIcon(rss)
        {
          url = url.substring(0, url.length - "/favicon.ico".length);
          xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-	     xmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
 	     xmlHttpRequest.overrideMimeType("application/xml");
 	     xmlHttpRequest.send("");
          var root = url;
@@ -1194,7 +1192,6 @@ function inforssFindIcon(rss)
        if (url == null)
        {
          xmlHttpRequest.open("GET", rss.getAttribute("url"), false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-	     xmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
 	     xmlHttpRequest.overrideMimeType("application/xml");
 	     xmlHttpRequest.send(null);
          if ((xmlHttpRequest.status == 200) || (xmlHttpRequest.status == 201) ||(xmlHttpRequest.status == 202))

--- a/content/inforss/inforssIO.js
+++ b/content/inforss/inforssIO.js
@@ -145,7 +145,6 @@ function inforssGetOutputStream()
   file.append(INFORSS_REPOSITORY);
   if ( file.exists() == false )
   {
-    // alert( "Creating file... " );
     file.create( Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420 );
   }
   var outputStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance( Components.interfaces.nsIFileOutputStream );
@@ -194,7 +193,6 @@ function inforssGetOutputStream()
 //-------------------------------------------------------------------------------------------------------------
 function inforssRead(withMenu, relocateFlag)
 {
-//dump("DEBUG: read\n");
   try
   {
     RSSList = inforssGetRepositoryAsDom();
@@ -220,13 +218,11 @@ function inforssRead(withMenu, relocateFlag)
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
-//dump("DEBUG: end read\n");
 }
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssGetRepositoryAsDom(source)
 {
-//dump("DEBUG: getRepositoryAsDom\n");
   var repository = null;
   try
   {
@@ -240,14 +236,12 @@ function inforssGetRepositoryAsDom(source)
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
-//dump("DEBUG: end getRepositoryAsDom\n");
   return repository;
 }
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssGetRepositoryAsString(source)
 {
-//dump("DEBUG: getRepositoryAsDom\n");
   var outputStr = null;
   try
   {
@@ -255,7 +249,6 @@ function inforssGetRepositoryAsString(source)
 
     if ((file != null) && (file.exists() == true ))
     {
-//dump("DEBUG: getRepositoryAsDom read\n");
       var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance( Components.interfaces.nsIFileInputStream );
       is.init(file, 0x01, 00004, null);
       var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance( Components.interfaces.nsIScriptableInputStream );
@@ -263,31 +256,25 @@ function inforssGetRepositoryAsString(source)
       var output = sis.read(-1);
       is.close();
       sis.close();
-//dump("DEBUG: getRepositoryAsDom output.length=" + output.length + "\n");
       if (output.length > 0)
       {
         var uConv = Components.classes['@mozilla.org/intl/utf8converterservice;1'].createInstance(Components.interfaces.nsIUTF8ConverterService);
         outputStr = uConv.convertStringToUTF8(output, "UTF-8", false);
       }
-//dump("DEBUG: getRepositoryAsDom ok\n");
     }
   }
   catch(e)
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
-//dump("DEBUG: end getRepositoryAsDom\n");
   return outputStr;
 }
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssRestoreRepository()
 {
-//dump("DEBUG: restoreRepository\n");
   try
   {
-//dump("DEBUG: restoreRepository 1\n");
-//    netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
     var file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
     file.append(INFORSS_REPOSITORY);
     if ( file.exists() == true)
@@ -309,29 +296,24 @@ function inforssRestoreRepository()
     var source = file.clone();
     source.append("extensions");
     source.append("{" + INFORSS_GUID + "}");
-//    source.append(INFORSS_INSTALL_DIR);
     source.append(INFORSS_DEFAULT_REPOSITORY);
     if (source.exists() == true)
     {
       source.copyTo(file, INFORSS_REPOSITORY);
     }
-//dump("DEBUG: restoreRepository 2\n");
   }
   catch (e)
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
-//dump("DEBUG: end restoreRepository\n");
 }
 
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssRemoveRDFRepository()
 {
-//dump("DEBUG: inforssRemoveRDFRepository\n");
   try
   {
-//dump("DEBUG: restoreRepository 1\n");
     inforssRDFRepository
 
   }
@@ -339,13 +321,11 @@ function inforssRemoveRDFRepository()
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
-//dump("DEBUG: end inforssRemoveRDFRepository\n");
 }
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssAdjustRepository()
 {
-//dump("DEBUG: adjustRepository\n");
   try
   {
     var items = RSSList.getElementsByTagName("RSS");
@@ -1026,48 +1006,22 @@ function inforssAdjustRepository()
   {
     inforssDebug(e);
   }
-//dump("DEBUG: end adjustRepository\n");
 }
-
-//var dirName = "file://c:/example/";
-//try
-//{
-//var obj_URI = Components.classes["@mozilla.org/network/standard-url;1"].createInstance(Components.interfaces.nsIURL);
-//obj_URI.spec = dirName;
-//var f = Components.classes['@mozilla.org/file/local;1'].createInstance(Components.interfaces.nsILocalFile);
-//f.initWithPath(obj_URI.filePath.replace(/^\//,"").replace(/\//g,"\\"));
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssGetFile(version, source)
 {
-//dump("DEBUG getFile\n");
-  try
-  {
-//    netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
-  }
-  catch (e)
-  {
-    alert(document.getElementById("bundle_inforss").getString("inforss.permissionDenied"));
-  }
   var file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
   file.append(INFORSS_REPOSITORY);
-//dump("DEBUG permission=" + file.permissions  + "\n");
-//dump("DEBUG fileSize=" + file.fileSize  + "\n");
-//dump("DEBUG exists=" + file.exists()  + "\n");
-//dump("DEBUG isWritable  =" + file.isWritable()    + "\n");
-//dump("DEBUG isReadable  =" + file.isReadable()    + "\n");
-//dump("DEBUG isFile  =" + file.isFile()    + "\n");
 
   if ( file.exists() == false )
   {
-//dump("DEBUG getFile file does not exist\n");
     inforssRestoreRepository();
     file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
     file.append(INFORSS_REPOSITORY);
   }
   if ( file.exists() == true )
   {
-//dump("DEBUG getFile now file exists\n");
     var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance( Components.interfaces.nsIFileInputStream );
     is.init(file, 0x01, 00004, null);
     var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance( Components.interfaces.nsIScriptableInputStream );
@@ -1075,13 +1029,11 @@ function inforssGetFile(version, source)
     var output = sis.read(-1);
     sis.close();
     is.close();
-//dump("DEBUG getFile output.length=" + output.length + "\n");
     if (output.length > 0)
     {
       var repository = new DOMParser().parseFromString(output, "text/xml");
       if (repository.firstChild.getAttribute("version") < version)
       {
-//dump("getFile error in file\n");
         alert(document.getElementById("bundle_inforss").getString("inforss.wrongVersionXmlFile"));
         inforssRestoreRepository();
         file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
@@ -1096,38 +1048,9 @@ function inforssGetFile(version, source)
       file.append(INFORSS_REPOSITORY);
     }
   }
-//dump("DEBUG end getFile\n");
   return file;
 }
 
-/*
-            try
-            {
-                    netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
-            } catch (e)
-            {
-                    alert("Permission to save file was denied.");
-            }
-            var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
-
-            file.initWithPath( "c:\\didier.rss" );
-            if ( file.exists() == false ) {
-                   // alert( "Creating file... " );
-                    file.create( Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420 );
-            }
-            var outputStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance( Components.interfaces.nsIFileOutputStream );
-            try
-            {
-              outputStream.init( file, 0x04 | 0x08 | 0x20, 420, 0 );
-              outputStream.write( gXMLHttpRequest.responseText, gXMLHttpRequest.responseText.length );
-              outputStream.close();
-            }
-            catch(e)
-            {
-              alert(e);
-            }
-
-*/
 //-------------------------------------------------------------------------------------------------------------
 function inforssFindIcon(rss)
 {
@@ -1285,7 +1208,6 @@ function inforssGetFormat(objDoc)
     {
       var i=0;
       var nodeName = null;
-// alert("length=" + objDoc.childNodes.length);
       while ((i < objDoc.childNodes.length) && (format == null))
       {
         nodeName = objDoc.childNodes[i].nodeName.toLowerCase();
@@ -1294,7 +1216,6 @@ function inforssGetFormat(objDoc)
         {
           nodeName = nodeName.substring(index+1);
         }
-// alert("nodeName=" + nodeName);
         if ((nodeName == "feed") || (nodeName == "rdf") || (nodeName == "rss") || (nodeName == "opml"))
         {
           format = nodeName;
@@ -1311,14 +1232,12 @@ function inforssGetFormat(objDoc)
     inforssDebug(e);
   }
   inforssTraceOut();
-//alert(format);
   return format;
 }
 
 //-------------------------------------------------------------------------------------------------------------
 function inforssCopyRemoteToLocal(protocol, server, directory, user, password, ftpDownloadCallback)
 {
-//dump("inforssCopyRemoteToLocal\n");
   if (directory.match(/^\/.*/) == null)
   {
     directory = "/" + directory;
@@ -1327,20 +1246,15 @@ function inforssCopyRemoteToLocal(protocol, server, directory, user, password, f
   {
     directory = directory + "/";
   }
-//dump("inforssCopyRemoteToLocal 1\n");
   var ioService  = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
   var path = protocol + user + ":" + password + "@" + server + directory;
   var uri = ioService.newURI(path + "inforss.xml","UTF-8", null);
-//dump("inforssCopyRemoteToLocal\n");
   gInforssFTPDownload = new inforssFTPDownload();
-//dump("avant\n");
 
   if (typeof setImportProgressionBar != "undefined")
   {
     setImportProgressionBar(20);
-//dump("apres\n");
   }
-//dump("apres 1\n");
   gInforssFTPDownload.start(uri, path, inforssCopyRemoteToLocalCallback, ftpDownloadCallback);
 }
 
@@ -1486,7 +1400,6 @@ function inforssCopyLocalToRemoteCallback(step, status, path, callbackOriginal, 
 {
   inforssTraceIn();
   var returnValue = true;
-//dump("inforssCopyLocalToRemoteCallback " + step + " " + status + "\n");
   try
   {
     if (step == "send")
@@ -1538,7 +1451,6 @@ function inforssCopyLocalToRemote1Callback(step, status, path, callbackOriginal,
 {
   inforssTraceIn();
   var returnValue = true;
-//dump("inforssCopyLocalToRemote1Callback " + step + " " + status + "\n");
   try
   {
     if (step != "send")
@@ -1555,7 +1467,6 @@ function inforssCopyLocalToRemote1Callback(step, status, path, callbackOriginal,
         }
         else
         {
-//dump("notifier\n");
           var notifier = new inforssNotifier();
           notifier.notify("chrome://global/skin/icons/alert-exclam.png",
                           document.getElementById("bundle_inforss").getString("inforss.synchronization"),
@@ -1633,34 +1544,22 @@ var inforssFTPUpload =
 
   cancel : function()
   {
-//dump("cancel\n");
-/*    if(this._channel != null)
-    {
-      this._channel.cancel(0x804b0002);
-    }
-    delete this._channel;
-    this._channel = null;
-*/  },
+  },
 
   onDataAvailable : function (channel, ctxt, input, sourceOffset, count)
   {
-//dump("onDataAvailable\n");
     const sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
     sis.init(input);
     this._errorData += sis.read(count);
     this._inputStream.close();
-
-//    alert(this._errorData);
   },
 
   onStartRequest: function (channel, ctxt)
   {
-//dump("onStartRequest\n");
   },
 
   onStopRequest: function (channel, ctxt, status)
   {
-//dump("onStopRequest " + status + "\n");
     try
     {
       if(this._scheme != "ftp")
@@ -1692,17 +1591,12 @@ var inforssFTPUpload =
           inforssDebug(this._errorData);
         }
       }
-//    delete this._channel;
       delete channel;
       this._inputStream.close();
-//    this._channel = null;
       this._data = null;
-//dump("onStopRequest1 " + status + "\n");
       if (this._callback != null)
       {
-//alert("onStopRequest2 " + status + " " + "\n");
         this._callback("done", status, this._path, this._callbackOriginal, this._asyncFlag);
-//dump("onStopRequest3 " + status + "\n");
       }
     }
     catch(e)
@@ -1744,15 +1638,6 @@ inforssFTPDownload.prototype =
       var ioService  = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
       this.streamLoader = Components.classes["@mozilla.org/network/stream-loader;1"].createInstance(Components.interfaces.nsIStreamLoader);
       this._channel = ioService.newChannelFromURI(url);
-//dump("url=" + url.spec + "\n");
-//dump("path=" + path + "\n");
-//dump("channel=" + this._channel + "\n");
-//dump("callback=" + this._callback + "\n");
-
-//      if (url.scheme == "http" || url.scheme == "https")
-//      {
-//        this._channel.loadFlags |= Components.interfaces.nsIRequest.LOAD_BYPASS_CACHE;
-//      }
       if (isOnBranch) 
       { 
         this.streamLoader.init(this._channel, this , null);
@@ -1762,16 +1647,12 @@ inforssFTPDownload.prototype =
         this.streamLoader.init(this); 
         this._channel.asyncOpen(this.streamLoader, this._channel); 
       }
-//      this.streamLoader.init(this._channel, this , null);
       this._startTime = new Date().getTime();
       this._callback("send", null, path, callbackOriginal);
-//dump("inforssFTPDownload start 1\n");
       if (typeof setImportProgressionBar != "undefined")
       {
-//dump("inforssFTPDownload start 2\n");
         setImportProgressionBar(30);
       }
-//dump("inforssFTPDownload start 3\n");
     }
     catch(e)
     {

--- a/content/inforss/inforssIO.js
+++ b/content/inforss/inforssIO.js
@@ -58,12 +58,12 @@ function inforssBackup()
   {
     var file = inforssGetFile(INFORSS_VERSION);
 
-    if ((file != null) && (file.exists() == true ))
+    if ((file != null) && (file.exists() == true))
     {
-      var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance( Components.interfaces.nsIFileInputStream );
-      is.init( file,0x01, 00004, null);
-      var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance( Components.interfaces.nsIScriptableInputStream );
-      sis.init( is );
+      var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance(Components.interfaces.nsIFileInputStream);
+      is.init(file, 0x01, 00004, null);
+      var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
+      sis.init(is);
       var output = sis.read(-1);
       is.close();
       sis.close();
@@ -74,14 +74,14 @@ function inforssBackup()
       {
         file.remove(true);
       }
-      file.create( Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420 );
-      var outputStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance( Components.interfaces.nsIFileOutputStream );
+      file.create(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420);
+      var outputStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
       if (!file.isWritable())
       {
         file.permissions = 0644;
       }
-      outputStream.init( file, 0x04 | 0x08 | 0x20, 420, 0 );
-      outputStream.write( output, output.length );
+      outputStream.init(file, 0x04 | 0x08 | 0x20, 420, 0);
+      outputStream.write(output, output.length);
       outputStream.close();
     }
   }
@@ -99,12 +99,12 @@ function inforssSave()
     var outputStream = inforssGetOutputStream();
     if (RSSList != null)
     {
-       new XMLSerializer().serializeToStream(RSSList, outputStream, "UTF-8")
-       //var result = outputStream.write( output, output.length );
+      new XMLSerializer().serializeToStream(RSSList, outputStream, "UTF-8")
+      //var result = outputStream.write( output, output.length );
     }
     outputStream.close();
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -118,11 +118,11 @@ function inforssSaveFromString(str)
     var outputStream = inforssGetOutputStream();
     if (str != null)
     {
-       outputStream.write( str, str.length );
+      outputStream.write(str, str.length);
     }
     outputStream.close();
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -133,7 +133,7 @@ function inforssGetOutputStream()
 {
   try
   {
-//    netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
+    //    netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
   }
   catch (e)
   {
@@ -143,11 +143,11 @@ function inforssGetOutputStream()
   var file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
 
   file.append(INFORSS_REPOSITORY);
-  if ( file.exists() == false )
+  if (file.exists() == false)
   {
-    file.create( Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420 );
+    file.create(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420);
   }
-  var outputStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance( Components.interfaces.nsIFileOutputStream );
+  var outputStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
   /* Open flags
     #define PR_RDONLY       0x01
     #define PR_WRONLY       0x02
@@ -159,21 +159,21 @@ function inforssGetOutputStream()
     #define PR_EXCL         0x80
   */
   /*
-    ** File modes ....
-    **
-    ** CAVEAT: 'mode' is currently only applicable on UNIX platforms.
-    ** The 'mode' argument may be ignored by PR_Open on other platforms.
-    **
-    **   00400   Read by owner.
-    **   00200   Write by owner.
-    **   00100   Execute (search if a directory) by owner.
-    **   00040   Read by group.
-    **   00020   Write by group.
-    **   00010   Execute by group.
-    **   00004   Read by others.
-    **   00002   Write by others
-    **   00001   Execute by others.
-    **
+   ** File modes ....
+   **
+   ** CAVEAT: 'mode' is currently only applicable on UNIX platforms.
+   ** The 'mode' argument may be ignored by PR_Open on other platforms.
+   **
+   **   00400   Read by owner.
+   **   00200   Write by owner.
+   **   00100   Execute (search if a directory) by owner.
+   **   00040   Read by group.
+   **   00020   Write by group.
+   **   00010   Execute by group.
+   **   00004   Read by others.
+   **   00002   Write by others
+   **   00001   Execute by others.
+   **
    */
   try
   {
@@ -181,9 +181,9 @@ function inforssGetOutputStream()
     {
       file.permissions = 0644;
     }
-    outputStream.init( file, 0x04 | 0x08 | 0x20, 420, 0 );
+    outputStream.init(file, 0x04 | 0x08 | 0x20, 420, 0);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -201,7 +201,7 @@ function inforssRead(withMenu, relocateFlag)
       var items = RSSList.getElementsByTagName("RSS");
       inforssAdjustRepository();
       var selected = 0;
-      for (var i=0; i<items.length; i++)
+      for (var i = 0; i < items.length; i++)
       {
         if (withMenu == true)
         {
@@ -214,7 +214,7 @@ function inforssRead(withMenu, relocateFlag)
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
@@ -232,7 +232,7 @@ function inforssGetRepositoryAsDom(source)
       repository = new DOMParser().parseFromString(str, "text/xml");
     }
   }
-  catch(e)
+  catch (e)
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
@@ -247,12 +247,12 @@ function inforssGetRepositoryAsString(source)
   {
     var file = inforssGetFile(INFORSS_VERSION, source);
 
-    if ((file != null) && (file.exists() == true ))
+    if ((file != null) && (file.exists() == true))
     {
-      var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance( Components.interfaces.nsIFileInputStream );
+      var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance(Components.interfaces.nsIFileInputStream);
       is.init(file, 0x01, 00004, null);
-      var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance( Components.interfaces.nsIScriptableInputStream );
-      sis.init( is );
+      var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
+      sis.init(is);
       var output = sis.read(-1);
       is.close();
       sis.close();
@@ -263,7 +263,7 @@ function inforssGetRepositoryAsString(source)
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     alert(document.getElementById("bundle_inforss").getString("inforss.repo.error") + "\n" + e);
   }
@@ -275,11 +275,11 @@ function inforssRestoreRepository()
 {
   try
   {
-    var file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+    var file = file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
     file.append(INFORSS_REPOSITORY);
-    if ( file.exists() == true)
+    if (file.exists() == true)
     {
-      file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+      file = file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
       var dest = file.clone();
       dest.append(INFORSS_INERROR);
       if (dest.exists() == true)
@@ -329,680 +329,680 @@ function inforssAdjustRepository()
   try
   {
     var items = RSSList.getElementsByTagName("RSS");
-	if (RSSList.firstChild.getAttribute("version") == "3")
-	{
-	  RSSList.firstChild.setAttribute("red",127);
-	  RSSList.firstChild.setAttribute("green",192);
-	  RSSList.firstChild.setAttribute("blue",255);
-	  RSSList.firstChild.setAttribute("version","5");
-	  RSSList.firstChild.setAttribute("delay","15");
-	  RSSList.firstChild.setAttribute("refresh","2");
-	  RSSList.firstChild.setAttribute("switch","true");
-	  RSSList.firstChild.setAttribute("groupNbItem","3");
-	  RSSList.firstChild.setAttribute("groupLenghtItem","25");
-	  RSSList.firstChild.setAttribute("groupRefresh","2");
-	  RSSList.firstChild.setAttribute("separateLine","false");
-	  RSSList.firstChild.setAttribute("linePosition","bottom");
-	  RSSList.firstChild.setAttribute("scrolling","1");
-	  RSSList.firstChild.setAttribute("submenu","false");
-	  RSSList.firstChild.setAttribute("group","false");
-	  RSSList.firstChild.setAttribute("debug","false");
-	  RSSList.firstChild.setAttribute("log","false");
-	  RSSList.firstChild.setAttribute("statusbar","false");
-	  RSSList.firstChild.setAttribute("net","false");
-	  RSSList.firstChild.setAttribute("bold","true");
-	  RSSList.firstChild.setAttribute("italic","true");
-	  RSSList.firstChild.setAttribute("currentfeed","true");
-	  RSSList.firstChild.setAttribute("livemark","true");
-	  RSSList.firstChild.setAttribute("clipboard","true");
-	  RSSList.firstChild.setAttribute("scrollingspeed","19");
-	  RSSList.firstChild.setAttribute("font","auto");
-	  RSSList.firstChild.setAttribute("foregroundColor","auto");
-      RSSList.firstChild.setAttribute("defaultForegroundColor","default");
-	  RSSList.firstChild.setAttribute("favicon","true");
-	  RSSList.firstChild.setAttribute("scrollingArea","500");
-	  RSSList.firstChild.setAttribute("hideViewed","false");
-	  RSSList.firstChild.setAttribute("tooltip","description");
-	  RSSList.firstChild.setAttribute("clickHeadline","0");
-	  RSSList.firstChild.setAttribute("hideOld","false");
-	  RSSList.firstChild.setAttribute("sortedMenu","asc");
-	  RSSList.firstChild.setAttribute("hideOld","false");
-	  RSSList.firstChild.setAttribute("hideHistory","true");
-	  RSSList.firstChild.setAttribute("includeAssociated","true");
-	  RSSList.firstChild.setAttribute("cycling","false");
-	  RSSList.firstChild.setAttribute("cyclingDelay","5");
-	  RSSList.firstChild.setAttribute("nextFeed","next");
-      RSSList.firstChild.setAttribute("defaultPurgeHistory","3");
-	  RSSList.firstChild.setAttribute("fontSize","auto");
-	  RSSList.firstChild.setAttribute("stopscrolling","true");
-	  RSSList.firstChild.setAttribute("cycleWithinGroup","false");
-	  RSSList.firstChild.setAttribute("defaultGroupIcon","chrome://inforss/skin/group.png");
-	  RSSList.firstChild.setAttribute("scrollingdirection","rtl");
-      RSSList.firstChild.setAttribute("readAllIcon","true");
-      RSSList.firstChild.setAttribute("viewAllIcon","true");
-	  RSSList.firstChild.setAttribute("shuffleIcon","true");
-      RSSList.firstChild.setAttribute("directionIcon","true");
-	  RSSList.firstChild.setAttribute("scrollingIcon","true");
-	  RSSList.firstChild.setAttribute("previousIcon","true");
-	  RSSList.firstChild.setAttribute("pauseIcon","true");
-	  RSSList.firstChild.setAttribute("nextIcon","true");
-	  RSSList.firstChild.setAttribute("synchronizeIcon","false");
-	  RSSList.firstChild.setAttribute("refreshIcon","false");
-      RSSList.firstChild.setAttribute("hideOldIcon","false");
-	  RSSList.firstChild.setAttribute("hideViewedIcon","false");
-	  RSSList.firstChild.setAttribute("popupMessage","false");
-	  RSSList.firstChild.setAttribute("flashingIcon","true");
-	  RSSList.firstChild.setAttribute("homeIcon","false");
-	  RSSList.firstChild.setAttribute("filterIcon","false");
-      RSSList.firstChild.setAttribute("defaultPlayPodcast","true");
-	  RSSList.firstChild.setAttribute("displayEnclosure","true");
-	  RSSList.firstChild.setAttribute("displayBanned","true");
-	  RSSList.firstChild.setAttribute("savePodcastLocation","");
-	  RSSList.firstChild.setAttribute("defaultBrowserHistory","true");
-      RSSList.firstChild.setAttribute("collapseBar","false");
-	  RSSList.firstChild.setAttribute("scrollingIncrement","2");
-	  RSSList.firstChild.setAttribute("quickFilter","");
-	  RSSList.firstChild.setAttribute("quickFilterActif","false");
+    if (RSSList.firstChild.getAttribute("version") == "3")
+    {
+      RSSList.firstChild.setAttribute("red", 127);
+      RSSList.firstChild.setAttribute("green", 192);
+      RSSList.firstChild.setAttribute("blue", 255);
+      RSSList.firstChild.setAttribute("version", "5");
+      RSSList.firstChild.setAttribute("delay", "15");
+      RSSList.firstChild.setAttribute("refresh", "2");
+      RSSList.firstChild.setAttribute("switch", "true");
+      RSSList.firstChild.setAttribute("groupNbItem", "3");
+      RSSList.firstChild.setAttribute("groupLenghtItem", "25");
+      RSSList.firstChild.setAttribute("groupRefresh", "2");
+      RSSList.firstChild.setAttribute("separateLine", "false");
+      RSSList.firstChild.setAttribute("linePosition", "bottom");
+      RSSList.firstChild.setAttribute("scrolling", "1");
+      RSSList.firstChild.setAttribute("submenu", "false");
+      RSSList.firstChild.setAttribute("group", "false");
+      RSSList.firstChild.setAttribute("debug", "false");
+      RSSList.firstChild.setAttribute("log", "false");
+      RSSList.firstChild.setAttribute("statusbar", "false");
+      RSSList.firstChild.setAttribute("net", "false");
+      RSSList.firstChild.setAttribute("bold", "true");
+      RSSList.firstChild.setAttribute("italic", "true");
+      RSSList.firstChild.setAttribute("currentfeed", "true");
+      RSSList.firstChild.setAttribute("livemark", "true");
+      RSSList.firstChild.setAttribute("clipboard", "true");
+      RSSList.firstChild.setAttribute("scrollingspeed", "19");
+      RSSList.firstChild.setAttribute("font", "auto");
+      RSSList.firstChild.setAttribute("foregroundColor", "auto");
+      RSSList.firstChild.setAttribute("defaultForegroundColor", "default");
+      RSSList.firstChild.setAttribute("favicon", "true");
+      RSSList.firstChild.setAttribute("scrollingArea", "500");
+      RSSList.firstChild.setAttribute("hideViewed", "false");
+      RSSList.firstChild.setAttribute("tooltip", "description");
+      RSSList.firstChild.setAttribute("clickHeadline", "0");
+      RSSList.firstChild.setAttribute("hideOld", "false");
+      RSSList.firstChild.setAttribute("sortedMenu", "asc");
+      RSSList.firstChild.setAttribute("hideOld", "false");
+      RSSList.firstChild.setAttribute("hideHistory", "true");
+      RSSList.firstChild.setAttribute("includeAssociated", "true");
+      RSSList.firstChild.setAttribute("cycling", "false");
+      RSSList.firstChild.setAttribute("cyclingDelay", "5");
+      RSSList.firstChild.setAttribute("nextFeed", "next");
+      RSSList.firstChild.setAttribute("defaultPurgeHistory", "3");
+      RSSList.firstChild.setAttribute("fontSize", "auto");
+      RSSList.firstChild.setAttribute("stopscrolling", "true");
+      RSSList.firstChild.setAttribute("cycleWithinGroup", "false");
+      RSSList.firstChild.setAttribute("defaultGroupIcon", "chrome://inforss/skin/group.png");
+      RSSList.firstChild.setAttribute("scrollingdirection", "rtl");
+      RSSList.firstChild.setAttribute("readAllIcon", "true");
+      RSSList.firstChild.setAttribute("viewAllIcon", "true");
+      RSSList.firstChild.setAttribute("shuffleIcon", "true");
+      RSSList.firstChild.setAttribute("directionIcon", "true");
+      RSSList.firstChild.setAttribute("scrollingIcon", "true");
+      RSSList.firstChild.setAttribute("previousIcon", "true");
+      RSSList.firstChild.setAttribute("pauseIcon", "true");
+      RSSList.firstChild.setAttribute("nextIcon", "true");
+      RSSList.firstChild.setAttribute("synchronizeIcon", "false");
+      RSSList.firstChild.setAttribute("refreshIcon", "false");
+      RSSList.firstChild.setAttribute("hideOldIcon", "false");
+      RSSList.firstChild.setAttribute("hideViewedIcon", "false");
+      RSSList.firstChild.setAttribute("popupMessage", "false");
+      RSSList.firstChild.setAttribute("flashingIcon", "true");
+      RSSList.firstChild.setAttribute("homeIcon", "false");
+      RSSList.firstChild.setAttribute("filterIcon", "false");
+      RSSList.firstChild.setAttribute("defaultPlayPodcast", "true");
+      RSSList.firstChild.setAttribute("displayEnclosure", "true");
+      RSSList.firstChild.setAttribute("displayBanned", "true");
+      RSSList.firstChild.setAttribute("savePodcastLocation", "");
+      RSSList.firstChild.setAttribute("defaultBrowserHistory", "true");
+      RSSList.firstChild.setAttribute("collapseBar", "false");
+      RSSList.firstChild.setAttribute("scrollingIncrement", "2");
+      RSSList.firstChild.setAttribute("quickFilter", "");
+      RSSList.firstChild.setAttribute("quickFilterActif", "false");
       RSSList.firstChild.setAttribute("timeslice", "90");
       RSSList.firstChild.setAttribute("mouseEvent", "0");
       RSSList.firstChild.setAttribute("mouseWheelScroll", "pixel");
 
-	  for (var i=0; i<items.length; i++)
-	  {
-		items[i].setAttribute("group","false");
-	    items[i].setAttribute("filter","all");
-	    if (items[i].hasAttribute("nbItem") == false)
-	    {
-	      items[i].setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
-	    }
-	    if (items[i].hasAttribute("lengthItem") == false)
-	    {
-	      items[i].setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
-	    }
-	    if (items[i].hasAttribute("refresh") == false)
-	    {
-	      items[i].setAttribute("refresh", RSSList.firstChild.getAttribute("refresh"));
-	    }
-	    if (items[i].hasAttribute("playPodcast") == false)
-	    {
-	      items[i].setAttribute("playPodcast","true");
-	    }
-	    if (items[i].hasAttribute("savePodcastLocation") == false)
-	    {
-	      items[i].setAttribute("savePodcastLocation","");
-	    }
-	    if (items[i].hasAttribute("browserHistory") == false)
-	    {
-	      items[i].setAttribute("browserHistory","true");
-	    }
-	    if (items[i].hasAttribute("filterCaseSensitive") == false)
-	    {
-	      items[i].setAttribute("filterCaseSensitive","true");
-	    }
-	    if (items[i].hasAttribute("purgeHistory") == false)
-	    {
-	      items[i].setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
-	    }
-	    items[i].setAttribute("type","rss");
-	    items[i].setAttribute("filterPolicy","0");
-	    items[i].setAttribute("encoding","");
-	    if ((items[i].getAttribute("type") == "group") && (items[i].hasAttribute("playlist") == false))
-	    {
-	      items[i].setAttribute("playlist", "false");
-	    }
-	  }
-	}
-	else
-	{
-	  if (RSSList.firstChild.getAttribute("version") == "4")
-	  {
-		RSSList.firstChild.setAttribute("version","5");
-		RSSList.firstChild.setAttribute("refresh","2");
-		RSSList.firstChild.setAttribute("switch","true");
-		RSSList.firstChild.setAttribute("groupNbItem","3");
-		RSSList.firstChild.setAttribute("groupLenghtItem","25");
-		RSSList.firstChild.setAttribute("groupRefresh","2");
-		RSSList.firstChild.setAttribute("separateLine","false");
-	    RSSList.firstChild.setAttribute("linePosition","bottom");
-		RSSList.firstChild.setAttribute("scrolling","1");
-		RSSList.firstChild.setAttribute("submenu","false");
-		RSSList.firstChild.setAttribute("group","false");
-	    RSSList.firstChild.setAttribute("debug","false");
-	    RSSList.firstChild.setAttribute("log","false");
-	    RSSList.firstChild.setAttribute("statusbar","false");
-	    RSSList.firstChild.setAttribute("net","false");
-	    RSSList.firstChild.setAttribute("bold","true");
-	    RSSList.firstChild.setAttribute("italic","true");
-	    RSSList.firstChild.setAttribute("currentfeed","true");
-	    RSSList.firstChild.setAttribute("livemark","true");
-	    RSSList.firstChild.setAttribute("clipboard","true");
-	    RSSList.firstChild.setAttribute("scrollingspeed","19");
-	    RSSList.firstChild.setAttribute("font","auto");
-	    RSSList.firstChild.setAttribute("foregroundColor","auto");
-		RSSList.firstChild.setAttribute("defaultForegroundColor","default");
-	    RSSList.firstChild.setAttribute("favicon","true");
-	    RSSList.firstChild.setAttribute("scrollingArea","500");
-  	    RSSList.firstChild.setAttribute("hideViewed","false");
-	    RSSList.firstChild.setAttribute("tooltip","description");
-	    RSSList.firstChild.setAttribute("clickHeadline","0");
-	    RSSList.firstChild.setAttribute("hideOld","false");
-	    RSSList.firstChild.setAttribute("sortedMenu","asc");
-	    RSSList.firstChild.setAttribute("hideHistory","true");
-	    RSSList.firstChild.setAttribute("includeAssociated","true");
-	    RSSList.firstChild.setAttribute("cycling","false");
-	    RSSList.firstChild.setAttribute("cyclingDelay","5");
-	    RSSList.firstChild.setAttribute("nextFeed","next");
-		RSSList.firstChild.setAttribute("defaultPurgeHistory","3");
-		RSSList.firstChild.setAttribute("fontSize","auto");
-		RSSList.firstChild.setAttribute("stopscrolling","true");
-		RSSList.firstChild.setAttribute("cycleWithinGroup","false");
-	    RSSList.firstChild.setAttribute("defaultGroupIcon","chrome://inforss/skin/group.png");
-	    RSSList.firstChild.setAttribute("scrollingdirection","rtl");
-		RSSList.firstChild.setAttribute("readAllIcon","true");
-        RSSList.firstChild.setAttribute("viewAllIcon","true");
-	    RSSList.firstChild.setAttribute("shuffleIcon","true");
-		RSSList.firstChild.setAttribute("directionIcon","true");
-		RSSList.firstChild.setAttribute("scrollingIcon","true");
-		RSSList.firstChild.setAttribute("previousIcon","true");
-		RSSList.firstChild.setAttribute("pauseIcon","true");
-		RSSList.firstChild.setAttribute("nextIcon","true");
-		RSSList.firstChild.setAttribute("synchronizeIcon","false");
-	    RSSList.firstChild.setAttribute("refreshIcon","false");
-		RSSList.firstChild.setAttribute("hideOldIcon","false");
-		RSSList.firstChild.setAttribute("hideViewedIcon","false");
-		RSSList.firstChild.setAttribute("popupMessage","false");
-		RSSList.firstChild.setAttribute("flashingIcon","true");
-		RSSList.firstChild.setAttribute("homeIcon","false");
-		RSSList.firstChild.setAttribute("filterIcon","false");
-		RSSList.firstChild.setAttribute("defaultPlayPodcast","true");
-		RSSList.firstChild.setAttribute("displayEnclosure","true");
-		RSSList.firstChild.setAttribute("displayBanned","true");
-		RSSList.firstChild.setAttribute("savePodcastLocation","");
-		RSSList.firstChild.setAttribute("defaultBrowserHistory","true");
-		RSSList.firstChild.setAttribute("collapseBar","false");
-		RSSList.firstChild.setAttribute("scrollingIncrement","2");
-	    RSSList.firstChild.setAttribute("quickFilter","");
-		RSSList.firstChild.setAttribute("quickFilterActif","false");
-		RSSList.firstChild.setAttribute("timeslice", "90");
-		RSSList.firstChild.setAttribute("mouseEvent", "0");
-		RSSList.firstChild.setAttribute("mouseWheelScroll", "pixel");
-		for (var i=0; i<items.length; i++)
-		{
-		  items[i].setAttribute("group","false");
-		  items[i].setAttribute("filter","all");
-	      if (items[i].hasAttribute("nbItem") == false)
-	      {
-	        items[i].setAttribute("nbItem",RSSList.firstChild.getAttribute("defaultNbItem"));
-	      }
-	      if (items[i].hasAttribute("lengthItem") == false)
-	      {
-	        items[i].setAttribute("lengthItem",RSSList.firstChild.getAttribute("defaultLenghtItem"));
-	      }
-	      if (items[i].hasAttribute("refresh") == false)
-	      {
-	        items[i].setAttribute("refresh",RSSList.firstChild.getAttribute("refresh"));
-	      }
-	      if (items[i].hasAttribute("playPodcast") == false)
-	      {
-	        items[i].setAttribute("playPodcast","true");
-	      }
-	      if (items[i].hasAttribute("savePodcastLocation") == false)
-	      {
-	        items[i].setAttribute("savePodcastLocation","");
-	      }
-	      if (items[i].hasAttribute("browserHistory") == false)
-	      {
-	        items[i].setAttribute("browserHistory","true");
-	      }
-	      if (items[i].hasAttribute("filterCaseSensitive") == false)
-	      {
-	        items[i].setAttribute("filterCaseSensitive","true");
-	      }
-	      items[i].setAttribute("type","rss");
-	      items[i].setAttribute("filterPolicy","0");
-	      items[i].setAttribute("encoding","");
-	      if ((items[i].getAttribute("type") == "group") && (items[i].hasAttribute("playlist") == false))
-	      {
-	        items[i].setAttribute("playlist", "false");
-	      }
-	      if (items[i].hasAttribute("purgeHistory") == false)
-	      {
-	        items[i].setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
-	      }
-		}
-	  }
-	  else
-	  {
-		if (RSSList.firstChild.hasAttribute("switch") == false)
-		{
-		  RSSList.firstChild.setAttribute("switch","true");
-		}
-		if (RSSList.firstChild.getAttribute("switch") == "on")
-		{
-		  RSSList.firstChild.setAttribute("switch","true");
-		}
-		if (RSSList.firstChild.hasAttribute("groupNbItem") == false)
-		{
-		  RSSList.firstChild.setAttribute("groupNbItem","3");
-		}
-		if (RSSList.firstChild.hasAttribute("groupLenghtItem") == false)
-		{
-		  RSSList.firstChild.setAttribute("groupLenghtItem","25");
-		}
-		if (RSSList.firstChild.hasAttribute("groupRefresh") == false)
-		{
-		  RSSList.firstChild.setAttribute("groupRefresh","2");
-		}
-		if (RSSList.firstChild.hasAttribute("separateLine") == false)
-		{
-		  RSSList.firstChild.setAttribute("separateLine","false");
-		}
-		if (RSSList.firstChild.hasAttribute("scrolling") == false)
-		{
-		  RSSList.firstChild.setAttribute("scrolling","1");
-		}
-		else
-		{
-		  if (RSSList.firstChild.getAttribute("scrolling") == "true")
-		  {
-		    RSSList.firstChild.setAttribute("scrolling","1");
-		  }
-		  else
-		  {
-		    if (RSSList.firstChild.getAttribute("scrolling") == "false")
-		    {
-		      RSSList.firstChild.setAttribute("scrolling","0");
-		    }
-		  }
-		}
-		if (RSSList.firstChild.hasAttribute("submenu") == false)
-		{
-		  RSSList.firstChild.setAttribute("submenu","false");
-		}
-		if (RSSList.firstChild.hasAttribute("group") == false)
-		{
-		  RSSList.firstChild.setAttribute("group","false");
-		}
-		if (RSSList.firstChild.hasAttribute("linePosition") == false)
-		{
-		  RSSList.firstChild.setAttribute("linePosition","bottom");
-		}
-		if (RSSList.firstChild.hasAttribute("debug") == false)
-		{
-		  RSSList.firstChild.setAttribute("debug","false");
-		}
-		if (RSSList.firstChild.hasAttribute("log") == false)
-		{
-		  RSSList.firstChild.setAttribute("log","false");
-		}
-		if (RSSList.firstChild.hasAttribute("statusbar") == false)
-		{
-		  RSSList.firstChild.setAttribute("statusbar","false");
-		}
-		if (RSSList.firstChild.hasAttribute("net") == false)
-		{
-		  RSSList.firstChild.setAttribute("net","false");
-		}
-		if (RSSList.firstChild.hasAttribute("bold") == false)
-		{
-		  RSSList.firstChild.setAttribute("bold","true");
-		}
-		if (RSSList.firstChild.hasAttribute("italic") == false)
-		{
-		  RSSList.firstChild.setAttribute("italic","true");
-		}
-		if (RSSList.firstChild.hasAttribute("currentfeed") == false)
-		{
-		  RSSList.firstChild.setAttribute("currentfeed","true");
-		}
-		if (RSSList.firstChild.hasAttribute("livemark") == false)
-		{
-		  RSSList.firstChild.setAttribute("livemark","true");
-		}
-		if (RSSList.firstChild.hasAttribute("clipboard") == false)
-		{
-		  RSSList.firstChild.setAttribute("clipboard","true");
-		}
-		if (RSSList.firstChild.hasAttribute("scrollingspeed") == false)
-		{
-		  RSSList.firstChild.setAttribute("scrollingspeed","19");
-		}
-		if (RSSList.firstChild.hasAttribute("font") == false)
-		{
-		  RSSList.firstChild.setAttribute("font","auto");
-		}
-		if (RSSList.firstChild.hasAttribute("foregroundColor") == false)
-		{
-		  RSSList.firstChild.setAttribute("foregroundColor","auto");
-		}
-		if (RSSList.firstChild.hasAttribute("defaultForegroundColor") == false)
-		{
-		  RSSList.firstChild.setAttribute("defaultForegroundColor","default");
-		}
-		if (RSSList.firstChild.hasAttribute("favicon") == false)
-		{
-		  RSSList.firstChild.setAttribute("favicon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("scrollingArea") == false)
-		{
-		  RSSList.firstChild.setAttribute("scrollingArea","500");
-		}
-		if (RSSList.firstChild.hasAttribute("hideViewed") == false)
-		{
-		  RSSList.firstChild.setAttribute("hideViewed","false");
-		}
-		if (RSSList.firstChild.hasAttribute("tooltip") == false)
-		{
-		  RSSList.firstChild.setAttribute("tooltip","description");
-		}
-		if (RSSList.firstChild.hasAttribute("clickHeadline") == false)
-		{
-		  RSSList.firstChild.setAttribute("clickHeadline","0");
-		}
-		if (RSSList.firstChild.hasAttribute("hideOld") == false)
-		{
-		  RSSList.firstChild.setAttribute("hideOld","false");
-		}
-		if (RSSList.firstChild.hasAttribute("sortedMenu") == false)
-		{
-		  RSSList.firstChild.setAttribute("sortedMenu","asc");
-		}
-		if (RSSList.firstChild.hasAttribute("hideHistory") == false)
-		{
-		  RSSList.firstChild.setAttribute("hideHistory","true");
-		}
-		if (RSSList.firstChild.hasAttribute("includeAssociated") == false)
-		{
-		  RSSList.firstChild.setAttribute("includeAssociated","true");
-		}
-		if (RSSList.firstChild.hasAttribute("cycling") == false)
-		{
-		  RSSList.firstChild.setAttribute("cycling","false");
-		}
-		if (RSSList.firstChild.hasAttribute("cyclingDelay") == false)
-		{
-		  RSSList.firstChild.setAttribute("cyclingDelay","5");
-		}
-		if (RSSList.firstChild.hasAttribute("nextFeed") == false)
-		{
-		  RSSList.firstChild.setAttribute("nextFeed","next");
-		}
-		if (RSSList.firstChild.hasAttribute("defaultPurgeHistory") == false)
-		{
-		  RSSList.firstChild.setAttribute("defaultPurgeHistory", (RSSList.firstChild.hasAttribute("purgeHistory") == true)? RSSList.firstChild.getAttribute("purgeHistory") : "3");
-		}
-		if (RSSList.firstChild.hasAttribute("purgeHistory") == true)
-		{
-		  RSSList.firstChild.removeAttribute("purgeHistory");
-		}
-		if (RSSList.firstChild.hasAttribute("fontSize") == false)
-		{
-		  RSSList.firstChild.setAttribute("fontSize","auto");
-		}
-		if (RSSList.firstChild.hasAttribute("stopscrolling") == false)
-		{
-		  RSSList.firstChild.setAttribute("stopscrolling","true");
-		}
-		if (RSSList.firstChild.hasAttribute("cycleWithinGroup") == false)
-		{
-		  RSSList.firstChild.setAttribute("cycleWithinGroup","false");
-		}
-		if (RSSList.firstChild.hasAttribute("defaultGroupIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("defaultGroupIcon","chrome://inforss/skin/group.png");
-		}
-		if (RSSList.firstChild.hasAttribute("scrollingdirection") == false)
-		{
-		  RSSList.firstChild.setAttribute("scrollingdirection","rtl");
-		}
-		if (RSSList.firstChild.hasAttribute("readAllIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("readAllIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("viewAllIcon") == false)
-		{
-          RSSList.firstChild.setAttribute("viewAllIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("shuffleIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("shuffleIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("directionIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("directionIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("scrollingIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("scrollingIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("previousIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("previousIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("pauseIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("pauseIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("nextIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("nextIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("synchronizeIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("synchronizeIcon","false");
-		}
-		if (RSSList.firstChild.hasAttribute("refreshIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("refreshIcon","false");
-		}
-		if (RSSList.firstChild.hasAttribute("hideOldIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("hideOldIcon","false");
-		}
-		if (RSSList.firstChild.hasAttribute("hideViewedIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("hideViewedIcon","false");
-		}
-		if (RSSList.firstChild.hasAttribute("homeIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("homeIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("filterIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("filterIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("popupMessage") == false)
-		{
-		  RSSList.firstChild.setAttribute("popupMessage","true");
-		}
-		if (RSSList.firstChild.hasAttribute("playSound") == false)
-		{
-		  RSSList.firstChild.setAttribute("playSound","true");
-		}
-		if (RSSList.firstChild.hasAttribute("flashingIcon") == false)
-		{
-		  RSSList.firstChild.setAttribute("flashingIcon","true");
-		}
-		if (RSSList.firstChild.hasAttribute("defaultPlayPodcast") == false)
-		{
-		  RSSList.firstChild.setAttribute("defaultPlayPodcast","true");
-		}
-		if (RSSList.firstChild.hasAttribute("displayEnclosure") == false)
-		{
-		  RSSList.firstChild.setAttribute("displayEnclosure","true");
-		}
-		if (RSSList.firstChild.hasAttribute("displayBanned") == false)
-		{
-		  RSSList.firstChild.setAttribute("displayBanned","true");
-		}
-		if (RSSList.firstChild.hasAttribute("savePodcastLocation") == false)
-		{
-		  RSSList.firstChild.setAttribute("savePodcastLocation","");
-		}
-		if (RSSList.firstChild.hasAttribute("defaultBrowserHistory") == false)
-		{
-		  RSSList.firstChild.setAttribute("defaultBrowserHistory","true");
-		}
-		if (RSSList.firstChild.hasAttribute("collapseBar") == false)
-		{
-		  RSSList.firstChild.setAttribute("collapseBar","false");
-		}
-		if (RSSList.firstChild.hasAttribute("scrollingIncrement") == false)
-		{
-		  RSSList.firstChild.setAttribute("scrollingIncrement","2");
-		}
-		if (RSSList.firstChild.hasAttribute("quickFilter") == false)
-		{
-		  RSSList.firstChild.setAttribute("quickFilter","");
-		}
-		if (RSSList.firstChild.hasAttribute("quickFilterActif") == false)
-		{
-		  RSSList.firstChild.setAttribute("quickFilterActif","false");
-		}
-		if (RSSList.firstChild.hasAttribute("timeslice") == false)
-		{
-		  RSSList.firstChild.setAttribute("timeslice", "90");
-		}
-		if (RSSList.firstChild.hasAttribute("mouseEvent") == false)
-		{
-		  RSSList.firstChild.setAttribute("mouseEvent", "0");
-		}
-		if (RSSList.firstChild.hasAttribute("mouseWheelScroll") == false)
-		{
-		  RSSList.firstChild.setAttribute("mouseWheelScroll", "pixel");
-		}
-		for (var i=0; i<items.length; i++)
-		{
-		  if (items[i].hasAttribute("group") == false)
-		  {
-			items[i].setAttribute("group","false");
-		  }
-		  if (items[i].hasAttribute("filter") == false)
-		  {
-		    items[i].setAttribute("filter","all");
-	  	  }
-	      if (items[i].hasAttribute("nbItem") == false)
-	      {
-	        items[i].setAttribute("nbItem",RSSList.firstChild.getAttribute("defaultNbItem"));
-	      }
-	      if (items[i].hasAttribute("lengthItem") == false)
-	      {
-	        items[i].setAttribute("lengthItem",RSSList.firstChild.getAttribute("defaultLenghtItem"));
-	      }
-	      if (items[i].hasAttribute("refresh") == false)
-	      {
-	        items[i].setAttribute("refresh",RSSList.firstChild.getAttribute("refresh"));
-	      }
-	      if (items[i].hasAttribute("type") == false)
-	      {
-	        items[i].setAttribute("type","rss");
-	      }
-	      if (items[i].hasAttribute("filterPolicy") == false)
-	      {
-	        items[i].setAttribute("filterPolicy","0");
-	      }
-	      if ((items[i].getAttribute("type") == "html") && (items[i].hasAttribute("htmlDirection") == false))
-	      {
-	        items[i].setAttribute("htmlDirection","asc");
-	      }
-	      if (items[i].hasAttribute("playPodcast") == false)
-	      {
-	        items[i].setAttribute("playPodcast","true");
-	      }
-	      if (items[i].hasAttribute("savePodcastLocation") == false)
-	      {
-	        items[i].setAttribute("savePodcastLocation",((RSSList.firstChild.hasAttribute("savePodcastLocation") == false)? "" : RSSList.firstChild.getAttribute("savePodcastLocation")));
-	      }
-	      if (items[i].hasAttribute("browserHistory") == false)
-	      {
-	        items[i].setAttribute("browserHistory","true");
-	        if ((items[i].getAttribute("url").indexOf("https://gmail.google.com/gmail/feed/atom") == 0) ||
-	            (items[i].getAttribute("url").indexOf(".ebay.") != -1))
-	        {
-	          items[i].setAttribute("browserHistory","false");
-			}
-	      }
-	      if (items[i].hasAttribute("filterCaseSensitive") == false)
-	      {
-	        items[i].setAttribute("filterCaseSensitive","true");
-	      }
-	      if (items[i].hasAttribute("password") == true)
-	      {
-			if (items[i].getAttribute("password") != "")
-			{
-			  inforssXMLRepository.storePassword(items[i].getAttribute("url"),
-			                                     items[i].getAttribute("user"),
-			                                     items[i].getAttribute("password"));
-		    }
-		    items[i].removeAttribute("password");
-		  }
-	      if (items[i].hasAttribute("activity") == false)
-	      {
-	        items[i].setAttribute("activity", "true");
-	      }
-	      if (items[i].hasAttribute("encoding") == false)
-	      {
-	        items[i].setAttribute("encoding","");
-	      }
-	      if ((items[i].getAttribute("type") == "group") && (items[i].hasAttribute("playlist") == false))
-	      {
-	        items[i].setAttribute("playlist", "false");
-	      }
-	      if (items[i].hasAttribute("purgeHistory") == false)
-	      {
-	        items[i].setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
-	      }
-		}
-	  }
-	}
-	var find = false;
-	for (var i=0; i<items.length; i++)
-	{
-	  if ((items[i].getAttribute("icon") == null) || (items[i].getAttribute("icon") == ""))
-	  {
-	    url = inforssFindIcon(items[i]);
-	    if (url != null)
-	    {
-	      items[i].setAttribute("icon", url);
-	      find = true;
-	    }
-	  }
-	  items[i].setAttribute("groupAssociated","false");
+      for (var i = 0; i < items.length; i++)
+      {
+        items[i].setAttribute("group", "false");
+        items[i].setAttribute("filter", "all");
+        if (items[i].hasAttribute("nbItem") == false)
+        {
+          items[i].setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
+        }
+        if (items[i].hasAttribute("lengthItem") == false)
+        {
+          items[i].setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
+        }
+        if (items[i].hasAttribute("refresh") == false)
+        {
+          items[i].setAttribute("refresh", RSSList.firstChild.getAttribute("refresh"));
+        }
+        if (items[i].hasAttribute("playPodcast") == false)
+        {
+          items[i].setAttribute("playPodcast", "true");
+        }
+        if (items[i].hasAttribute("savePodcastLocation") == false)
+        {
+          items[i].setAttribute("savePodcastLocation", "");
+        }
+        if (items[i].hasAttribute("browserHistory") == false)
+        {
+          items[i].setAttribute("browserHistory", "true");
+        }
+        if (items[i].hasAttribute("filterCaseSensitive") == false)
+        {
+          items[i].setAttribute("filterCaseSensitive", "true");
+        }
+        if (items[i].hasAttribute("purgeHistory") == false)
+        {
+          items[i].setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
+        }
+        items[i].setAttribute("type", "rss");
+        items[i].setAttribute("filterPolicy", "0");
+        items[i].setAttribute("encoding", "");
+        if ((items[i].getAttribute("type") == "group") && (items[i].hasAttribute("playlist") == false))
+        {
+          items[i].setAttribute("playlist", "false");
+        }
+      }
+    }
+    else
+    {
+      if (RSSList.firstChild.getAttribute("version") == "4")
+      {
+        RSSList.firstChild.setAttribute("version", "5");
+        RSSList.firstChild.setAttribute("refresh", "2");
+        RSSList.firstChild.setAttribute("switch", "true");
+        RSSList.firstChild.setAttribute("groupNbItem", "3");
+        RSSList.firstChild.setAttribute("groupLenghtItem", "25");
+        RSSList.firstChild.setAttribute("groupRefresh", "2");
+        RSSList.firstChild.setAttribute("separateLine", "false");
+        RSSList.firstChild.setAttribute("linePosition", "bottom");
+        RSSList.firstChild.setAttribute("scrolling", "1");
+        RSSList.firstChild.setAttribute("submenu", "false");
+        RSSList.firstChild.setAttribute("group", "false");
+        RSSList.firstChild.setAttribute("debug", "false");
+        RSSList.firstChild.setAttribute("log", "false");
+        RSSList.firstChild.setAttribute("statusbar", "false");
+        RSSList.firstChild.setAttribute("net", "false");
+        RSSList.firstChild.setAttribute("bold", "true");
+        RSSList.firstChild.setAttribute("italic", "true");
+        RSSList.firstChild.setAttribute("currentfeed", "true");
+        RSSList.firstChild.setAttribute("livemark", "true");
+        RSSList.firstChild.setAttribute("clipboard", "true");
+        RSSList.firstChild.setAttribute("scrollingspeed", "19");
+        RSSList.firstChild.setAttribute("font", "auto");
+        RSSList.firstChild.setAttribute("foregroundColor", "auto");
+        RSSList.firstChild.setAttribute("defaultForegroundColor", "default");
+        RSSList.firstChild.setAttribute("favicon", "true");
+        RSSList.firstChild.setAttribute("scrollingArea", "500");
+        RSSList.firstChild.setAttribute("hideViewed", "false");
+        RSSList.firstChild.setAttribute("tooltip", "description");
+        RSSList.firstChild.setAttribute("clickHeadline", "0");
+        RSSList.firstChild.setAttribute("hideOld", "false");
+        RSSList.firstChild.setAttribute("sortedMenu", "asc");
+        RSSList.firstChild.setAttribute("hideHistory", "true");
+        RSSList.firstChild.setAttribute("includeAssociated", "true");
+        RSSList.firstChild.setAttribute("cycling", "false");
+        RSSList.firstChild.setAttribute("cyclingDelay", "5");
+        RSSList.firstChild.setAttribute("nextFeed", "next");
+        RSSList.firstChild.setAttribute("defaultPurgeHistory", "3");
+        RSSList.firstChild.setAttribute("fontSize", "auto");
+        RSSList.firstChild.setAttribute("stopscrolling", "true");
+        RSSList.firstChild.setAttribute("cycleWithinGroup", "false");
+        RSSList.firstChild.setAttribute("defaultGroupIcon", "chrome://inforss/skin/group.png");
+        RSSList.firstChild.setAttribute("scrollingdirection", "rtl");
+        RSSList.firstChild.setAttribute("readAllIcon", "true");
+        RSSList.firstChild.setAttribute("viewAllIcon", "true");
+        RSSList.firstChild.setAttribute("shuffleIcon", "true");
+        RSSList.firstChild.setAttribute("directionIcon", "true");
+        RSSList.firstChild.setAttribute("scrollingIcon", "true");
+        RSSList.firstChild.setAttribute("previousIcon", "true");
+        RSSList.firstChild.setAttribute("pauseIcon", "true");
+        RSSList.firstChild.setAttribute("nextIcon", "true");
+        RSSList.firstChild.setAttribute("synchronizeIcon", "false");
+        RSSList.firstChild.setAttribute("refreshIcon", "false");
+        RSSList.firstChild.setAttribute("hideOldIcon", "false");
+        RSSList.firstChild.setAttribute("hideViewedIcon", "false");
+        RSSList.firstChild.setAttribute("popupMessage", "false");
+        RSSList.firstChild.setAttribute("flashingIcon", "true");
+        RSSList.firstChild.setAttribute("homeIcon", "false");
+        RSSList.firstChild.setAttribute("filterIcon", "false");
+        RSSList.firstChild.setAttribute("defaultPlayPodcast", "true");
+        RSSList.firstChild.setAttribute("displayEnclosure", "true");
+        RSSList.firstChild.setAttribute("displayBanned", "true");
+        RSSList.firstChild.setAttribute("savePodcastLocation", "");
+        RSSList.firstChild.setAttribute("defaultBrowserHistory", "true");
+        RSSList.firstChild.setAttribute("collapseBar", "false");
+        RSSList.firstChild.setAttribute("scrollingIncrement", "2");
+        RSSList.firstChild.setAttribute("quickFilter", "");
+        RSSList.firstChild.setAttribute("quickFilterActif", "false");
+        RSSList.firstChild.setAttribute("timeslice", "90");
+        RSSList.firstChild.setAttribute("mouseEvent", "0");
+        RSSList.firstChild.setAttribute("mouseWheelScroll", "pixel");
+        for (var i = 0; i < items.length; i++)
+        {
+          items[i].setAttribute("group", "false");
+          items[i].setAttribute("filter", "all");
+          if (items[i].hasAttribute("nbItem") == false)
+          {
+            items[i].setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
+          }
+          if (items[i].hasAttribute("lengthItem") == false)
+          {
+            items[i].setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
+          }
+          if (items[i].hasAttribute("refresh") == false)
+          {
+            items[i].setAttribute("refresh", RSSList.firstChild.getAttribute("refresh"));
+          }
+          if (items[i].hasAttribute("playPodcast") == false)
+          {
+            items[i].setAttribute("playPodcast", "true");
+          }
+          if (items[i].hasAttribute("savePodcastLocation") == false)
+          {
+            items[i].setAttribute("savePodcastLocation", "");
+          }
+          if (items[i].hasAttribute("browserHistory") == false)
+          {
+            items[i].setAttribute("browserHistory", "true");
+          }
+          if (items[i].hasAttribute("filterCaseSensitive") == false)
+          {
+            items[i].setAttribute("filterCaseSensitive", "true");
+          }
+          items[i].setAttribute("type", "rss");
+          items[i].setAttribute("filterPolicy", "0");
+          items[i].setAttribute("encoding", "");
+          if ((items[i].getAttribute("type") == "group") && (items[i].hasAttribute("playlist") == false))
+          {
+            items[i].setAttribute("playlist", "false");
+          }
+          if (items[i].hasAttribute("purgeHistory") == false)
+          {
+            items[i].setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
+          }
+        }
+      }
+      else
+      {
+        if (RSSList.firstChild.hasAttribute("switch") == false)
+        {
+          RSSList.firstChild.setAttribute("switch", "true");
+        }
+        if (RSSList.firstChild.getAttribute("switch") == "on")
+        {
+          RSSList.firstChild.setAttribute("switch", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("groupNbItem") == false)
+        {
+          RSSList.firstChild.setAttribute("groupNbItem", "3");
+        }
+        if (RSSList.firstChild.hasAttribute("groupLenghtItem") == false)
+        {
+          RSSList.firstChild.setAttribute("groupLenghtItem", "25");
+        }
+        if (RSSList.firstChild.hasAttribute("groupRefresh") == false)
+        {
+          RSSList.firstChild.setAttribute("groupRefresh", "2");
+        }
+        if (RSSList.firstChild.hasAttribute("separateLine") == false)
+        {
+          RSSList.firstChild.setAttribute("separateLine", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("scrolling") == false)
+        {
+          RSSList.firstChild.setAttribute("scrolling", "1");
+        }
+        else
+        {
+          if (RSSList.firstChild.getAttribute("scrolling") == "true")
+          {
+            RSSList.firstChild.setAttribute("scrolling", "1");
+          }
+          else
+          {
+            if (RSSList.firstChild.getAttribute("scrolling") == "false")
+            {
+              RSSList.firstChild.setAttribute("scrolling", "0");
+            }
+          }
+        }
+        if (RSSList.firstChild.hasAttribute("submenu") == false)
+        {
+          RSSList.firstChild.setAttribute("submenu", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("group") == false)
+        {
+          RSSList.firstChild.setAttribute("group", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("linePosition") == false)
+        {
+          RSSList.firstChild.setAttribute("linePosition", "bottom");
+        }
+        if (RSSList.firstChild.hasAttribute("debug") == false)
+        {
+          RSSList.firstChild.setAttribute("debug", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("log") == false)
+        {
+          RSSList.firstChild.setAttribute("log", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("statusbar") == false)
+        {
+          RSSList.firstChild.setAttribute("statusbar", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("net") == false)
+        {
+          RSSList.firstChild.setAttribute("net", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("bold") == false)
+        {
+          RSSList.firstChild.setAttribute("bold", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("italic") == false)
+        {
+          RSSList.firstChild.setAttribute("italic", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("currentfeed") == false)
+        {
+          RSSList.firstChild.setAttribute("currentfeed", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("livemark") == false)
+        {
+          RSSList.firstChild.setAttribute("livemark", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("clipboard") == false)
+        {
+          RSSList.firstChild.setAttribute("clipboard", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("scrollingspeed") == false)
+        {
+          RSSList.firstChild.setAttribute("scrollingspeed", "19");
+        }
+        if (RSSList.firstChild.hasAttribute("font") == false)
+        {
+          RSSList.firstChild.setAttribute("font", "auto");
+        }
+        if (RSSList.firstChild.hasAttribute("foregroundColor") == false)
+        {
+          RSSList.firstChild.setAttribute("foregroundColor", "auto");
+        }
+        if (RSSList.firstChild.hasAttribute("defaultForegroundColor") == false)
+        {
+          RSSList.firstChild.setAttribute("defaultForegroundColor", "default");
+        }
+        if (RSSList.firstChild.hasAttribute("favicon") == false)
+        {
+          RSSList.firstChild.setAttribute("favicon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("scrollingArea") == false)
+        {
+          RSSList.firstChild.setAttribute("scrollingArea", "500");
+        }
+        if (RSSList.firstChild.hasAttribute("hideViewed") == false)
+        {
+          RSSList.firstChild.setAttribute("hideViewed", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("tooltip") == false)
+        {
+          RSSList.firstChild.setAttribute("tooltip", "description");
+        }
+        if (RSSList.firstChild.hasAttribute("clickHeadline") == false)
+        {
+          RSSList.firstChild.setAttribute("clickHeadline", "0");
+        }
+        if (RSSList.firstChild.hasAttribute("hideOld") == false)
+        {
+          RSSList.firstChild.setAttribute("hideOld", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("sortedMenu") == false)
+        {
+          RSSList.firstChild.setAttribute("sortedMenu", "asc");
+        }
+        if (RSSList.firstChild.hasAttribute("hideHistory") == false)
+        {
+          RSSList.firstChild.setAttribute("hideHistory", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("includeAssociated") == false)
+        {
+          RSSList.firstChild.setAttribute("includeAssociated", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("cycling") == false)
+        {
+          RSSList.firstChild.setAttribute("cycling", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("cyclingDelay") == false)
+        {
+          RSSList.firstChild.setAttribute("cyclingDelay", "5");
+        }
+        if (RSSList.firstChild.hasAttribute("nextFeed") == false)
+        {
+          RSSList.firstChild.setAttribute("nextFeed", "next");
+        }
+        if (RSSList.firstChild.hasAttribute("defaultPurgeHistory") == false)
+        {
+          RSSList.firstChild.setAttribute("defaultPurgeHistory", (RSSList.firstChild.hasAttribute("purgeHistory") == true) ? RSSList.firstChild.getAttribute("purgeHistory") : "3");
+        }
+        if (RSSList.firstChild.hasAttribute("purgeHistory") == true)
+        {
+          RSSList.firstChild.removeAttribute("purgeHistory");
+        }
+        if (RSSList.firstChild.hasAttribute("fontSize") == false)
+        {
+          RSSList.firstChild.setAttribute("fontSize", "auto");
+        }
+        if (RSSList.firstChild.hasAttribute("stopscrolling") == false)
+        {
+          RSSList.firstChild.setAttribute("stopscrolling", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("cycleWithinGroup") == false)
+        {
+          RSSList.firstChild.setAttribute("cycleWithinGroup", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("defaultGroupIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("defaultGroupIcon", "chrome://inforss/skin/group.png");
+        }
+        if (RSSList.firstChild.hasAttribute("scrollingdirection") == false)
+        {
+          RSSList.firstChild.setAttribute("scrollingdirection", "rtl");
+        }
+        if (RSSList.firstChild.hasAttribute("readAllIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("readAllIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("viewAllIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("viewAllIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("shuffleIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("shuffleIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("directionIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("directionIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("scrollingIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("scrollingIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("previousIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("previousIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("pauseIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("pauseIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("nextIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("nextIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("synchronizeIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("synchronizeIcon", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("refreshIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("refreshIcon", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("hideOldIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("hideOldIcon", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("hideViewedIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("hideViewedIcon", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("homeIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("homeIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("filterIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("filterIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("popupMessage") == false)
+        {
+          RSSList.firstChild.setAttribute("popupMessage", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("playSound") == false)
+        {
+          RSSList.firstChild.setAttribute("playSound", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("flashingIcon") == false)
+        {
+          RSSList.firstChild.setAttribute("flashingIcon", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("defaultPlayPodcast") == false)
+        {
+          RSSList.firstChild.setAttribute("defaultPlayPodcast", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("displayEnclosure") == false)
+        {
+          RSSList.firstChild.setAttribute("displayEnclosure", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("displayBanned") == false)
+        {
+          RSSList.firstChild.setAttribute("displayBanned", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("savePodcastLocation") == false)
+        {
+          RSSList.firstChild.setAttribute("savePodcastLocation", "");
+        }
+        if (RSSList.firstChild.hasAttribute("defaultBrowserHistory") == false)
+        {
+          RSSList.firstChild.setAttribute("defaultBrowserHistory", "true");
+        }
+        if (RSSList.firstChild.hasAttribute("collapseBar") == false)
+        {
+          RSSList.firstChild.setAttribute("collapseBar", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("scrollingIncrement") == false)
+        {
+          RSSList.firstChild.setAttribute("scrollingIncrement", "2");
+        }
+        if (RSSList.firstChild.hasAttribute("quickFilter") == false)
+        {
+          RSSList.firstChild.setAttribute("quickFilter", "");
+        }
+        if (RSSList.firstChild.hasAttribute("quickFilterActif") == false)
+        {
+          RSSList.firstChild.setAttribute("quickFilterActif", "false");
+        }
+        if (RSSList.firstChild.hasAttribute("timeslice") == false)
+        {
+          RSSList.firstChild.setAttribute("timeslice", "90");
+        }
+        if (RSSList.firstChild.hasAttribute("mouseEvent") == false)
+        {
+          RSSList.firstChild.setAttribute("mouseEvent", "0");
+        }
+        if (RSSList.firstChild.hasAttribute("mouseWheelScroll") == false)
+        {
+          RSSList.firstChild.setAttribute("mouseWheelScroll", "pixel");
+        }
+        for (var i = 0; i < items.length; i++)
+        {
+          if (items[i].hasAttribute("group") == false)
+          {
+            items[i].setAttribute("group", "false");
+          }
+          if (items[i].hasAttribute("filter") == false)
+          {
+            items[i].setAttribute("filter", "all");
+          }
+          if (items[i].hasAttribute("nbItem") == false)
+          {
+            items[i].setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
+          }
+          if (items[i].hasAttribute("lengthItem") == false)
+          {
+            items[i].setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
+          }
+          if (items[i].hasAttribute("refresh") == false)
+          {
+            items[i].setAttribute("refresh", RSSList.firstChild.getAttribute("refresh"));
+          }
+          if (items[i].hasAttribute("type") == false)
+          {
+            items[i].setAttribute("type", "rss");
+          }
+          if (items[i].hasAttribute("filterPolicy") == false)
+          {
+            items[i].setAttribute("filterPolicy", "0");
+          }
+          if ((items[i].getAttribute("type") == "html") && (items[i].hasAttribute("htmlDirection") == false))
+          {
+            items[i].setAttribute("htmlDirection", "asc");
+          }
+          if (items[i].hasAttribute("playPodcast") == false)
+          {
+            items[i].setAttribute("playPodcast", "true");
+          }
+          if (items[i].hasAttribute("savePodcastLocation") == false)
+          {
+            items[i].setAttribute("savePodcastLocation", ((RSSList.firstChild.hasAttribute("savePodcastLocation") == false) ? "" : RSSList.firstChild.getAttribute("savePodcastLocation")));
+          }
+          if (items[i].hasAttribute("browserHistory") == false)
+          {
+            items[i].setAttribute("browserHistory", "true");
+            if ((items[i].getAttribute("url").indexOf("https://gmail.google.com/gmail/feed/atom") == 0) ||
+              (items[i].getAttribute("url").indexOf(".ebay.") != -1))
+            {
+              items[i].setAttribute("browserHistory", "false");
+            }
+          }
+          if (items[i].hasAttribute("filterCaseSensitive") == false)
+          {
+            items[i].setAttribute("filterCaseSensitive", "true");
+          }
+          if (items[i].hasAttribute("password") == true)
+          {
+            if (items[i].getAttribute("password") != "")
+            {
+              inforssXMLRepository.storePassword(items[i].getAttribute("url"),
+                items[i].getAttribute("user"),
+                items[i].getAttribute("password"));
+            }
+            items[i].removeAttribute("password");
+          }
+          if (items[i].hasAttribute("activity") == false)
+          {
+            items[i].setAttribute("activity", "true");
+          }
+          if (items[i].hasAttribute("encoding") == false)
+          {
+            items[i].setAttribute("encoding", "");
+          }
+          if ((items[i].getAttribute("type") == "group") && (items[i].hasAttribute("playlist") == false))
+          {
+            items[i].setAttribute("playlist", "false");
+          }
+          if (items[i].hasAttribute("purgeHistory") == false)
+          {
+            items[i].setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
+          }
+        }
+      }
+    }
+    var find = false;
+    for (var i = 0; i < items.length; i++)
+    {
+      if ((items[i].getAttribute("icon") == null) || (items[i].getAttribute("icon") == ""))
+      {
+        url = inforssFindIcon(items[i]);
+        if (url != null)
+        {
+          items[i].setAttribute("icon", url);
+          find = true;
+        }
+      }
+      items[i].setAttribute("groupAssociated", "false");
     }
 
-	for (var i=0; i<items.length; i++)
-	{
-	  if (items[i].getAttribute("type") == "group")
-	  {
-	    var groups = items[i].getElementsByTagName("GROUP");
-	    if (groups != null)
-	    {
-	      for (var j = 0; j < groups.length; j++)
-	      {
-	        var k = 0;
-	        var find1 = false;
-	        while ((k < items.length) && (find1 == false))
-	        {
-	          if ((items[k].getAttribute("type") != "group") && (items[k].getAttribute("url") == groups[j].getAttribute("url")))
-	          {
-	            items[k].setAttribute("groupAssociated","true");
-	            find1 = true;
-	          }
-	          else
-	          {
-	            k++;
-	          }
-	        }
-	      }
-	    }
-	  }
+    for (var i = 0; i < items.length; i++)
+    {
+      if (items[i].getAttribute("type") == "group")
+      {
+        var groups = items[i].getElementsByTagName("GROUP");
+        if (groups != null)
+        {
+          for (var j = 0; j < groups.length; j++)
+          {
+            var k = 0;
+            var find1 = false;
+            while ((k < items.length) && (find1 == false))
+            {
+              if ((items[k].getAttribute("type") != "group") && (items[k].getAttribute("url") == groups[j].getAttribute("url")))
+              {
+                items[k].setAttribute("groupAssociated", "true");
+                find1 = true;
+              }
+              else
+              {
+                k++;
+              }
+            }
+          }
+        }
+      }
     }
     if (find == true)
     {
       inforssSave();
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1011,21 +1011,21 @@ function inforssAdjustRepository()
 //-------------------------------------------------------------------------------------------------------------
 function inforssGetFile(version, source)
 {
-  var file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+  var file = file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
   file.append(INFORSS_REPOSITORY);
 
-  if ( file.exists() == false )
+  if (file.exists() == false)
   {
     inforssRestoreRepository();
     file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
     file.append(INFORSS_REPOSITORY);
   }
-  if ( file.exists() == true )
+  if (file.exists() == true)
   {
-    var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance( Components.interfaces.nsIFileInputStream );
+    var is = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance(Components.interfaces.nsIFileInputStream);
     is.init(file, 0x01, 00004, null);
-    var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance( Components.interfaces.nsIScriptableInputStream );
-    sis.init( is );
+    var sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
+    sis.init(is);
     var output = sis.read(-1);
     sis.close();
     is.close();
@@ -1057,103 +1057,102 @@ function inforssFindIcon(rss)
   var url = null;
   try
   {
-     var xmlHttpRequest = new XMLHttpRequest();
-     var error = false;
-     try
-     {
-       url = inforssGetFavicon(rss.getAttribute("link"));
-       xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-//	   xmlHttpRequest.overrideMimeType("image/ico");
-	   xmlHttpRequest.send("");
-	 }
-	 catch(e)
-	 {
-	   error = true;
-	 }
-     if ((xmlHttpRequest.status == 404) || (error == true))
-     {
-       try
-       {
-         url = url.substring(0, url.length - "/favicon.ico".length);
-         xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-	     xmlHttpRequest.overrideMimeType("application/xml");
-	     xmlHttpRequest.send("");
-         var root = url;
-         url = null;
-         var htmlStr = xmlHttpRequest.responseText;
-         var index = htmlStr.toLowerCase().indexOf("<link rel=\"shortcut icon\"");
-         if (index == -1)
-         {
-           index = htmlStr.toLowerCase().indexOf("<link rel=\"icon\"");
-         }
-         if (index != -1)
-         {
-           var index1 = htmlStr.substring(index).indexOf(">");
-           if (index1 != -1)
-           {
-             htmlStr = htmlStr.substring(index).substring(0, index1) + "/>";
-             var link = new DOMParser().parseFromString(htmlStr, "text/xml").getElementsByTagName("link").item(0);
-             if (link != null)
-             {
-               var href = link.getAttribute("href");
-               if (href.indexOf("http") == 0)
-               {
-				 url = href;
-			   }
-			   else
-			   {
-                 url = root + ((href.indexOf("/") == 0)? "" : "/") + href;
-			   }
-             }
-           }
-         }
-       }
-       catch(e)
-       {
-         url = null;
-       }
-       if (url == null)
-       {
-         xmlHttpRequest.open("GET", rss.getAttribute("url"), false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
-	     xmlHttpRequest.overrideMimeType("application/xml");
-	     xmlHttpRequest.send(null);
-         if ((xmlHttpRequest.status == 200) || (xmlHttpRequest.status == 201) ||(xmlHttpRequest.status == 202))
-         {
-           var objDoc = new DOMParser().parseFromString(xmlHttpRequest.responseText, "text/xml");
-           if (objDoc != null)
-           {
-             var channel = objDoc.getElementsByTagName("channel");
-             if ((channel != null) && (channel.length > 0))
-             {
-               var child = channel[0].firstChild;
-               var find = false;
-               while ((child != null) && (find == false))
-               {
-                 if (child.localName == "image")
-                 {
-                   find = true;
-                   url = child.getElementsByTagName("url");
-                   url = getNodeValue(url);
-                 }
-                 else
-                 {
-                   child = child.nextSibling;
-                 }
-               }
-             }
-           }
-         }
-         if (url == null)
-         {
-           url = INFORSS_DEFAULT_ICO;
-         }
-       }
-     }
-     else
-     {
-     }
+    var xmlHttpRequest = new XMLHttpRequest();
+    var error = false;
+    try
+    {
+      url = inforssGetFavicon(rss.getAttribute("link"));
+      xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
+      //	   xmlHttpRequest.overrideMimeType("image/ico");
+      xmlHttpRequest.send("");
+    }
+    catch (e)
+    {
+      error = true;
+    }
+    if ((xmlHttpRequest.status == 404) || (error == true))
+    {
+      try
+      {
+        url = url.substring(0, url.length - "/favicon.ico".length);
+        xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
+        xmlHttpRequest.overrideMimeType("application/xml");
+        xmlHttpRequest.send("");
+        var root = url;
+        url = null;
+        var htmlStr = xmlHttpRequest.responseText;
+        var index = htmlStr.toLowerCase().indexOf("<link rel=\"shortcut icon\"");
+        if (index == -1)
+        {
+          index = htmlStr.toLowerCase().indexOf("<link rel=\"icon\"");
+        }
+        if (index != -1)
+        {
+          var index1 = htmlStr.substring(index).indexOf(">");
+          if (index1 != -1)
+          {
+            htmlStr = htmlStr.substring(index).substring(0, index1) + "/>";
+            var link = new DOMParser().parseFromString(htmlStr, "text/xml").getElementsByTagName("link").item(0);
+            if (link != null)
+            {
+              var href = link.getAttribute("href");
+              if (href.indexOf("http") == 0)
+              {
+                url = href;
+              }
+              else
+              {
+                url = root + ((href.indexOf("/") == 0) ? "" : "/") + href;
+              }
+            }
+          }
+        }
+      }
+      catch (e)
+      {
+        url = null;
+      }
+      if (url == null)
+      {
+        xmlHttpRequest.open("GET", rss.getAttribute("url"), false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
+        xmlHttpRequest.overrideMimeType("application/xml");
+        xmlHttpRequest.send(null);
+        if ((xmlHttpRequest.status == 200) || (xmlHttpRequest.status == 201) || (xmlHttpRequest.status == 202))
+        {
+          var objDoc = new DOMParser().parseFromString(xmlHttpRequest.responseText, "text/xml");
+          if (objDoc != null)
+          {
+            var channel = objDoc.getElementsByTagName("channel");
+            if ((channel != null) && (channel.length > 0))
+            {
+              var child = channel[0].firstChild;
+              var find = false;
+              while ((child != null) && (find == false))
+              {
+                if (child.localName == "image")
+                {
+                  find = true;
+                  url = child.getElementsByTagName("url");
+                  url = getNodeValue(url);
+                }
+                else
+                {
+                  child = child.nextSibling;
+                }
+              }
+            }
+          }
+        }
+        if (url == null)
+        {
+          url = INFORSS_DEFAULT_ICO;
+        }
+      }
+    }
+    else
+    {}
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
     url = INFORSS_DEFAULT_ICO;
@@ -1164,24 +1163,24 @@ function inforssFindIcon(rss)
 //-------------------------------------------------------------------------------------------------------------
 function inforssGetFavicon(link)
 {
-  var re = new RegExp (' ', 'gi') ;
+  var re = new RegExp(' ', 'gi');
   link = link.replace(re, '');
   if (link.indexOf("http://") == 0)
   {
-    var index = link.indexOf("/",7);
+    var index = link.indexOf("/", 7);
     if (index != -1)
     {
-      link = link.substring(0,index);
+      link = link.substring(0, index);
     }
   }
   else
   {
     if (link.indexOf("https://") == 0)
     {
-      var index = link.indexOf("/",8);
+      var index = link.indexOf("/", 8);
       if (index != -1)
       {
-        link = link.substring(0,index);
+        link = link.substring(0, index);
       }
     }
     else
@@ -1189,7 +1188,7 @@ function inforssGetFavicon(link)
       var index = link.indexOf("/");
       if (index != -1)
       {
-        link = link.substring(0,index);
+        link = link.substring(0, index);
       }
       link = "http://" + link;
     }
@@ -1206,7 +1205,7 @@ function inforssGetFormat(objDoc)
   {
     if ((objDoc != null) && (objDoc.childNodes.length > 0))
     {
-      var i=0;
+      var i = 0;
       var nodeName = null;
       while ((i < objDoc.childNodes.length) && (format == null))
       {
@@ -1214,7 +1213,7 @@ function inforssGetFormat(objDoc)
         var index = nodeName.indexOf(":");
         if (index != -1)
         {
-          nodeName = nodeName.substring(index+1);
+          nodeName = nodeName.substring(index + 1);
         }
         if ((nodeName == "feed") || (nodeName == "rdf") || (nodeName == "rss") || (nodeName == "opml"))
         {
@@ -1227,7 +1226,7 @@ function inforssGetFormat(objDoc)
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1246,9 +1245,9 @@ function inforssCopyRemoteToLocal(protocol, server, directory, user, password, f
   {
     directory = directory + "/";
   }
-  var ioService  = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
+  var ioService = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
   var path = protocol + user + ":" + password + "@" + server + directory;
-  var uri = ioService.newURI(path + "inforss.xml","UTF-8", null);
+  var uri = ioService.newURI(path + "inforss.xml", "UTF-8", null);
   gInforssFTPDownload = new inforssFTPDownload();
 
   if (typeof setImportProgressionBar != "undefined")
@@ -1285,7 +1284,7 @@ function inforssCopyRemoteToLocalCallback(step, status, path, callbackOriginal)
         callbackOriginal(step, status);
       }
       else
-      { 
+      {
         var str = gInforssFTPDownload.data;
 
         if (str.length > 0)
@@ -1295,8 +1294,8 @@ function inforssCopyRemoteToLocalCallback(step, status, path, callbackOriginal)
         }
         RSSList = new DOMParser().parseFromString(str, "text/xml");
         inforssSave();
-        var ioService  = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
-        var uri = ioService.newURI( path + "inforss.rdf","UTF-8", null);
+        var ioService = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
+        var uri = ioService.newURI(path + "inforss.rdf", "UTF-8", null);
         if (typeof setImportProgressionBar != "undefined")
         {
           setImportProgressionBar(50);
@@ -1305,7 +1304,7 @@ function inforssCopyRemoteToLocalCallback(step, status, path, callbackOriginal)
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
     callbackOriginal(-1, null);
@@ -1346,15 +1345,15 @@ function inforssCopyRemoteToLocal1Callback(step, status, path, callbackOriginal)
         inforssRDFRepository.saveRDFFromString(str);
         var notifier = new inforssNotifier();
         notifier.notify("chrome://global/skin/icons/alert-exclam.png",
-                        document.getElementById("bundle_inforss").getString("inforss.synchronization"),
-                        document.getElementById("bundle_inforss").getString("inforss.remote.success"),
-                        INFORSS_NULL_URL);
+          document.getElementById("bundle_inforss").getString("inforss.synchronization"),
+          document.getElementById("bundle_inforss").getString("inforss.remote.success"),
+          INFORSS_NULL_URL);
       }
       callbackOriginal(step, status);
       gInforssFTPDownload = null;
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1379,16 +1378,16 @@ function inforssCopyLocalToRemote(protocol, server, directory, user, password, f
     {
       directory = directory + "/";
     }
-    var ioService  = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
+    var ioService = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
     var path = protocol + user + ":" + password + "@" + server + directory;
-    var uri = ioService.newURI( path + "inforss.xml","UTF-8", null);
+    var uri = ioService.newURI(path + "inforss.xml", "UTF-8", null);
     if (typeof setImportProgressionBar != "undefined")
     {
       setImportProgressionBar(40);
     }
     inforssFTPUpload.start(str, uri, contentType, path, inforssCopyLocalToRemoteCallback, ftpUploadCallback, asyncFlag);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1429,13 +1428,13 @@ function inforssCopyLocalToRemoteCallback(step, status, path, callbackOriginal, 
         var contentType = "application/octet-stream";
         contentType = "text/xml; charset=UTF-8";
 
-        var ioService  = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
-        var uri = ioService.newURI( path + "inforss.rdf","UTF-8", null);
+        var ioService = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
+        var uri = ioService.newURI(path + "inforss.rdf", "UTF-8", null);
         inforssFTPUpload.start(str, uri, contentType, path, inforssCopyLocalToRemote1Callback, callbackOriginal, asyncFlag);
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
     if (callbackOriginal != null)
@@ -1455,10 +1454,10 @@ function inforssCopyLocalToRemote1Callback(step, status, path, callbackOriginal,
   {
     if (step != "send")
     {
-        if (typeof setImportProgressionBar != "undefined")
-        {
-          setImportProgressionBar(80);
-        }
+      if (typeof setImportProgressionBar != "undefined")
+      {
+        setImportProgressionBar(80);
+      }
       if (asyncFlag == true)
       {
         if (status != 0)
@@ -1469,9 +1468,9 @@ function inforssCopyLocalToRemote1Callback(step, status, path, callbackOriginal,
         {
           var notifier = new inforssNotifier();
           notifier.notify("chrome://global/skin/icons/alert-exclam.png",
-                          document.getElementById("bundle_inforss").getString("inforss.synchronization"),
-                          document.getElementById("bundle_inforss").getString("inforss.remote.success"),
-                          "http://inforss.mozdev.org");
+            document.getElementById("bundle_inforss").getString("inforss.synchronization"),
+            document.getElementById("bundle_inforss").getString("inforss.remote.success"),
+            "http://inforss.mozdev.org");
         }
       }
       if (callbackOriginal != null)
@@ -1480,7 +1479,7 @@ function inforssCopyLocalToRemote1Callback(step, status, path, callbackOriginal,
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -1488,19 +1487,18 @@ function inforssCopyLocalToRemote1Callback(step, status, path, callbackOriginal,
 }
 
 //-------------------------------------------------------------------------------------------------------------
-var inforssFTPUpload =
-{
-  _channel : null,
-  _callback : null,
-  _callbackOriginal : null,
-  _data : "",
-  _scheme : "",
-  _errorData : "",
-  _path : null,
-  _inputStream : null,
-  _asyncFlag : null,
+var inforssFTPUpload = {
+  _channel: null,
+  _callback: null,
+  _callbackOriginal: null,
+  _data: "",
+  _scheme: "",
+  _errorData: "",
+  _path: null,
+  _inputStream: null,
+  _asyncFlag: null,
 
-  start : function(text, url, contentType, path, callback, callbackOriginal, asyncFlag)
+  start: function(text, url, contentType, path, callback, callbackOriginal, asyncFlag)
   {
     var returnValue = false;
     try
@@ -1511,13 +1509,13 @@ var inforssFTPUpload =
       this._path = path;
       this._scheme = url.scheme;
       var ioService = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
-//      this._channel = ioService.newChannelFromURI(url).QueryInterface(Components.interfaces.nsIUploadChannel);
+      //      this._channel = ioService.newChannelFromURI(url).QueryInterface(Components.interfaces.nsIUploadChannel);
       var channel = ioService.newChannelFromURI(url).QueryInterface(Components.interfaces.nsIUploadChannel);
-      this._inputStream = Components.classes["@mozilla.org/io/string-input-stream;1"].createInstance(Components.interfaces.nsIStringInputStream) ;
+      this._inputStream = Components.classes["@mozilla.org/io/string-input-stream;1"].createInstance(Components.interfaces.nsIStringInputStream);
 
       var unicodeConverter = Components.classes["@mozilla.org/intl/scriptableunicodeconverter"].createInstance(Components.interfaces.nsIScriptableUnicodeConverter);
       unicodeConverter.charset = "UTF-8";
-      text = unicodeConverter.ConvertFromUnicode( text ) + unicodeConverter.Finish();
+      text = unicodeConverter.ConvertFromUnicode(text) + unicodeConverter.Finish();
 
       this._inputStream.setData(text, -1);
       channel.setUploadStream(this._inputStream, contentType, -1);
@@ -1535,18 +1533,16 @@ var inforssFTPUpload =
       this._data = text;
       returnValue = true;
     }
-    catch(e)
+    catch (e)
     {
       inforssDebug(e);
     }
     return returnValue;
   },
 
-  cancel : function()
-  {
-  },
+  cancel: function() {},
 
-  onDataAvailable : function (channel, ctxt, input, sourceOffset, count)
+  onDataAvailable: function(channel, ctxt, input, sourceOffset, count)
   {
     const sis = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
     sis.init(input);
@@ -1554,33 +1550,31 @@ var inforssFTPUpload =
     this._inputStream.close();
   },
 
-  onStartRequest: function (channel, ctxt)
-  {
-  },
+  onStartRequest: function(channel, ctxt) {},
 
-  onStopRequest: function (channel, ctxt, status)
+  onStopRequest: function(channel, ctxt, status)
   {
     try
     {
-      if(this._scheme != "ftp")
+      if (this._scheme != "ftp")
       {
         var res = 0;
         try
         {
           res = channel.QueryInterface(Components.interfaces.nsIHttpChannel).responseStatus;
         }
-        catch(e)
+        catch (e)
         {}
         if ((res == 200) || (res == 201) || (res == 204))
         {
           status = 0;
         }
-      /*
-        200:OK
-        201:Created
-        204:No Content
-        This is an uploading channel, no need to "GET" the file contents.
-      */
+        /*
+          200:OK
+          201:Created
+          204:No Content
+          This is an uploading channel, no need to "GET" the file contents.
+        */
         if (this._errorData)
         {
           status = res;
@@ -1599,7 +1593,7 @@ var inforssFTPUpload =
         this._callback("done", status, this._path, this._callbackOriginal, this._asyncFlag);
       }
     }
-    catch(e)
+    catch (e)
     {
       inforssDebug(e);
     }
@@ -1612,20 +1606,19 @@ function inforssFTPDownload()
   return this;
 }
 
-inforssFTPDownload.prototype =
-{
-  _channel : null,
-  streamLoader : null,
-  data : null,
-  length : null,
+inforssFTPDownload.prototype = {
+  _channel: null,
+  streamLoader: null,
+  data: null,
+  length: null,
 
-  _path : null,
-  _callback : null,
-  _startTime : 0,
-  _endTime : 0,
-  _callbackOriginal : null,
+  _path: null,
+  _callback: null,
+  _startTime: 0,
+  _endTime: 0,
+  _callbackOriginal: null,
 
-  start : function(url, path, callback, callbackOriginal)
+  start: function(url, path, callback, callbackOriginal)
   {
     this._callback = callback;
     this._callbackOriginal = callbackOriginal;
@@ -1633,19 +1626,19 @@ inforssFTPDownload.prototype =
     var returnValue = true;
     try
     {
-      var appInfo = Components.classes["@mozilla.org/xre/app-info;1"].getService(Components.interfaces.nsIXULAppInfo); 
-      var isOnBranch = appInfo.platformVersion.indexOf("1.8") == 0; 	
-      var ioService  = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
+      var appInfo = Components.classes["@mozilla.org/xre/app-info;1"].getService(Components.interfaces.nsIXULAppInfo);
+      var isOnBranch = appInfo.platformVersion.indexOf("1.8") == 0;
+      var ioService = Components.classes["@mozilla.org/network/io-service;1"].getService(Components.interfaces.nsIIOService);
       this.streamLoader = Components.classes["@mozilla.org/network/stream-loader;1"].createInstance(Components.interfaces.nsIStreamLoader);
       this._channel = ioService.newChannelFromURI(url);
-      if (isOnBranch) 
-      { 
-        this.streamLoader.init(this._channel, this , null);
-      } 
-      else 
-      { 
-        this.streamLoader.init(this); 
-        this._channel.asyncOpen(this.streamLoader, this._channel); 
+      if (isOnBranch)
+      {
+        this.streamLoader.init(this._channel, this, null);
+      }
+      else
+      {
+        this.streamLoader.init(this);
+        this._channel.asyncOpen(this.streamLoader, this._channel);
       }
       this._startTime = new Date().getTime();
       this._callback("send", null, path, callbackOriginal);
@@ -1654,7 +1647,7 @@ inforssFTPDownload.prototype =
         setImportProgressionBar(30);
       }
     }
-    catch(e)
+    catch (e)
     {
       inforssDebug(e);
       returnValue = false;
@@ -1662,7 +1655,7 @@ inforssFTPDownload.prototype =
     return returnValue;
   },
 
-  cancel : function()
+  cancel: function()
   {
     if (this._channel)
     {
@@ -1670,7 +1663,7 @@ inforssFTPDownload.prototype =
     }
   },
 
-  onStreamComplete : function ( loader , ctxt , status , resultLength , result )
+  onStreamComplete: function(loader, ctxt, status, resultLength, result)
   {
     this.data = "";
     this._endTime = new Date().getTime();
@@ -1683,11 +1676,11 @@ inforssFTPDownload.prototype =
       }
       else
       {
-        while (result.length > (256*192) )
+        while (result.length > (256 * 192))
         {
-          this.data += String.fromCharCode.apply(this,result.splice(0,256*192));
+          this.data += String.fromCharCode.apply(this, result.splice(0, 256 * 192));
         }
-        this.data += String.fromCharCode.apply(this,result);
+        this.data += String.fromCharCode.apply(this, result);
       }
     }
 
@@ -1698,6 +1691,3 @@ inforssFTPDownload.prototype =
   },
 
 };
-
-
-

--- a/content/inforss/inforssOpml.js
+++ b/content/inforss/inforssOpml.js
@@ -245,7 +245,6 @@ function importOpml(mode, from)
         gRssXmlHttpRequest.open("GET", url, false);
         gRssXmlHttpRequest.onload = null;
         gRssXmlHttpRequest.onerror = null;
-        gRssXmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
         try
         {
           gRssXmlHttpRequest.send(null);

--- a/content/inforss/inforssOption.js
+++ b/content/inforss/inforssOption.js
@@ -299,20 +299,6 @@ const INFORSS_DEFAULT_GROUP_ICON = "chrome://inforss/skin/group.png";
 
      for (var i=0; i < items.length; i++)
      {
-/*         element = document.createElement("menuitem");
-
-         element.setAttribute("label", items[i].getAttribute("title"));
-
-         element.setAttribute("value", items[i].getAttribute("title"));
-
-
-         element.setAttribute("tooltiptext",items[i].getAttribute("description"));
-         element.setAttribute("image",items[i].getAttribute("icon"));
-         element.setAttribute("validate", "never");
-         element.setAttribute("id","rss-" + i);
-
-         element.setAttribute("class", "menuitem-iconic");
-*/
        var find = false;
        var j = 0;
        var menuItem = null;
@@ -333,12 +319,10 @@ const INFORSS_DEFAULT_GROUP_ICON = "chrome://inforss/skin/group.png";
        if (find == false)
        {
          element = menu.appendItem(items[i].getAttribute("title"), "rss_" + i);
-//         menupopup.appendChild(element);
        }
        else
        {
          element = menu.insertItemAt(j, items[i].getAttribute("title"), "rss_" + i);
-//         menupopup.insertBefore(element, menuItem);
          if (pos != -1)
          {
            if (j <= pos)
@@ -357,7 +341,6 @@ const INFORSS_DEFAULT_GROUP_ICON = "chrome://inforss/skin/group.png";
        gNbRss++;
        element.setAttribute("url", items[i].getAttribute("url"));
        element.setAttribute("user", items[i].getAttribute("user"));
-//       element.setAttribute("password", items[i].getAttribute("password"));
        if ((pos == -1) && (items[i].getAttribute("selected") == "true"))
        {
          selectedIndex = i;
@@ -377,7 +360,6 @@ const INFORSS_DEFAULT_GROUP_ICON = "chrome://inforss/skin/group.png";
      document.getElementById("inforss.current.feed").setAttribute("value", theCurrentFeed.getTitle());
      document.getElementById("inforss.current.feed").setAttribute("tooltiptext", theCurrentFeed.getTitle());
 
-//alert(pos);
      if ((pos == -1) && (items.length > 0))
      {
        selectedIndex = 0;
@@ -425,7 +407,6 @@ const INFORSS_DEFAULT_GROUP_ICON = "chrome://inforss/skin/group.png";
        document.getElementById("inforss.location4").appendChild(linetext);
 
        var cancel = document.getElementById('inforssOption').getButton("cancel");
-//       var but = cancel.cloneNode(true);
        var apply = document.getElementById('inforssOption').getButton("extra1");
        apply.parentNode.removeChild(apply);
        apply.label=document.getElementById("bundle_inforss").getString("inforss.apply");
@@ -469,14 +450,7 @@ const INFORSS_DEFAULT_GROUP_ICON = "chrome://inforss/skin/group.png";
            document.getElementById("rss.filter.hlnumber").appendItem(i, i);
          }
        }
-//       document.getElementById("inforss.rss.fetch").style.visibility = "hidden";
      }
-//     else
-//     {
-//       element = document.getElementById("select-folder").firstChild;
-//       document.getElementById("select-menu").selectedItem = element;
-//       selectRSS1(element.getAttribute("url"));
-//     }
    }
    catch (e)
    {
@@ -606,14 +580,11 @@ function updateReport()
       	   var treechildren = document.createElement("treechildren");
       	   treeitem.appendChild(treechildren);
       	   var selectedList = items[i].getElementsByTagName("GROUP");
-//alert("length=" + selectedList.length + "\n");
 		   for (var j = 0; j < selectedList.length; j++)
 		   {
-//alert(selectedList[j].getAttribute("url"));
     	     originalFeed = gInforssMediator.locateFeed(selectedList[j].getAttribute("url"));
     	     if (originalFeed != null)
     	     {
-//inforssInspect(originalFeed);
     	       originalFeed = originalFeed.info;
       	       treeitem = document.createElement("treeitem");
                treeitem.setAttribute("title", originalFeed.feedXML.getAttribute("title"));
@@ -621,7 +592,6 @@ function updateReport()
 		       treeitem.appendChild(treerow);
 		       treerow.setAttribute("properties","rss");
                treerow.setAttribute("url", selectedList[j].getAttribute("url"));
-//dump("url=" + selectedList[j].getAttribute("url") + "\n");
                var rss1 = inforssGetItemFromUrl(selectedList[j].getAttribute("url"));
       	       addCell(originalFeed.feedXML.getAttribute("icon"), treerow, "icon", "image");
       	       addCell("", treerow, (rss1.getAttribute("activity") == "true")? "on" : "off");
@@ -674,30 +644,18 @@ function addRssToVbox(rss)
   var count = listbox.childNodes.length;
 
   var listitem = document.createElement("listitem");
-//  listitem.setAttribute("value", rss.getAttribute("title"));
-//  listitem.setAttribute("url", rss.getAttribute("url"));
-//  listitem.setAttribute("flex","1");
   var listcell = document.createElement("listcell");
-//  listitem.setAttribute("flex", "1");
   listcell.setAttribute("type", "checkbox");
-//  listcell.setAttribute("flex", "0");
 
   listcell.addEventListener("click", function(event) { var lc = event.currentTarget; if (lc.getAttribute("checked") == "false") { lc.setAttribute("checked", "true") } else { lc.setAttribute("checked", "false"); }}, false);
-//  listcell.style.maxWidth = "18px";
-//  listcell.style.borderStyle = "solid";
-//  listcell.style.borderWidth="1px";
   listitem.appendChild(listcell);
   
   listcell = document.createElement("listcell");
   listcell.setAttribute("class", "listcell-iconic");
   listcell.setAttribute("image", rss.getAttribute("icon"));
-//  listcell.setAttribute("image", "chrome://inforss/skin/inforss.png");
   listcell.setAttribute("value", rss.getAttribute("title"));
   listcell.setAttribute("label", rss.getAttribute("title"));
   listcell.setAttribute("url", rss.getAttribute("url"));
-//  listcell.style.borderStyle = "solid";
-//  listcell.style.borderWidth="1px";
-//  listcell.setAttribute("flex", "1");
   listitem.appendChild(listcell);
   window.setTimeout(resizeImage, (1000 + 10 * count), listcell, rss.getAttribute("icon"));
   
@@ -729,22 +687,6 @@ function addRssToVbox(rss)
     listbox.insertBefore(listitem, listbox.childNodes[j]);
   }
 
-/*
-  var checkbox = document.createElement("checkbox");
-  hbox.appendChild(checkbox);
-  var image = document.createElement("image");
-  image.setAttribute("src", rss.getAttribute("icon"));
-  image.setAttribute("maxheight", "16");
-  image.setAttribute("maxwidth", "16");
-  image.style.maxWidth = "16px";
-  image.style.maxHeight = "16px";
-  hbox.appendChild(image);
-  var label = document.createElement("label");
-  label.setAttribute("value", rss.getAttribute("title"));
-  label.setAttribute("url", rss.getAttribute("url"));
-  hbox.appendChild(label);
-*/
-  
   list = document.getElementById("inforss.apply.list");
   var count = (list.firstChild == null)? 0 : list.childNodes.length;
 
@@ -780,23 +722,6 @@ function addRssToVbox(rss)
   }
 
   window.setTimeout(resizeImage, (1000 + 10 * count), listitem, rss.getAttribute("icon"));
-/*  var subElement = document.getAnonymousNodes(listitem);
-  var i = 0;
-  while ((i < 20) && (subElement == null))
-  {
-	subElement = document.getAnonymousNodes(listitem);
-	i++;
-  }
-  if (subElement != null)
-  {
-    var subElement1 = document.getAnonymousNodes(subElement[0]);
-    if (subElement1 != null)
-    {
-      subElement1[0].style.maxWidth = "16px";
-      subElement1[0].style.maxHeight = "16px";
-    }
-  }
-  else alert(rss.getAttribute("title"));*/
 }
 
 
@@ -812,21 +737,15 @@ function resizeImage(listitem, url)
   }
   if (subElement != null)
   {
-//alert(subElement[0].nodeName);
-//alert(subElement[0].nodeName);
-//inforssInspect(subElement[0]);
     var subElement1 = document.getAnonymousNodes(subElement[0]);
     if (subElement1 != null)
     {
-//dump("nodeName=" + subElement1[0].nodeName + "\n");
-//dump("url=" + url + "\n");
       subElement1[0].style.maxWidth = "16px";
       subElement1[0].style.width = "16px";
       subElement1[0].style.maxHeight = "16px";
       subElement1[0].style.height = "16px";
       subElement1[0].setAttribute("width", "16");
       subElement1[0].setAttribute("height", "16");
-//      listitem.setAttribute("image", url);
     }
     else
     {
@@ -841,7 +760,6 @@ function resizeImage(listitem, url)
       }
     }
   }
-  else alert(rss.getAttribute("title"));
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -855,7 +773,6 @@ function checkRssList()
 
     if ((subElement != null) && (subElement.length > 0) && (subElement[0] != null) && (subElement[0].firstChild != null) && (subElement[0].firstChild.localName =="image"))
     {
-//		alert(subElement[0].firstChild.getAttribute("class"));
       subElement[0].firstChild.setAttribute("maxwidth","16");
       subElement[0].firstChild.setAttribute("maxheight","16");
       subElement[0].firstChild.setAttribute("minwidth","16");
@@ -929,7 +846,6 @@ function changeColor(arg)
     font = "inherit";
   }
   document.getElementById("sample").style.fontFamily = font;
-//alert(document.getElementById("fresh-font").value);
   sample.style.fontWeight = (document.getElementById("inforss.bold").getAttribute("checked") == "true")? "bolder" : "inherit";
   sample.style.fontStyle = (document.getElementById("inforss.italic").getAttribute("checked") == "true")? "italic" : "inherit";
 
@@ -1044,15 +960,7 @@ function _apply()
     {
       inforssSave();
       var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-//      if (makeCurrentInvoked == false)
-//      {
         observerService.notifyObservers(null,"reload", gRemovedUrl);
-//      }
-//      else
-//      {
-//        observerService.notifyObservers(null,"rssChanged", "");
-//      }
-//      makeCurrentInvoked = false;
       returnValue = true;
     }
   }
@@ -1101,7 +1009,6 @@ function storeValue()
              rss.setAttribute("browserHistory", (document.getElementById('browserHistory').selectedIndex == 0)? "true" : "false");
              rss.setAttribute("filterCaseSensitive", (document.getElementById('filterCaseSensitive').selectedIndex == 0)? "true" : "false");
              rss.setAttribute("purgeHistory", document.getElementById('purgeHistory').value);
-//             rss.setAttribute("activity", "true");
              break;
            }
            case "group":
@@ -1114,7 +1021,6 @@ function storeValue()
              rss.setAttribute("filterCaseSensitive", (document.getElementById('filterCaseSensitive').selectedIndex == 0)? "true" : "false");
              rss.setAttribute("filter", ((document.getElementById("inforss.filter.anyall").selectedIndex == 0)? "all" : "any"));
              rss.setAttribute("playlist", (document.getElementById('playlistoption').selectedIndex == 0)? "true" : "false");
-//             rss.setAttribute("activity", "true");
              var child = rss.firstChild;
              var next = null;
              while (child != null)
@@ -1126,7 +1032,6 @@ function storeValue()
                }
                child = next;
              }
-//alert("storeValue group\n");
              var listbox = document.getElementById("group-list-rss");
              var listitem = null;
              var checkbox = null;
@@ -1136,10 +1041,8 @@ function storeValue()
                listitem = listbox.childNodes[i];
                checkbox = listitem.childNodes[0];
                label = listitem.childNodes[1];
-//alert("storeValue label=" + label.getAttribute("value") + "\n");
                if (checkbox.getAttribute("checked") == "true")
                {
-// dump("storeValue checked\n");
                  var child = rss.parentNode.parentNode.createElement("GROUP");
                  child.setAttribute("url",label.getAttribute("url"));
                  rss.appendChild(child);
@@ -1164,8 +1067,6 @@ function storeValue()
                  playLists.appendChild(playList);
                  playList.setAttribute("url", richListItem.getAttribute("url"));
                  playList.setAttribute("delay", richListItem.firstChild.firstChild.value);
-//alert(playList.getAttribute("url"));
-//alert(playList.getAttribute("delay"));
                }
              }
              break;
@@ -1175,16 +1076,13 @@ function storeValue()
          var next = null;
          while (child != null)
          {
-//alert("storeValue loop filter " + child.nodeName + "\n");
            next = child.nextSibling;
            if (child.nodeName.indexOf("FILTER") != -1)
            {
              rss.removeChild(child);
-//alert("remove filter\n");
            }
            child = next;
          }
-//alert(rss.getAttribute("url"));
          var vbox = document.getElementById("inforss.filter.vbox");
          var hbox = vbox.childNodes[3]; // first filter
          while (hbox != null)
@@ -1202,7 +1100,6 @@ function storeValue()
            filter.setAttribute("unit", deck.childNodes[1].childNodes[2].selectedIndex);
            filter.setAttribute("hlcompare", deck.childNodes[2].childNodes[0].selectedIndex);
            filter.setAttribute("nb", deck.childNodes[2].childNodes[1].selectedIndex);
-//alert(rss.parentNode.parentNode);
            rss.appendChild(filter);
            hbox = hbox.nextSibling;
          }
@@ -1320,12 +1217,10 @@ function updateGroup(oldUrl, newUrl)
       if (items[i].getAttribute("type") == "group")
       {
       	var groupList = items[i].getElementsByTagName("GROUP");
-//alert("length=" + selectedList.length + "\n");
 	    for (var j = 0; j < groupList.length; j++)
 	    {
           if (groupList[j].getAttribute("url") == oldUrl)
           {
-//alert("modif:" + oldUrl + " " + newUrl);
             groupList[j].setAttribute("url", newUrl);
           }
         }
@@ -1793,8 +1688,6 @@ function newRss(type)
             gRssXmlHttpRequest.user = user;
             gRssXmlHttpRequest.title = title;
             gRssXmlHttpRequest.password = password;
-//alert("foo pass=" + password);
-            gRssXmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
             document.getElementById("inforss.new.feed").setAttribute("disabled","true");
             if ((type == "rss") || (type == "twitter")) // rss
             {
@@ -1842,28 +1735,6 @@ function newNntp(type)
   try
   {
     var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
-//    var url1 = { value: "news://news."};
-//    var passwdChkbox = { value: false };
-//    var user = { value: "" };
-//    var passwd = { value: "" };
-//    var valid  = promptService.prompt(window, document.getElementById("bundle_inforss").getString("inforss.new.nntp"),
-//                          document.getElementById("bundle_inforss").getString("inforss.add.nntp"),
-//                          url1, document.getElementById("bundle_inforss").getString("inforss.add.nntp.password"), passwdChkbox);
-//    var url = url1.value;
-//    if ((valid == true) && (url != null) && (url != ""))
-//    {
-//      var error = false;
-//      if (passwdChkbox.value == true)
-//      {
-//        getFlag = promptService.promptUsernameAndPassword(window, null , document.getElementById("bundle_inforss").getString("inforss.account") + " " + url , user  , passwd  , null , { value: false });
-//        if ((user.value == null) || (user.value == "") || (passwd.value == null) || (passwd.value == ""))
-//        {
-//          alert(document.getElementById("bundle_inforss").getString("inforss.nntp.usermandatory"));
-//          error = true;
-//        }
-//      }
-//      if (error == false)
-//      {
         if (nameAlreadyExists(type.url) == true)
         {
           alert(document.getElementById("bundle_inforss").getString("inforss.nntp.alreadyexists"));
@@ -1932,8 +1803,6 @@ function newNntp(type)
             document.getElementById("inforss.group.treecell5").setAttribute("label", ""); 
           }
         }
-//      }
-//    }
   }
   catch (e)
   {
@@ -1947,7 +1816,6 @@ function testValidNntpUrl(url, user, passwd)
   var returnValue = {valid: false};
   try
   {
-//alert(url);
     if ((url.indexOf("news://") == 0) && (url.lastIndexOf("/") > 7))
     {
       var newsHost = url.substring(7, url.lastIndexOf("/"));
@@ -1963,7 +1831,6 @@ function testValidNntpUrl(url, user, passwd)
           pump = Components.classes["@mozilla.org/network/input-stream-pump;1"].createInstance(Components.interfaces.nsIInputStreamPump);
           pump.init(instream, -1, -1, 0, 0, false);
           var res = data.split(" ");
-// dump("res=" + res[0] + "\n");
           if (res.length > 0)
           {
             switch (res[0])
@@ -2086,10 +1953,8 @@ function selectRSS(menuitem)
 {
   try
   {
-//    document.getElementById("categoryDeck").selectedIndex = 1;
     if ((currentRSS == null) || (validDialog() == true))
     {
-//      window.setTimeout("selectRSS1('" + menuitem.getAttribute("url") + "','" + menuitem.getAttribute("user") + "')", 0);
       selectRSS1(menuitem.getAttribute("url"), menuitem.getAttribute("user"));
       gOldRssIndex = document.getElementById("rss-select-menu").selectedIndex;
     }
@@ -2229,7 +2094,6 @@ function selectRSS1(url, user)
 {
   try
   {
-//dump("selectRSS1 start " + url + "\n");
     var password = inforssXMLRepository.readPassword(url, user);
     document.getElementById("inforss.previous.rss").setAttribute("disabled","true");
     document.getElementById("inforss.next.rss").setAttribute("disabled","true");
@@ -2264,7 +2128,6 @@ function selectRSS1(url, user)
       gRssXmlHttpRequest.open("GET", url, true, user, password);
       gRssXmlHttpRequest.onload = processCategories;
       gRssXmlHttpRequest.onerror = rssCategoryTimeout;
-      gRssXmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
       gRssXmlHttpRequest.overrideMimeType("application/xml");
       gRssXmlHttpRequest.send(null);
     }
@@ -2281,8 +2144,6 @@ function selectRSS1(url, user)
   {
     inforssDebug(e);
   }
-//dump("selectRSS1 end " + url + "\n");
-//  document.getElementById("categoryDeck").selectedIndex = 0;
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -2290,7 +2151,6 @@ function selectRSS2(rss)
 {
   try
   {
-//dump("selectRSS1 start " + url + "\n");
     var url = rss.getAttribute("url");
     switch (rss.getAttribute("type"))
     {
@@ -2300,7 +2160,6 @@ function selectRSS2(rss)
       case "nntp":
       case "twitter":  
       {
-//        netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
         var br = document.getElementById("inforss.canvas.browser");
         br.setAttribute("collapsed", "false");
 
@@ -2379,16 +2238,7 @@ function selectRSS2(rss)
         document.getElementById("filterCaseSensitive").selectedIndex = (filterCaseSensitive == "true")? 0 : 1;
         document.getElementById("purgeHistory").value = rss.getAttribute("purgeHistory"); 
 
-/*        var tree = document.getElementById("inforss.tree.feed");
-        while (tree.firstChild != null)
-        {
-    	  tree.removeChild(tree.firstChild);
-    	}
-    	var treeitem = document.createElement("treeitem");
-    	tree.appendChild(treeitem);
-    	var treerow = document.createElement("treerow");
-    	treeitem.appendChild(treerow);
-*/    	var originalFeed = gInforssMediator.locateFeed(url);
+    	var originalFeed = gInforssMediator.locateFeed(url);
     	if (originalFeed != null)
     	{
     	  originalFeed = originalFeed.info;
@@ -2514,8 +2364,6 @@ function selectFeedReport(tree, event)
         var cell = row.firstChild;
         var treecols = tree.getElementsByTagName("treecols").item(0);
         var cell1 = treecols.firstChild;
-//    var i = 0;
-//    alert(cell1.getAttribute("id"));
         while (cell1.getAttribute("id").indexOf(".report.activity") == -1)
         {
 	      cell1 = cell1.nextSibling;
@@ -2523,13 +2371,9 @@ function selectFeedReport(tree, event)
 	      {
 	        cell = cell.nextSibling;
           }
-//	  i++;
-//      alert(cell1.getAttribute("id"));
 	    }
-//	alert(i);
         cell.setAttribute("properties",(cell.getAttribute("properties").indexOf("on") != -1)? "off" : "on");
         var rss = inforssGetItemFromUrl(cell.parentNode.getAttribute("url"));
-//alert(cell.parentNode.getAttribute("url"));
         rss.setAttribute("activity", (rss.getAttribute("activity") == "true")? "false" : "true");
         if (tree.getAttribute("id") != "inforss.tree3")
         {
@@ -2714,7 +2558,6 @@ function processRss()
     {
     	inforssXMLRepository.storePassword(gRssXmlHttpRequest.url, gRssXmlHttpRequest.user, gRssXmlHttpRequest.password);
     }
-//    rss.setAttribute("password", gRssXmlHttpRequest.password);
     rss.setAttribute("filter","all");
     rss.setAttribute("filterCaseSensitive","true");
     rss.setAttribute("activity", "true");
@@ -3032,8 +2875,6 @@ function exportLivemark()
 
     BMDS  = RDF.GetDataSource("rdf:bookmarks");
     BMSVC = BMDS.QueryInterface(Components.interfaces.nsIBookmarksService);
-//    BookmarkTransaction.prototype.RDFC = RDFC;
-//    BookmarkTransaction.prototype.BMDS = BMDS;
 
     RDFCU            = Components.classes["@mozilla.org/rdf/container-utils;1"].getService(Components.interfaces.nsIRDFContainerUtils);
 
@@ -3091,7 +2932,6 @@ function exportBrowser()
     var topMostBrowser = getTopMostBrowser();
     if (topMostBrowser != null)
     {
-//      netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
       var file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
       file.append(INFORSS_REPOSITORY);
       if ( file.exists() == true )
@@ -3317,7 +3157,6 @@ function setIcon()
 //-----------------------------------------------------------------------------------------------------
 function updateCanvas()
 {
-//dump("updateCanvas\n");
   inforssTraceIn();
   try
   {
@@ -3346,7 +3185,6 @@ function updateCanvas()
 //-----------------------------------------------------------------------------------------------------
 function canvasOver(event)
 {
-//dump("canvasOver\n");
   inforssTraceIn();
   try
   {
@@ -3354,9 +3192,6 @@ function canvasOver(event)
     var canvas = document.getElementById("inforss.magnify.canvas");
     var newx = eval(event.clientX - canvas1.offsetLeft) + 12;
     var newy = eval(event.clientY - canvas1.offsetTop) + 18;
-//dump("1=" + newx + "\n");
-//dump("2=" + parseInt(canvas1.style.width) + "\n");
-//dump("3=" + parseInt(canvas.getAttribute("width")) + "\n");
     if (newx > (parseInt(canvas1.style.width) - parseInt(canvas.getAttribute("width")) - 2))
     {
       newx = parseInt(canvas1.style.width) - parseInt(canvas.getAttribute("width")) - 2;
@@ -3388,7 +3223,6 @@ function canvasOver(event)
 //-----------------------------------------------------------------------------------------------------
 function canvasOut()
 {
-//dump("canvasOut\n");
   inforssTraceIn();
   try
   {
@@ -3404,7 +3238,6 @@ function canvasOut()
 //-----------------------------------------------------------------------------------------------------
 function canvasMove(event)
 {
-//dump("canvasMove\n");
   inforssTraceIn();
   try
   {
@@ -3428,7 +3261,6 @@ function canvasMove(event)
     try
     {
       var ctx = canvas.getContext("2d");
-//dump("left=" + (newx + 20) + "\n");
       document.getElementById("inforss.magnify").setAttribute("left", newx + "px");
       document.getElementById("inforss.magnify").setAttribute("top", newy + "px");
       document.getElementById("inforss.magnify").style.left = newx + "px";
@@ -3724,10 +3556,6 @@ function locateExportEnclosure(suf1, suf2)
   {
     var dirPicker = Components.classes["@mozilla.org/filepicker;1"].createInstance(Components.interfaces.nsIFilePicker);
     dirPicker.init(window, document.getElementById("bundle_inforss").getString("inforss.podcast.location"), dirPicker.modeGetFolder);
-//    dirPicker.defaultString = OPML_FILENAME;
-//    dirPicker.appendFilter("", "*.rdf");
-//    dirPicker.appendFilters(Components.interfaces.nsIFilePicker.filterXML);
-//    filePicker.appendFilters(Components.interfaces.nsIFilePicker.filterAll);
 
     var response = dirPicker.show();
     if ((response == dirPicker.returnOK) || (response == dirPicker.returnReplace))
@@ -3784,10 +3612,8 @@ function addToPlayList()
   try
   {
     var listbox = document.getElementById("group-list-rss");
-//alert("step1");
     if (listbox.selectedItem != null)
     {
-//alert("step2");
       if (listbox.selectedItem.childNodes[0].getAttribute("checked") == "false")
       {
         listbox.selectedItem.childNodes[0].setAttribute("checked", "true");
@@ -3796,7 +3622,6 @@ function addToPlayList()
                      listbox.selectedItem.childNodes[1].getAttribute("image"),
                      listbox.selectedItem.childNodes[1].getAttribute("label"),
                      listbox.selectedItem.childNodes[1].getAttribute("url"));
-//alert("step4");
     }
   }
   catch(e)
@@ -3808,10 +3633,6 @@ function addToPlayList()
 //-----------------------------------------------------------------------------------------------------
 function addToPlayList1(value, image, label, url)
 {
-//alert("value=" + value);
-//alert("image=" + image);
-//alert("label=" + label);
-//alert("url=" + url);
   try
   {
       var richlistitem = document.createElement("richlistitem");
@@ -3819,12 +3640,6 @@ function addToPlayList1(value, image, label, url)
       var input = document.createElement("textbox");
       input.setAttribute("value", value);
       input.style.maxWidth = "30px";
-//      input.style.minHeight = "20px";
-//      input.style.height = "35px";
-//      richlistitem.style.minHeight = "35px";
-//      richlistitem.style.height = "35px";
-//      hbox.style.minHeight = "35px";
-//      hbox.style.height = "35px";
       hbox.appendChild(input);
       var vbox = document.createElement("vbox");
       var spacer = document.createElement("spacer");
@@ -3855,10 +3670,8 @@ function addToPlayList1(value, image, label, url)
       richlistitem.setAttribute("value", value);
       richlistitem.setAttribute("label", label);
       richlistitem.setAttribute("url", url);
-//alert("step3");
 
       document.getElementById("group-playlist").appendChild(richlistitem);
-//alert("step4");
   }
   catch(e)
   {
@@ -3872,10 +3685,8 @@ function removeFromPlayList()
   try
   {
     var listbox = document.getElementById("group-playlist");
-//alert("step1");
     if (listbox.selectedItem != null)
     {
-//alert("step2");
       listbox.removeChild(listbox.selectedItem);
     }
   }
@@ -3891,11 +3702,9 @@ function moveUpInPlayList()
   try
   {
     var listbox = document.getElementById("group-playlist");
-//alert("step1");
     var richListitem = listbox.selectedItem
     if ((richListitem != null) && (richListitem.previousSibling != null))
     {
-//alert("step2");
       var oldValue = richListitem.childNodes[0].childNodes[0].value;
       var previous = richListitem.previousSibling;
       listbox.removeChild(listbox.selectedItem);
@@ -3915,11 +3724,9 @@ function moveDownInPlayList()
   try
   {
     var listbox = document.getElementById("group-playlist");
-//alert("step1");
     var richListitem = listbox.selectedItem
     if ((richListitem != null) && (richListitem.nextSibling != null))
     {
-//alert("step2");
       var oldValue = richListitem.childNodes[0].childNodes[0].value;
       var next = richListitem.nextSibling.nextSibling;
       listbox.removeChild(listbox.selectedItem);
@@ -4085,15 +3892,11 @@ function locateRepository(ext)
   try
   {
     var dir = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
-//  dir.append(INFORSS_REPOSITORY);
     var localFile = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
     localFile.initWithPath(dir.path );
     var filePicker = Components.classes["@mozilla.org/filepicker;1"].createInstance(Components.interfaces.nsIFilePicker);
     filePicker.appendFilter("", "*.rdf");
     filePicker.appendFilters(Components.interfaces.nsIFilePicker.filterXML);
-//    filePicker.displayDirectory = dir;
-//dump("locate=" + dir.path + "\n");
-//dump("isDir=" + dir.isDirectory() + "\n");
     filePicker.init(window, "", Components.interfaces.nsIFilePicker.modeOpen);
     filePicker.displayDirectory = localFile;
     filePicker.defaultString = null;
@@ -4106,5 +3909,3 @@ function locateRepository(ext)
     inforssDebug(e);
   }
 }
-
-// http://www.rsscache.com/Section/Stats/more/767.aspx

--- a/content/inforss/inforssOption.js
+++ b/content/inforss/inforssOption.js
@@ -65,397 +65,403 @@ var canvasPosY = 0;
 const INFORSS_DEFAULT_GROUP_ICON = "chrome://inforss/skin/group.png";
 
 //-----------------------------------------------------------------------------------------------------
- function init(withRead)
- {
-   inforssTraceIn();
-   try
-   {
-     var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
-     var windowManagerInterface = windowManager.QueryInterface( Components.interfaces.nsIWindowMediator);
-     var enumerator = windowManagerInterface.getEnumerator(null);
-     var win = null;
-     var find = false;
-     while ((enumerator.hasMoreElements()) && (find == false))
-     {
-       win = enumerator.getNext();
-       if (win.gInforssMediator != null)
-       {
-		 find = true;
-		 gInforssMediator = win.gInforssMediator;
-	   }
-     }
+function init(withRead)
+{
+  inforssTraceIn();
+  try
+  {
+    var windowManager = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService();
+    var windowManagerInterface = windowManager.QueryInterface(Components.interfaces.nsIWindowMediator);
+    var enumerator = windowManagerInterface.getEnumerator(null);
+    var win = null;
+    var find = false;
+    while ((enumerator.hasMoreElements()) && (find == false))
+    {
+      win = enumerator.getNext();
+      if (win.gInforssMediator != null)
+      {
+        find = true;
+        gInforssMediator = win.gInforssMediator;
+      }
+    }
 
-     if ((withRead == null) || (withRead == true))
-     {
-       inforssRead(false, false);
-     }
-     var nbitem = RSSList.firstChild.getAttribute("defaultNbItem");
-     document.getElementById("defaultnbitem").selectedIndex = (nbitem == "9999")? 0 : 1;
-     if (nbitem != "9999")
-     {
-       document.getElementById("defaultnbitem1").value = nbitem;
-     }
-     var lengthitem = RSSList.firstChild.getAttribute("defaultLenghtItem");
-     document.getElementById("defaultlengthitem").selectedIndex = (lengthitem == "9999")? 0 : 1;
-     if (lengthitem != "9999")
-     {
-       document.getElementById('defaultlengthitem1').value = lengthitem;
-     }
-     var refresh = RSSList.firstChild.getAttribute("refresh");
-     document.getElementById("defaultrefresh1").value = refresh;
+    if ((withRead == null) || (withRead == true))
+    {
+      inforssRead(false, false);
+    }
+    var nbitem = RSSList.firstChild.getAttribute("defaultNbItem");
+    document.getElementById("defaultnbitem").selectedIndex = (nbitem == "9999") ? 0 : 1;
+    if (nbitem != "9999")
+    {
+      document.getElementById("defaultnbitem1").value = nbitem;
+    }
+    var lengthitem = RSSList.firstChild.getAttribute("defaultLenghtItem");
+    document.getElementById("defaultlengthitem").selectedIndex = (lengthitem == "9999") ? 0 : 1;
+    if (lengthitem != "9999")
+    {
+      document.getElementById('defaultlengthitem1').value = lengthitem;
+    }
+    var refresh = RSSList.firstChild.getAttribute("refresh");
+    document.getElementById("defaultrefresh1").value = refresh;
 
-     if (refresh == 60*24)
-     {
-       document.getElementById("inforss.defaultrefresh").selectedIndex = 0;
-       document.getElementById("defaultrefresh1").value = 1;
-     }
-     else
-     {
-       document.getElementById("defaultrefresh1").value = refresh;
-       document.getElementById("inforss.defaultrefresh").selectedIndex = (refresh == 60)? 1 : 2;
-     }
+    if (refresh == 60 * 24)
+    {
+      document.getElementById("inforss.defaultrefresh").selectedIndex = 0;
+      document.getElementById("defaultrefresh1").value = 1;
+    }
+    else
+    {
+      document.getElementById("defaultrefresh1").value = refresh;
+      document.getElementById("inforss.defaultrefresh").selectedIndex = (refresh == 60) ? 1 : 2;
+    }
 
 
-     var defaultBrowserHistory = RSSList.firstChild.getAttribute("defaultBrowserHistory");
-     document.getElementById("defaultBrowserHistory").selectedIndex = (defaultBrowserHistory == "true")? 0 : 1;
-     var red = RSSList.firstChild.getAttribute("red");
-     var green = RSSList.firstChild.getAttribute("green");
-     var blue = RSSList.firstChild.getAttribute("blue");
-     var delay = RSSList.firstChild.getAttribute("delay");
-     document.getElementById("backgroundColor").selectedIndex = (red == "-1")? 0 : 1;
-     document.getElementById("red1").value = (red == "-1")? 0 : red;
-     document.getElementById("green1").value = (green == "-1")? 0 : green;
-     document.getElementById("blue1").value = (blue == "-1")? 0 : blue;
-     document.getElementById("delay1").value = delay;
-     var activity = RSSList.firstChild.getAttribute("switch");
-     document.getElementById("activity").selectedIndex = (activity == "true")? 0 : 1;
-     var submenu = RSSList.firstChild.getAttribute("submenu");
-     document.getElementById("submenu").selectedIndex = (submenu == "true")? 0 : 1;
-     var scrolling = RSSList.firstChild.getAttribute("scrolling");
-     document.getElementById("scrolling").selectedIndex = scrolling;
-     var separateLine = RSSList.firstChild.getAttribute("separateLine");
-     var linePosition = RSSList.firstChild.getAttribute("linePosition");
-     document.getElementById("linePosition").selectedIndex = (separateLine == "false")? 0 : ((linePosition == "top")? 1 : 2);
-     var debug = RSSList.firstChild.getAttribute("debug");
-     document.getElementById("debug").selectedIndex = (debug == "true")? 0 : 1;
-     var statusbar = RSSList.firstChild.getAttribute("statusbar");
-     document.getElementById("statusbar").selectedIndex = (statusbar == "true")? 0 : 1;
-     var log = RSSList.firstChild.getAttribute("log");
-     document.getElementById("log").selectedIndex = (log == "true")? 0 : 1;
-     var net = RSSList.firstChild.getAttribute("net");
-     document.getElementById("net").selectedIndex = (net == "true")? 0 : 1;
-     var bold = RSSList.firstChild.getAttribute("bold");
-     document.getElementById("inforss.bold").setAttribute("checked", bold);
-     var italic = RSSList.firstChild.getAttribute("italic");
-     document.getElementById("inforss.italic").setAttribute("checked", italic);
-     var currentfeed = RSSList.firstChild.getAttribute("currentfeed");
-     document.getElementById("currentfeed").selectedIndex = (currentfeed == "true")? 0 : 1;
-     var livemark = RSSList.firstChild.getAttribute("livemark");
-     document.getElementById("livemark").selectedIndex = (livemark == "true")? 0 : 1;
-     var clipboard = RSSList.firstChild.getAttribute("clipboard");
-     document.getElementById("clipboard").selectedIndex = (clipboard == "true")? 0 : 1;
-     var scrollingspeed = RSSList.firstChild.getAttribute("scrollingspeed");
-     document.getElementById("scrollingspeed1").value = scrollingspeed;
-     var scrollingIncrement = RSSList.firstChild.getAttribute("scrollingIncrement");
-     document.getElementById("scrollingIncrement1").value = scrollingIncrement;
-     var favicon = RSSList.firstChild.getAttribute("favicon");
-     document.getElementById("favicon").selectedIndex = (favicon == "true")? 0 : 1;
-     var foregroundColor = RSSList.firstChild.getAttribute("foregroundColor");
-     document.getElementById("foregroundColor").selectedIndex = (foregroundColor == "auto")? 0 : 1;
-     document.getElementById("manualColor").color = (foregroundColor == "auto")? "white" : foregroundColor;
-     var defaultForegroundColor = RSSList.firstChild.getAttribute("defaultForegroundColor");
-     document.getElementById("defaultForegroundColor").selectedIndex = (defaultForegroundColor == "default")? 0 : (defaultForegroundColor == "sameas")? 1 : 2;
-     document.getElementById("defaultManualColor").color = (defaultForegroundColor == "default")? "white" : (defaultForegroundColor == "sameas")? foregroundColor : defaultForegroundColor;
-     var hideViewed = RSSList.firstChild.getAttribute("hideViewed");
-     document.getElementById("hideViewed").selectedIndex = (hideViewed == "true")? 0 : 1;
-     var clickHeadline = RSSList.firstChild.getAttribute("clickHeadline");
-     document.getElementById("clickHeadline").selectedIndex = eval(clickHeadline);
-     var tooltip = RSSList.firstChild.getAttribute("tooltip");
-     document.getElementById("tooltip").selectedIndex = (tooltip == "description")? 0 : (tooltip == "title")? 1 : (tooltip == "allInfo")? 2 : 3;
-     var hideOld = RSSList.firstChild.getAttribute("hideOld");
-     document.getElementById("hideOld").selectedIndex = (hideOld == "true")? 0 : 1;
-     var sortedMenu = RSSList.firstChild.getAttribute("sortedMenu");
-     document.getElementById("sortedMenu").selectedIndex = (sortedMenu == "no")? 0 : ((sortedMenu == "asc")? 1 : 2);
-     var hideHistory = RSSList.firstChild.getAttribute("hideHistory");
-     document.getElementById("hideHistory").selectedIndex = (hideHistory == "true")? 0 : 1;
-     var includeAssociated = RSSList.firstChild.getAttribute("includeAssociated");
-     document.getElementById("includeAssociated").selectedIndex = (includeAssociated == "true")? 0 : 1;
-     var cycling = RSSList.firstChild.getAttribute("cycling");
-     document.getElementById("cycling").selectedIndex = (cycling == "true")? 0 : 1;
-     var cyclingDelay = RSSList.firstChild.getAttribute("cyclingDelay");
-     document.getElementById("cyclingDelay1").value = cyclingDelay;
-     var nextFeed = RSSList.firstChild.getAttribute("nextFeed");
-     document.getElementById("nextFeed").selectedIndex = (nextFeed == "next")? 0 : 1;
-     var timeslice = RSSList.firstChild.getAttribute("timeslice");
-     document.getElementById("timeslice").value = timeslice;
-     var fontSize = RSSList.firstChild.getAttribute("fontSize");
-     document.getElementById("fontSize").selectedIndex = (fontSize == "auto")? 0 : 1;
-     if (fontSize != "auto")
-     {
-       document.getElementById("fontSize1").value = fontSize;
-     }
-     var stopscrolling = RSSList.firstChild.getAttribute("stopscrolling");
-     document.getElementById("stopscrolling").selectedIndex = (stopscrolling == "true")? 0 : 1;
-     var defaultGroupIcon = RSSList.firstChild.getAttribute("defaultGroupIcon");
-     document.getElementById("defaultGroupIcon").value = defaultGroupIcon;
-     document.getElementById("inforss.defaultgroup.icon").src = defaultGroupIcon;
-     var cycleWithinGroup = RSSList.firstChild.getAttribute("cycleWithinGroup");
-     document.getElementById("cycleWithinGroup").selectedIndex = (cycleWithinGroup == "true")? 0 : 1;
-     var scrollingdirection = RSSList.firstChild.getAttribute("scrollingdirection");
-     document.getElementById("scrollingdirection").selectedIndex = (scrollingdirection == "rtl")? 0 : 1;
-     var synchronizeIcon = RSSList.firstChild.getAttribute("synchronizeIcon");
-     document.getElementById("synchronizeIcon").selectedIndex = (synchronizeIcon == "true")? 0 : 1;
-     var flashingIcon = RSSList.firstChild.getAttribute("flashingIcon");
-     document.getElementById("flashingIcon").selectedIndex = (flashingIcon == "true")? 0 : 1;
-     var mouseEvent = RSSList.firstChild.getAttribute("mouseEvent");
-     document.getElementById("mouseEvent").selectedIndex = (mouseEvent == "0")? 0 : 1;
-     var popupMessage = RSSList.firstChild.getAttribute("popupMessage");
-     document.getElementById("popupMessage").selectedIndex = (popupMessage == "true")? 0 : 1;
-     var playSound = RSSList.firstChild.getAttribute("playSound");
-     document.getElementById("playSound").selectedIndex = (playSound == "true")? 0 : 1;
-     var defaultPlayPodcast = RSSList.firstChild.getAttribute("defaultPlayPodcast");
-     document.getElementById("defaultPlayPodcast").selectedIndex = (defaultPlayPodcast == "true")? 0 : 1;
-     var defaultPurgeHistory = RSSList.firstChild.getAttribute("defaultPurgeHistory");
-     document.getElementById("defaultPurgeHistory").value = defaultPurgeHistory;
-     var displayEnclosure = RSSList.firstChild.getAttribute("displayEnclosure");
-     document.getElementById("displayEnclosure").selectedIndex = (displayEnclosure == "true")? 0 : 1;
-     var displayBanned = RSSList.firstChild.getAttribute("displayBanned");
-     document.getElementById("displayBanned").selectedIndex = (displayBanned == "true")? 0 : 1;
-     var savePodcastLocation = RSSList.firstChild.getAttribute("savePodcastLocation");
-     if ((savePodcastLocation == null) || (savePodcastLocation == ""))
-     {
-       document.getElementById("savePodcastLocation").selectedIndex = 1;
-       document.getElementById("savePodcastLocation1").value = "";
-     }
-     else
-     {
-       document.getElementById("savePodcastLocation").selectedIndex = 0;
-       document.getElementById("savePodcastLocation1").value = savePodcastLocation;
-     }
-     var collapseBar = RSSList.firstChild.getAttribute("collapseBar");
-     document.getElementById("collapseBar").selectedIndex = (collapseBar == "true")? 0 : 1;
-     var mouseWheelScroll = RSSList.firstChild.getAttribute("mouseWheelScroll");
-     document.getElementById("mouseWheelScroll").selectedIndex = (mouseWheelScroll == "pixel")? 0 : (mouseWheelScroll == "pixels")? 1 : 2;
+    var defaultBrowserHistory = RSSList.firstChild.getAttribute("defaultBrowserHistory");
+    document.getElementById("defaultBrowserHistory").selectedIndex = (defaultBrowserHistory == "true") ? 0 : 1;
+    var red = RSSList.firstChild.getAttribute("red");
+    var green = RSSList.firstChild.getAttribute("green");
+    var blue = RSSList.firstChild.getAttribute("blue");
+    var delay = RSSList.firstChild.getAttribute("delay");
+    document.getElementById("backgroundColor").selectedIndex = (red == "-1") ? 0 : 1;
+    document.getElementById("red1").value = (red == "-1") ? 0 : red;
+    document.getElementById("green1").value = (green == "-1") ? 0 : green;
+    document.getElementById("blue1").value = (blue == "-1") ? 0 : blue;
+    document.getElementById("delay1").value = delay;
+    var activity = RSSList.firstChild.getAttribute("switch");
+    document.getElementById("activity").selectedIndex = (activity == "true") ? 0 : 1;
+    var submenu = RSSList.firstChild.getAttribute("submenu");
+    document.getElementById("submenu").selectedIndex = (submenu == "true") ? 0 : 1;
+    var scrolling = RSSList.firstChild.getAttribute("scrolling");
+    document.getElementById("scrolling").selectedIndex = scrolling;
+    var separateLine = RSSList.firstChild.getAttribute("separateLine");
+    var linePosition = RSSList.firstChild.getAttribute("linePosition");
+    document.getElementById("linePosition").selectedIndex = (separateLine == "false") ? 0 : ((linePosition == "top") ? 1 : 2);
+    var debug = RSSList.firstChild.getAttribute("debug");
+    document.getElementById("debug").selectedIndex = (debug == "true") ? 0 : 1;
+    var statusbar = RSSList.firstChild.getAttribute("statusbar");
+    document.getElementById("statusbar").selectedIndex = (statusbar == "true") ? 0 : 1;
+    var log = RSSList.firstChild.getAttribute("log");
+    document.getElementById("log").selectedIndex = (log == "true") ? 0 : 1;
+    var net = RSSList.firstChild.getAttribute("net");
+    document.getElementById("net").selectedIndex = (net == "true") ? 0 : 1;
+    var bold = RSSList.firstChild.getAttribute("bold");
+    document.getElementById("inforss.bold").setAttribute("checked", bold);
+    var italic = RSSList.firstChild.getAttribute("italic");
+    document.getElementById("inforss.italic").setAttribute("checked", italic);
+    var currentfeed = RSSList.firstChild.getAttribute("currentfeed");
+    document.getElementById("currentfeed").selectedIndex = (currentfeed == "true") ? 0 : 1;
+    var livemark = RSSList.firstChild.getAttribute("livemark");
+    document.getElementById("livemark").selectedIndex = (livemark == "true") ? 0 : 1;
+    var clipboard = RSSList.firstChild.getAttribute("clipboard");
+    document.getElementById("clipboard").selectedIndex = (clipboard == "true") ? 0 : 1;
+    var scrollingspeed = RSSList.firstChild.getAttribute("scrollingspeed");
+    document.getElementById("scrollingspeed1").value = scrollingspeed;
+    var scrollingIncrement = RSSList.firstChild.getAttribute("scrollingIncrement");
+    document.getElementById("scrollingIncrement1").value = scrollingIncrement;
+    var favicon = RSSList.firstChild.getAttribute("favicon");
+    document.getElementById("favicon").selectedIndex = (favicon == "true") ? 0 : 1;
+    var foregroundColor = RSSList.firstChild.getAttribute("foregroundColor");
+    document.getElementById("foregroundColor").selectedIndex = (foregroundColor == "auto") ? 0 : 1;
+    document.getElementById("manualColor").color = (foregroundColor == "auto") ? "white" : foregroundColor;
+    var defaultForegroundColor = RSSList.firstChild.getAttribute("defaultForegroundColor");
+    document.getElementById("defaultForegroundColor").selectedIndex = (defaultForegroundColor == "default") ? 0 : (defaultForegroundColor == "sameas") ? 1 : 2;
+    document.getElementById("defaultManualColor").color = (defaultForegroundColor == "default") ? "white" : (defaultForegroundColor == "sameas") ? foregroundColor : defaultForegroundColor;
+    var hideViewed = RSSList.firstChild.getAttribute("hideViewed");
+    document.getElementById("hideViewed").selectedIndex = (hideViewed == "true") ? 0 : 1;
+    var clickHeadline = RSSList.firstChild.getAttribute("clickHeadline");
+    document.getElementById("clickHeadline").selectedIndex = eval(clickHeadline);
+    var tooltip = RSSList.firstChild.getAttribute("tooltip");
+    document.getElementById("tooltip").selectedIndex = (tooltip == "description") ? 0 : (tooltip == "title") ? 1 : (tooltip == "allInfo") ? 2 : 3;
+    var hideOld = RSSList.firstChild.getAttribute("hideOld");
+    document.getElementById("hideOld").selectedIndex = (hideOld == "true") ? 0 : 1;
+    var sortedMenu = RSSList.firstChild.getAttribute("sortedMenu");
+    document.getElementById("sortedMenu").selectedIndex = (sortedMenu == "no") ? 0 : ((sortedMenu == "asc") ? 1 : 2);
+    var hideHistory = RSSList.firstChild.getAttribute("hideHistory");
+    document.getElementById("hideHistory").selectedIndex = (hideHistory == "true") ? 0 : 1;
+    var includeAssociated = RSSList.firstChild.getAttribute("includeAssociated");
+    document.getElementById("includeAssociated").selectedIndex = (includeAssociated == "true") ? 0 : 1;
+    var cycling = RSSList.firstChild.getAttribute("cycling");
+    document.getElementById("cycling").selectedIndex = (cycling == "true") ? 0 : 1;
+    var cyclingDelay = RSSList.firstChild.getAttribute("cyclingDelay");
+    document.getElementById("cyclingDelay1").value = cyclingDelay;
+    var nextFeed = RSSList.firstChild.getAttribute("nextFeed");
+    document.getElementById("nextFeed").selectedIndex = (nextFeed == "next") ? 0 : 1;
+    var timeslice = RSSList.firstChild.getAttribute("timeslice");
+    document.getElementById("timeslice").value = timeslice;
+    var fontSize = RSSList.firstChild.getAttribute("fontSize");
+    document.getElementById("fontSize").selectedIndex = (fontSize == "auto") ? 0 : 1;
+    if (fontSize != "auto")
+    {
+      document.getElementById("fontSize1").value = fontSize;
+    }
+    var stopscrolling = RSSList.firstChild.getAttribute("stopscrolling");
+    document.getElementById("stopscrolling").selectedIndex = (stopscrolling == "true") ? 0 : 1;
+    var defaultGroupIcon = RSSList.firstChild.getAttribute("defaultGroupIcon");
+    document.getElementById("defaultGroupIcon").value = defaultGroupIcon;
+    document.getElementById("inforss.defaultgroup.icon").src = defaultGroupIcon;
+    var cycleWithinGroup = RSSList.firstChild.getAttribute("cycleWithinGroup");
+    document.getElementById("cycleWithinGroup").selectedIndex = (cycleWithinGroup == "true") ? 0 : 1;
+    var scrollingdirection = RSSList.firstChild.getAttribute("scrollingdirection");
+    document.getElementById("scrollingdirection").selectedIndex = (scrollingdirection == "rtl") ? 0 : 1;
+    var synchronizeIcon = RSSList.firstChild.getAttribute("synchronizeIcon");
+    document.getElementById("synchronizeIcon").selectedIndex = (synchronizeIcon == "true") ? 0 : 1;
+    var flashingIcon = RSSList.firstChild.getAttribute("flashingIcon");
+    document.getElementById("flashingIcon").selectedIndex = (flashingIcon == "true") ? 0 : 1;
+    var mouseEvent = RSSList.firstChild.getAttribute("mouseEvent");
+    document.getElementById("mouseEvent").selectedIndex = (mouseEvent == "0") ? 0 : 1;
+    var popupMessage = RSSList.firstChild.getAttribute("popupMessage");
+    document.getElementById("popupMessage").selectedIndex = (popupMessage == "true") ? 0 : 1;
+    var playSound = RSSList.firstChild.getAttribute("playSound");
+    document.getElementById("playSound").selectedIndex = (playSound == "true") ? 0 : 1;
+    var defaultPlayPodcast = RSSList.firstChild.getAttribute("defaultPlayPodcast");
+    document.getElementById("defaultPlayPodcast").selectedIndex = (defaultPlayPodcast == "true") ? 0 : 1;
+    var defaultPurgeHistory = RSSList.firstChild.getAttribute("defaultPurgeHistory");
+    document.getElementById("defaultPurgeHistory").value = defaultPurgeHistory;
+    var displayEnclosure = RSSList.firstChild.getAttribute("displayEnclosure");
+    document.getElementById("displayEnclosure").selectedIndex = (displayEnclosure == "true") ? 0 : 1;
+    var displayBanned = RSSList.firstChild.getAttribute("displayBanned");
+    document.getElementById("displayBanned").selectedIndex = (displayBanned == "true") ? 0 : 1;
+    var savePodcastLocation = RSSList.firstChild.getAttribute("savePodcastLocation");
+    if ((savePodcastLocation == null) || (savePodcastLocation == ""))
+    {
+      document.getElementById("savePodcastLocation").selectedIndex = 1;
+      document.getElementById("savePodcastLocation1").value = "";
+    }
+    else
+    {
+      document.getElementById("savePodcastLocation").selectedIndex = 0;
+      document.getElementById("savePodcastLocation1").value = savePodcastLocation;
+    }
+    var collapseBar = RSSList.firstChild.getAttribute("collapseBar");
+    document.getElementById("collapseBar").selectedIndex = (collapseBar == "true") ? 0 : 1;
+    var mouseWheelScroll = RSSList.firstChild.getAttribute("mouseWheelScroll");
+    document.getElementById("mouseWheelScroll").selectedIndex = (mouseWheelScroll == "pixel") ? 0 : (mouseWheelScroll == "pixels") ? 1 : 2;
 
-     var serverInfo = inforssXMLRepository.getServerInfo();
-     document.getElementById('inforss.repo.urltype').value = serverInfo.protocol;
-     document.getElementById('ftpServer').value = serverInfo.server;
-     document.getElementById('repoDirectory').value = serverInfo.directory;
-     document.getElementById('repoLogin').value = serverInfo.user;
-     document.getElementById('repoPassword').value = serverInfo.password;
-     document.getElementById('repoAutoSync').selectedIndex = (serverInfo.autosync == true)? 0 : 1;
+    var serverInfo = inforssXMLRepository.getServerInfo();
+    document.getElementById('inforss.repo.urltype').value = serverInfo.protocol;
+    document.getElementById('ftpServer').value = serverInfo.server;
+    document.getElementById('repoDirectory').value = serverInfo.directory;
+    document.getElementById('repoLogin').value = serverInfo.user;
+    document.getElementById('repoPassword').value = serverInfo.password;
+    document.getElementById('repoAutoSync').selectedIndex = (serverInfo.autosync == true) ? 0 : 1;
 
-     document.getElementById("readAllIcon").setAttribute("checked", RSSList.firstChild.getAttribute("readAllIcon"));
-     document.getElementById("viewAllIcon").setAttribute("checked", RSSList.firstChild.getAttribute("viewAllIcon"));
-     document.getElementById("shuffleIcon").setAttribute("checked", RSSList.firstChild.getAttribute("shuffleIcon"));
-     document.getElementById("directionIcon").setAttribute("checked", RSSList.firstChild.getAttribute("directionIcon"));
-     document.getElementById("scrollingIcon").setAttribute("checked", RSSList.firstChild.getAttribute("scrollingIcon"));
-     document.getElementById("previousIcon").setAttribute("checked", RSSList.firstChild.getAttribute("previousIcon"));
-     document.getElementById("pauseIcon").setAttribute("checked", RSSList.firstChild.getAttribute("pauseIcon"));
-     document.getElementById("nextIcon").setAttribute("checked", RSSList.firstChild.getAttribute("nextIcon"));
-     document.getElementById("refreshIcon").setAttribute("checked", RSSList.firstChild.getAttribute("refreshIcon"));
-     document.getElementById("hideOldIcon").setAttribute("checked", RSSList.firstChild.getAttribute("hideOldIcon"));
-     document.getElementById("hideViewedIcon").setAttribute("checked", RSSList.firstChild.getAttribute("hideViewedIcon"));
-     document.getElementById("synchronizationIcon").setAttribute("checked", RSSList.firstChild.getAttribute("synchronizationIcon"));
-     document.getElementById("homeIcon").setAttribute("checked", RSSList.firstChild.getAttribute("homeIcon"));
-     document.getElementById("filterIcon").setAttribute("checked", RSSList.firstChild.getAttribute("filterIcon"));
+    document.getElementById("readAllIcon").setAttribute("checked", RSSList.firstChild.getAttribute("readAllIcon"));
+    document.getElementById("viewAllIcon").setAttribute("checked", RSSList.firstChild.getAttribute("viewAllIcon"));
+    document.getElementById("shuffleIcon").setAttribute("checked", RSSList.firstChild.getAttribute("shuffleIcon"));
+    document.getElementById("directionIcon").setAttribute("checked", RSSList.firstChild.getAttribute("directionIcon"));
+    document.getElementById("scrollingIcon").setAttribute("checked", RSSList.firstChild.getAttribute("scrollingIcon"));
+    document.getElementById("previousIcon").setAttribute("checked", RSSList.firstChild.getAttribute("previousIcon"));
+    document.getElementById("pauseIcon").setAttribute("checked", RSSList.firstChild.getAttribute("pauseIcon"));
+    document.getElementById("nextIcon").setAttribute("checked", RSSList.firstChild.getAttribute("nextIcon"));
+    document.getElementById("refreshIcon").setAttribute("checked", RSSList.firstChild.getAttribute("refreshIcon"));
+    document.getElementById("hideOldIcon").setAttribute("checked", RSSList.firstChild.getAttribute("hideOldIcon"));
+    document.getElementById("hideViewedIcon").setAttribute("checked", RSSList.firstChild.getAttribute("hideViewedIcon"));
+    document.getElementById("synchronizationIcon").setAttribute("checked", RSSList.firstChild.getAttribute("synchronizationIcon"));
+    document.getElementById("homeIcon").setAttribute("checked", RSSList.firstChild.getAttribute("homeIcon"));
+    document.getElementById("filterIcon").setAttribute("checked", RSSList.firstChild.getAttribute("filterIcon"));
 
-//inforssInspectDump(navigator, null, false);
-     if ((navigator.vendor == "Thunderbird") || (navigator.vendor == "Linspire Inc."))
-     {
-       document.getElementById("inforss.repo.synchronize.exporttoremote").setAttribute("collapsed", "true");
-       document.getElementById("inforss.repo.synchronize.importfromremote").setAttribute("collapsed", "true");
-       document.getElementById("repoAutoSync").setAttribute("disabled","true");
-       document.getElementById("repoAutoSyncOn").setAttribute("disabled","true");
-       document.getElementById("repoAutoSyncOff").setAttribute("disabled","true");
-       document.getElementById("inforss.tab.synchro").setAttribute("disabled","true");
-     }
-     changeColor();
+    if ((navigator.vendor == "Thunderbird") || (navigator.vendor == "Linspire Inc."))
+    {
+      document.getElementById("inforss.repo.synchronize.exporttoremote").setAttribute("collapsed", "true");
+      document.getElementById("inforss.repo.synchronize.importfromremote").setAttribute("collapsed", "true");
+      document.getElementById("repoAutoSync").setAttribute("disabled", "true");
+      document.getElementById("repoAutoSyncOn").setAttribute("disabled", "true");
+      document.getElementById("repoAutoSyncOff").setAttribute("disabled", "true");
+      document.getElementById("inforss.tab.synchro").setAttribute("disabled", "true");
+    }
+    changeColor();
 
-     var items = RSSList.getElementsByTagName("RSS");
-     document.getElementById("rss-select-menu").removeAllItems();
-     var selectFolder = document.createElement("menupopup");
-     selectFolder.setAttribute("id","rss-select-folder");
-     document.getElementById("rss-select-menu").appendChild(selectFolder);
-     var element = null;
-     var selectedUrl = null;
-     var pos = -1;
-     var selectedIndex = -1;
-     var menu = document.getElementById("rss-select-menu");
-     var menupopup = menu.firstChild;
-     var tree = document.getElementById("inforss.tree.report");
+    var items = RSSList.getElementsByTagName("RSS");
+    document.getElementById("rss-select-menu").removeAllItems();
+    var selectFolder = document.createElement("menupopup");
+    selectFolder.setAttribute("id", "rss-select-folder");
+    document.getElementById("rss-select-menu").appendChild(selectFolder);
+    var element = null;
+    var selectedUrl = null;
+    var pos = -1;
+    var selectedIndex = -1;
+    var menu = document.getElementById("rss-select-menu");
+    var menupopup = menu.firstChild;
+    var tree = document.getElementById("inforss.tree.report");
 
-     while (tree.firstChild != null)
-     {
-   	   tree.removeChild(tree.firstChild);
-     }
-     var list2 = document.getElementById("group-list-rss");
-     var listcols = list2.firstChild;
-     while (list2.firstChild != null)
-     {
-   	   list2.removeChild(list2.firstChild);
-     }
-     list2.appendChild(listcols);
+    while (tree.firstChild != null)
+    {
+      tree.removeChild(tree.firstChild);
+    }
+    var list2 = document.getElementById("group-list-rss");
+    var listcols = list2.firstChild;
+    while (list2.firstChild != null)
+    {
+      list2.removeChild(list2.firstChild);
+    }
+    list2.appendChild(listcols);
 
-     for (var i=0; i < items.length; i++)
-     {
-       var find = false;
-       var j = 0;
-       var menuItem = null;
-       var count = (menupopup == null)? 0 : menupopup.childNodes.length;
-       var title = items[i].getAttribute("title").toLowerCase();
-       while ((j < count) && (find == false))
-       {
-         menuItem = menupopup.childNodes[j];
-         if (title <= menuItem.getAttribute("label").toLowerCase())
-         {
-           find = true;
-         }
-         else
-         {
-           j++;
-         }
-       }
-       if (find == false)
-       {
-         element = menu.appendItem(items[i].getAttribute("title"), "rss_" + i);
-       }
-       else
-       {
-         element = menu.insertItemAt(j, items[i].getAttribute("title"), "rss_" + i);
-         if (pos != -1)
-         {
-           if (j <= pos)
-           {
-             pos++;
-           }
-         }
-       }
+    for (var i = 0; i < items.length; i++)
+    {
+      var find = false;
+      var j = 0;
+      var menuItem = null;
+      var count = (menupopup == null) ? 0 : menupopup.childNodes.length;
+      var title = items[i].getAttribute("title").toLowerCase();
+      while ((j < count) && (find == false))
+      {
+        menuItem = menupopup.childNodes[j];
+        if (title <= menuItem.getAttribute("label").toLowerCase())
+        {
+          find = true;
+        }
+        else
+        {
+          j++;
+        }
+      }
+      if (find == false)
+      {
+        element = menu.appendItem(items[i].getAttribute("title"), "rss_" + i);
+      }
+      else
+      {
+        element = menu.insertItemAt(j, items[i].getAttribute("title"), "rss_" + i);
+        if (pos != -1)
+        {
+          if (j <= pos)
+          {
+            pos++;
+          }
+        }
+      }
 
-       element.setAttribute("class","menuitem-iconic");
-       element.setAttribute("image",items[i].getAttribute("icon"));
-       if (items[i].getAttribute("type") != "group")
-       {
-         addRssToVbox(items[i]);
-       }
-       gNbRss++;
-       element.setAttribute("url", items[i].getAttribute("url"));
-       element.setAttribute("user", items[i].getAttribute("user"));
-       if ((pos == -1) && (items[i].getAttribute("selected") == "true"))
-       {
-         selectedIndex = i;
-         if (find == false)
-         {
-           pos = i;
-         }
-         else
-         {
-           pos = j;
-         }
-       }
-     }
+      element.setAttribute("class", "menuitem-iconic");
+      element.setAttribute("image", items[i].getAttribute("icon"));
+      if (items[i].getAttribute("type") != "group")
+      {
+        addRssToVbox(items[i]);
+      }
+      gNbRss++;
+      element.setAttribute("url", items[i].getAttribute("url"));
+      element.setAttribute("user", items[i].getAttribute("user"));
+      if ((pos == -1) && (items[i].getAttribute("selected") == "true"))
+      {
+        selectedIndex = i;
+        if (find == false)
+        {
+          pos = i;
+        }
+        else
+        {
+          pos = j;
+        }
+      }
+    }
 
-     updateReport();
-     theCurrentFeed = gInforssMediator.getSelectedInfo(true);
-     document.getElementById("inforss.current.feed").setAttribute("value", theCurrentFeed.getTitle());
-     document.getElementById("inforss.current.feed").setAttribute("tooltiptext", theCurrentFeed.getTitle());
+    updateReport();
+    theCurrentFeed = gInforssMediator.getSelectedInfo(true);
+    document.getElementById("inforss.current.feed").setAttribute("value", theCurrentFeed.getTitle());
+    document.getElementById("inforss.current.feed").setAttribute("tooltiptext", theCurrentFeed.getTitle());
 
-     if ((pos == -1) && (items.length > 0))
-     {
-       selectedIndex = 0;
-       var count = (menupopup == null)? 0 : menupopup.childNodes.length;
-       var title = items[0].getAttribute("title").toLowerCase();
-       var j = 0;
-       var find = false;
-       var menuItem = null;
-       while ((j < count) && (find == false))
-       {
-         menuItem = menupopup.childNodes[j];
-         if (title == menuItem.getAttribute("label").toLowerCase())
-         {
-           find = true;
-         }
-         else
-         {
-           j++;
-         }
-       }
-       pos = j;
-       items[0].setAttribute("selected", "true");
-     }
-     if (pos != -1)
-     {
-       menu.selectedIndex = pos;
-       selectRSS1(items[selectedIndex].getAttribute("url"), items[selectedIndex].getAttribute("user"));
-     }
+    if ((pos == -1) && (items.length > 0))
+    {
+      selectedIndex = 0;
+      var count = (menupopup == null) ? 0 : menupopup.childNodes.length;
+      var title = items[0].getAttribute("title").toLowerCase();
+      var j = 0;
+      var find = false;
+      var menuItem = null;
+      while ((j < count) && (find == false))
+      {
+        menuItem = menupopup.childNodes[j];
+        if (title == menuItem.getAttribute("label").toLowerCase())
+        {
+          find = true;
+        }
+        else
+        {
+          j++;
+        }
+      }
+      pos = j;
+      items[0].setAttribute("selected", "true");
+    }
+    if (pos != -1)
+    {
+      menu.selectedIndex = pos;
+      selectRSS1(items[selectedIndex].getAttribute("url"), items[selectedIndex].getAttribute("user"));
+    }
 
-     if (gNbRss > 0)
-     {
-       document.getElementById("inforss.next.rss").setAttribute("disabled",false);
-     }
-     
-     
-     if (document.getElementById("inforss.apply") == null)
-     {
-       var file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
-       file.append(INFORSS_REPOSITORY);
-       var linetext = document.createTextNode(file.path);
-       document.getElementById("inforss.location3").appendChild(linetext);
-       file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
-       file.append(INFORSS_RDF_REPOSITORY);
-       linetext = document.createTextNode(file.path);
-       document.getElementById("inforss.location4").appendChild(linetext);
+    if (gNbRss > 0)
+    {
+      document.getElementById("inforss.next.rss").setAttribute("disabled", false);
+    }
 
-       var cancel = document.getElementById('inforssOption').getButton("cancel");
-       var apply = document.getElementById('inforssOption').getButton("extra1");
-       apply.parentNode.removeChild(apply);
-       apply.label=document.getElementById("bundle_inforss").getString("inforss.apply");
-       apply.setAttribute("label",apply.label);
-       apply.setAttribute("accesskey","");
-       apply.setAttribute("id","inforss.apply");
-       apply.addEventListener("click", function () { return _apply() }, false);
-       cancel.parentNode.insertBefore(apply, cancel);
 
-       var fontService = Components.classes["@mozilla.org/gfx/fontenumerator;1"].getService(Components.interfaces.nsIFontEnumerator);
+    if (document.getElementById("inforss.apply") == null)
+    {
+      var file = file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+      file.append(INFORSS_REPOSITORY);
+      var linetext = document.createTextNode(file.path);
+      document.getElementById("inforss.location3").appendChild(linetext);
+      file = file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+      file.append(INFORSS_RDF_REPOSITORY);
+      linetext = document.createTextNode(file.path);
+      document.getElementById("inforss.location4").appendChild(linetext);
 
-       var count = { value: null };
-       var arr = { value: null };
-       var fonts = fontService.EnumerateAllFonts(count);
-       var font = null;
-       var str = null;
-       for (var i = 0; i<fonts.length; i++)
-       {
-         var element = document.getElementById("fresh-font").appendItem(fonts[i], fonts[i]);
-         element.style.fontFamily = fonts[i];
-         if (RSSList.firstChild.getAttribute("font") == fonts[i])
-         {
-           document.getElementById("fresh-font").selectedIndex = (i + 1);
-         }
-       }
-       if (RSSList.firstChild.getAttribute("font") == "auto")
-       {
-         document.getElementById("fresh-font").selectedIndex = 0;
-       }
-       changeColor();
-       
-       document.getElementById("rss.filter.number").removeAllItems();
-       selectFolder = document.createElement("menupopup");
-       selectFolder.setAttribute("id","rss.filter.number.1");
-       document.getElementById("rss.filter.number").appendChild(selectFolder);
-       for (var i=0; i<100; i++)
-       {
-         document.getElementById("rss.filter.number").appendItem(i, i);
-         if (i < 51)
-         {
-           document.getElementById("rss.filter.hlnumber").appendItem(i, i);
-         }
-       }
-     }
-   }
-   catch (e)
-   {
-     inforssDebug(e);
-   }
+      var cancel = document.getElementById('inforssOption').getButton("cancel");
+      var apply = document.getElementById('inforssOption').getButton("extra1");
+      apply.parentNode.removeChild(apply);
+      apply.label = document.getElementById("bundle_inforss").getString("inforss.apply");
+      apply.setAttribute("label", apply.label);
+      apply.setAttribute("accesskey", "");
+      apply.setAttribute("id", "inforss.apply");
+      apply.addEventListener("click", function()
+      {
+        return _apply()
+      }, false);
+      cancel.parentNode.insertBefore(apply, cancel);
+
+      var fontService = Components.classes["@mozilla.org/gfx/fontenumerator;1"].getService(Components.interfaces.nsIFontEnumerator);
+
+      var count = {
+        value: null
+      };
+      var arr = {
+        value: null
+      };
+      var fonts = fontService.EnumerateAllFonts(count);
+      var font = null;
+      var str = null;
+      for (var i = 0; i < fonts.length; i++)
+      {
+        var element = document.getElementById("fresh-font").appendItem(fonts[i], fonts[i]);
+        element.style.fontFamily = fonts[i];
+        if (RSSList.firstChild.getAttribute("font") == fonts[i])
+        {
+          document.getElementById("fresh-font").selectedIndex = (i + 1);
+        }
+      }
+      if (RSSList.firstChild.getAttribute("font") == "auto")
+      {
+        document.getElementById("fresh-font").selectedIndex = 0;
+      }
+      changeColor();
+
+      document.getElementById("rss.filter.number").removeAllItems();
+      selectFolder = document.createElement("menupopup");
+      selectFolder.setAttribute("id", "rss.filter.number.1");
+      document.getElementById("rss.filter.number").appendChild(selectFolder);
+      for (var i = 0; i < 100; i++)
+      {
+        document.getElementById("rss.filter.number").appendItem(i, i);
+        if (i < 51)
+        {
+          document.getElementById("rss.filter.hlnumber").appendItem(i, i);
+        }
+      }
+    }
+  }
+  catch (e)
+  {
+    inforssDebug(e);
+  }
   inforssTraceOut();
 }
 
@@ -464,171 +470,171 @@ function updateReport()
 {
   try
   {
-     var items = RSSList.getElementsByTagName("RSS");
-     var tree = document.getElementById("inforss.tree.report");
-     while (tree.firstChild != null)
-     {
-   	   tree.removeChild(tree.firstChild);
-     }
-     
-     gInforssNbFeed = 0;
+    var items = RSSList.getElementsByTagName("RSS");
+    var tree = document.getElementById("inforss.tree.report");
+    while (tree.firstChild != null)
+    {
+      tree.removeChild(tree.firstChild);
+    }
 
-     for (var i=0; i < items.length; i++)
-     {
-       var originalFeed = gInforssMediator.locateFeed(items[i].getAttribute("url"));
-       if ((originalFeed != null) && (originalFeed.info != null))
-       {
-         originalFeed = originalFeed.info;
-         if (items[i].getAttribute("type") != "group")
-         {
-		   gInforssNbFeed++;
-           var treeitem = document.createElement("treeitem");
-           treeitem.setAttribute("title", items[i].getAttribute("title"));
-           var treerow = document.createElement("treerow");
-           treerow.setAttribute("url", items[i].getAttribute("url"));
-           treeitem.appendChild(treerow);
-           addCell(items[i].getAttribute("icon"), treerow, "icon", "image");
-           addCell("", treerow, (items[i].getAttribute("activity") == "true")? "on" : "off");
-      	   addCell(items[i].getAttribute("title"), treerow, null);
-    	   addCell("", treerow, (originalFeed.active == true)? "active" : "unactive");
-    	   addCell(((originalFeed.lastRefresh == null)? "" : inforssGetStringDate(originalFeed.lastRefresh)), treerow, null);
-    	   addCell(((originalFeed.lastRefresh == null) || (originalFeed.active == false) || (items[i].getAttribute("activity") == "false"))? "" : inforssGetStringDate(new Date(eval(originalFeed.lastRefresh.getTime() + originalFeed.feedXML.getAttribute("refresh") * 60000))), treerow, null);
-    	   addCell((originalFeed.lastRefresh == null)? "" : originalFeed.getNbHeadlines(), treerow, null);
-    	   addCell((originalFeed.lastRefresh == null)? "" : originalFeed.getNbUnread(), treerow, null);
-    	   addCell((originalFeed.lastRefresh == null)? "" : originalFeed.getNbNew(), treerow, null);
-    	   addCell(((originalFeed.feedXML.getAttribute("groupAssociated") == "true")? "Y" : "N"), treerow, null);
-           var find = false;
-           var child = tree.firstChild;
-           while ((child != null) && (find == false))
-           {
-			 if (treeitem.getAttribute("title").toLowerCase() > child.getAttribute("title").toLowerCase())
-			 {
-			   child = child.nextSibling;
-		     }
-		     else
-		     {
-			   find = true;
-			 }
-		   }
-		   if (find == false)
-		   {
-             tree.appendChild(treeitem);
-	       }
-           else
-           {
-			 tree.insertBefore(treeitem, child);
-		   }
-         }
-	   }
-	 }
-	 var first = true;
-	 var treeseparator = null;
-     for (var i=0; i < items.length; i++)
-     {
-       var originalFeed = gInforssMediator.locateFeed(items[i].getAttribute("url"));
-       if ((originalFeed != null) && (originalFeed.info))
-       {
-         originalFeed = originalFeed.info;
-         if (items[i].getAttribute("type") == "group")
-         {
-		   if (first == true)
-		   {
-		     first = false;
-             treeseparator = document.createElement("treeseparator");
-             tree.appendChild(treeseparator);
-		   }
-           var treeitem = document.createElement("treeitem");
-           treeitem.setAttribute("title", items[i].getAttribute("title"));
-           var treerow = document.createElement("treerow");
-           treeitem.appendChild(treerow);
-		   treeitem.setAttribute("container","true");
-		   treeitem.setAttribute("open","false");
-		   treerow.setAttribute("properties","group");
-           treerow.setAttribute("url", items[i].getAttribute("url"));
-      	   addCell(items[i].getAttribute("icon"), treerow, "icon", "image");
-      	   addCell("", treerow, (items[i].getAttribute("activity") == "true")? "on" : "off");
-      	   addCell(items[i].getAttribute("title"), treerow, null);
-    	   addCell("", treerow, (originalFeed.active == true)? "active" : "unactive");
-      	   addCell("", treerow, null);
-      	   addCell("", treerow, null);
-    	   addCell(originalFeed.getNbHeadlines(), treerow, null);
-    	   addCell(originalFeed.getNbUnread(), treerow, null);
-      	   addCell("", treerow, null);
+    gInforssNbFeed = 0;
 
-           var find = false;
-           var child = treeseparator.nextSibling;
-           while ((child != null) && (find == false))
-           {
-			 if (treeitem.getAttribute("title").toLowerCase() > child.getAttribute("title").toLowerCase())
-			 {
-			   child = child.nextSibling;
-		     }
-		     else
-		     {
-			   find = true;
-			 }
-		   }
-		   if (find == false)
-		   {
-             tree.appendChild(treeitem);
-	       }
-           else
-           {
-			 tree.insertBefore(treeitem, child);
-		   }
+    for (var i = 0; i < items.length; i++)
+    {
+      var originalFeed = gInforssMediator.locateFeed(items[i].getAttribute("url"));
+      if ((originalFeed != null) && (originalFeed.info != null))
+      {
+        originalFeed = originalFeed.info;
+        if (items[i].getAttribute("type") != "group")
+        {
+          gInforssNbFeed++;
+          var treeitem = document.createElement("treeitem");
+          treeitem.setAttribute("title", items[i].getAttribute("title"));
+          var treerow = document.createElement("treerow");
+          treerow.setAttribute("url", items[i].getAttribute("url"));
+          treeitem.appendChild(treerow);
+          addCell(items[i].getAttribute("icon"), treerow, "icon", "image");
+          addCell("", treerow, (items[i].getAttribute("activity") == "true") ? "on" : "off");
+          addCell(items[i].getAttribute("title"), treerow, null);
+          addCell("", treerow, (originalFeed.active == true) ? "active" : "unactive");
+          addCell(((originalFeed.lastRefresh == null) ? "" : inforssGetStringDate(originalFeed.lastRefresh)), treerow, null);
+          addCell(((originalFeed.lastRefresh == null) || (originalFeed.active == false) || (items[i].getAttribute("activity") == "false")) ? "" : inforssGetStringDate(new Date(eval(originalFeed.lastRefresh.getTime() + originalFeed.feedXML.getAttribute("refresh") * 60000))), treerow, null);
+          addCell((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbHeadlines(), treerow, null);
+          addCell((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbUnread(), treerow, null);
+          addCell((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbNew(), treerow, null);
+          addCell(((originalFeed.feedXML.getAttribute("groupAssociated") == "true") ? "Y" : "N"), treerow, null);
+          var find = false;
+          var child = tree.firstChild;
+          while ((child != null) && (find == false))
+          {
+            if (treeitem.getAttribute("title").toLowerCase() > child.getAttribute("title").toLowerCase())
+            {
+              child = child.nextSibling;
+            }
+            else
+            {
+              find = true;
+            }
+          }
+          if (find == false)
+          {
+            tree.appendChild(treeitem);
+          }
+          else
+          {
+            tree.insertBefore(treeitem, child);
+          }
+        }
+      }
+    }
+    var first = true;
+    var treeseparator = null;
+    for (var i = 0; i < items.length; i++)
+    {
+      var originalFeed = gInforssMediator.locateFeed(items[i].getAttribute("url"));
+      if ((originalFeed != null) && (originalFeed.info))
+      {
+        originalFeed = originalFeed.info;
+        if (items[i].getAttribute("type") == "group")
+        {
+          if (first == true)
+          {
+            first = false;
+            treeseparator = document.createElement("treeseparator");
+            tree.appendChild(treeseparator);
+          }
+          var treeitem = document.createElement("treeitem");
+          treeitem.setAttribute("title", items[i].getAttribute("title"));
+          var treerow = document.createElement("treerow");
+          treeitem.appendChild(treerow);
+          treeitem.setAttribute("container", "true");
+          treeitem.setAttribute("open", "false");
+          treerow.setAttribute("properties", "group");
+          treerow.setAttribute("url", items[i].getAttribute("url"));
+          addCell(items[i].getAttribute("icon"), treerow, "icon", "image");
+          addCell("", treerow, (items[i].getAttribute("activity") == "true") ? "on" : "off");
+          addCell(items[i].getAttribute("title"), treerow, null);
+          addCell("", treerow, (originalFeed.active == true) ? "active" : "unactive");
+          addCell("", treerow, null);
+          addCell("", treerow, null);
+          addCell(originalFeed.getNbHeadlines(), treerow, null);
+          addCell(originalFeed.getNbUnread(), treerow, null);
+          addCell("", treerow, null);
 
-      	   var treechildren = document.createElement("treechildren");
-      	   treeitem.appendChild(treechildren);
-      	   var selectedList = items[i].getElementsByTagName("GROUP");
-		   for (var j = 0; j < selectedList.length; j++)
-		   {
-    	     originalFeed = gInforssMediator.locateFeed(selectedList[j].getAttribute("url"));
-    	     if (originalFeed != null)
-    	     {
-    	       originalFeed = originalFeed.info;
-      	       treeitem = document.createElement("treeitem");
-               treeitem.setAttribute("title", originalFeed.feedXML.getAttribute("title"));
-		       treerow = document.createElement("treerow");
-		       treeitem.appendChild(treerow);
-		       treerow.setAttribute("properties","rss");
-               treerow.setAttribute("url", selectedList[j].getAttribute("url"));
-               var rss1 = inforssGetItemFromUrl(selectedList[j].getAttribute("url"));
-      	       addCell(originalFeed.feedXML.getAttribute("icon"), treerow, "icon", "image");
-      	       addCell("", treerow, (rss1.getAttribute("activity") == "true")? "on" : "off");
-      	       addCell(originalFeed.feedXML.getAttribute("title"), treerow, null);
-    	       addCell("", treerow, (originalFeed.active == true)? "active" : "unactive");
-    	       addCell(((originalFeed.lastRefresh == null)? "" : inforssGetStringDate(originalFeed.lastRefresh)), treerow, null);
-    	       addCell(((originalFeed.lastRefresh == null) || (originalFeed.active == false) || (rss1.getAttribute("activity") == "false"))? "" : inforssGetStringDate(new Date(eval(originalFeed.lastRefresh.getTime() + originalFeed.feedXML.getAttribute("refresh") * 60000))), treerow, null);
-    	       addCell((originalFeed.lastRefresh == null)? "" : originalFeed.getNbHeadlines(), treerow, null);
-    	       addCell((originalFeed.lastRefresh == null)? "" : originalFeed.getNbUnread(), treerow, null);
-    	       addCell("", treerow, null);
+          var find = false;
+          var child = treeseparator.nextSibling;
+          while ((child != null) && (find == false))
+          {
+            if (treeitem.getAttribute("title").toLowerCase() > child.getAttribute("title").toLowerCase())
+            {
+              child = child.nextSibling;
+            }
+            else
+            {
+              find = true;
+            }
+          }
+          if (find == false)
+          {
+            tree.appendChild(treeitem);
+          }
+          else
+          {
+            tree.insertBefore(treeitem, child);
+          }
 
-               var find = false;
-               var child = treechildren.firstChild;
-               while ((child != null) && (find == false))
-               {
-			     if (treeitem.getAttribute("title").toLowerCase() > child.getAttribute("title").toLowerCase())
-			     {
-			       child = child.nextSibling;
-		         }
-		         else
-		         {
-			       find = true;
-			     }
-		       }
-		       if (find == false)
-		       {
-		         treechildren.appendChild(treeitem);
-	           }
-               else
-               {
-			     treechildren.insertBefore(treeitem, child);
-		       }
-		     }
-		   }
-	     }
-       }
-     }
+          var treechildren = document.createElement("treechildren");
+          treeitem.appendChild(treechildren);
+          var selectedList = items[i].getElementsByTagName("GROUP");
+          for (var j = 0; j < selectedList.length; j++)
+          {
+            originalFeed = gInforssMediator.locateFeed(selectedList[j].getAttribute("url"));
+            if (originalFeed != null)
+            {
+              originalFeed = originalFeed.info;
+              treeitem = document.createElement("treeitem");
+              treeitem.setAttribute("title", originalFeed.feedXML.getAttribute("title"));
+              treerow = document.createElement("treerow");
+              treeitem.appendChild(treerow);
+              treerow.setAttribute("properties", "rss");
+              treerow.setAttribute("url", selectedList[j].getAttribute("url"));
+              var rss1 = inforssGetItemFromUrl(selectedList[j].getAttribute("url"));
+              addCell(originalFeed.feedXML.getAttribute("icon"), treerow, "icon", "image");
+              addCell("", treerow, (rss1.getAttribute("activity") == "true") ? "on" : "off");
+              addCell(originalFeed.feedXML.getAttribute("title"), treerow, null);
+              addCell("", treerow, (originalFeed.active == true) ? "active" : "unactive");
+              addCell(((originalFeed.lastRefresh == null) ? "" : inforssGetStringDate(originalFeed.lastRefresh)), treerow, null);
+              addCell(((originalFeed.lastRefresh == null) || (originalFeed.active == false) || (rss1.getAttribute("activity") == "false")) ? "" : inforssGetStringDate(new Date(eval(originalFeed.lastRefresh.getTime() + originalFeed.feedXML.getAttribute("refresh") * 60000))), treerow, null);
+              addCell((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbHeadlines(), treerow, null);
+              addCell((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbUnread(), treerow, null);
+              addCell("", treerow, null);
+
+              var find = false;
+              var child = treechildren.firstChild;
+              while ((child != null) && (find == false))
+              {
+                if (treeitem.getAttribute("title").toLowerCase() > child.getAttribute("title").toLowerCase())
+                {
+                  child = child.nextSibling;
+                }
+                else
+                {
+                  find = true;
+                }
+              }
+              if (find == false)
+              {
+                treechildren.appendChild(treeitem);
+              }
+              else
+              {
+                treechildren.insertBefore(treeitem, child);
+              }
+            }
+          }
+        }
+      }
+    }
   }
   catch (e)
   {
@@ -647,9 +653,20 @@ function addRssToVbox(rss)
   var listcell = document.createElement("listcell");
   listcell.setAttribute("type", "checkbox");
 
-  listcell.addEventListener("click", function(event) { var lc = event.currentTarget; if (lc.getAttribute("checked") == "false") { lc.setAttribute("checked", "true") } else { lc.setAttribute("checked", "false"); }}, false);
+  listcell.addEventListener("click", function(event)
+  {
+    var lc = event.currentTarget;
+    if (lc.getAttribute("checked") == "false")
+    {
+      lc.setAttribute("checked", "true")
+    }
+    else
+    {
+      lc.setAttribute("checked", "false");
+    }
+  }, false);
   listitem.appendChild(listcell);
-  
+
   listcell = document.createElement("listcell");
   listcell.setAttribute("class", "listcell-iconic");
   listcell.setAttribute("image", rss.getAttribute("icon"));
@@ -658,10 +675,10 @@ function addRssToVbox(rss)
   listcell.setAttribute("url", rss.getAttribute("url"));
   listitem.appendChild(listcell);
   window.setTimeout(resizeImage, (1000 + 10 * count), listcell, rss.getAttribute("icon"));
-  
+
   listitem.setAttribute("allowevents", "true");
- 
- 
+
+
   var j = 1;
   var find = false;
   var label = null;
@@ -688,13 +705,13 @@ function addRssToVbox(rss)
   }
 
   list = document.getElementById("inforss.apply.list");
-  var count = (list.firstChild == null)? 0 : list.childNodes.length;
+  var count = (list.firstChild == null) ? 0 : list.childNodes.length;
 
   var listitem = document.createElement("listitem");
-  listitem.setAttribute("label",rss.getAttribute("title"));
-  listitem.setAttribute("url",rss.getAttribute("url"));
-  listitem.setAttribute("class","listitem-iconic");
-  listitem.setAttribute("image",rss.getAttribute("icon"));
+  listitem.setAttribute("label", rss.getAttribute("title"));
+  listitem.setAttribute("url", rss.getAttribute("url"));
+  listitem.setAttribute("class", "listitem-iconic");
+  listitem.setAttribute("image", rss.getAttribute("icon"));
   listitem.style.maxHeight = "18px";
   var j = 0;
   var find = false;
@@ -732,8 +749,8 @@ function resizeImage(listitem, url)
   var i = 0;
   while ((i < 20) && (subElement == null))
   {
-	subElement = document.getAnonymousNodes(listitem);
-	i++;
+    subElement = document.getAnonymousNodes(listitem);
+    i++;
   }
   if (subElement != null)
   {
@@ -750,7 +767,7 @@ function resizeImage(listitem, url)
     else
     {
       if (subElement[0].nodeName == "xul:image")
-      { 
+      {
         subElement[0].style.maxWidth = "16px";
         subElement[0].style.width = "16px";
         subElement[0].style.maxHeight = "16px";
@@ -771,19 +788,19 @@ function checkRssList()
   {
     var subElement = document.getAnonymousNodes(menuItem);
 
-    if ((subElement != null) && (subElement.length > 0) && (subElement[0] != null) && (subElement[0].firstChild != null) && (subElement[0].firstChild.localName =="image"))
+    if ((subElement != null) && (subElement.length > 0) && (subElement[0] != null) && (subElement[0].firstChild != null) && (subElement[0].firstChild.localName == "image"))
     {
-      subElement[0].firstChild.setAttribute("maxwidth","16");
-      subElement[0].firstChild.setAttribute("maxheight","16");
-      subElement[0].firstChild.setAttribute("minwidth","16");
-      subElement[0].firstChild.setAttribute("minheight","16");
+      subElement[0].firstChild.setAttribute("maxwidth", "16");
+      subElement[0].firstChild.setAttribute("maxheight", "16");
+      subElement[0].firstChild.setAttribute("minwidth", "16");
+      subElement[0].firstChild.setAttribute("minheight", "16");
 
       subElement[0].firstChild.style.maxWidth = "16px";
       subElement[0].firstChild.style.maxHeight = "16px";
       subElement[0].firstChild.style.minWidth = "16px";
       subElement[0].firstChild.style.minHeight = "16px";
 
-      subElement[0].firstChild.setAttribute("collapsed","false");
+      subElement[0].firstChild.setAttribute("collapsed", "false");
       subElement[0].firstChild.style.visibility = "visible";
     }
     menuItem = menuItem.nextSibling;
@@ -806,16 +823,16 @@ function changeColor(arg)
   var vert = document.getElementById('green1').value;
   var bleu = document.getElementById('blue1').value;
   var sample = document.getElementById("sample1");
-  
+
   if (document.getElementById('backgroundColor').selectedIndex == 0)
   {
     sample.style.backgroundColor = "inherit";
   }
   else
   {
-    sample.style.backgroundColor="rgb(" + rouge + "," + vert + "," + bleu + ")";
+    sample.style.backgroundColor = "rgb(" + rouge + "," + vert + "," + bleu + ")";
   }
-  var foregroundColor = (document.getElementById('foregroundColor').selectedIndex == 0)? "auto" : document.getElementById('manualColor').color;
+  var foregroundColor = (document.getElementById('foregroundColor').selectedIndex == 0) ? "auto" : document.getElementById('manualColor').color;
   if (foregroundColor == "auto")
   {
     if (document.getElementById('backgroundColor').selectedIndex == 0)
@@ -824,7 +841,7 @@ function changeColor(arg)
     }
     else
     {
-      sample.style.color = ((eval(rouge)  + eval(vert) + eval(bleu)) < (3 * 85))? "white" : "black";
+      sample.style.color = ((eval(rouge) + eval(vert) + eval(bleu)) < (3 * 85)) ? "white" : "black";
     }
   }
   else
@@ -846,8 +863,8 @@ function changeColor(arg)
     font = "inherit";
   }
   document.getElementById("sample").style.fontFamily = font;
-  sample.style.fontWeight = (document.getElementById("inforss.bold").getAttribute("checked") == "true")? "bolder" : "inherit";
-  sample.style.fontStyle = (document.getElementById("inforss.italic").getAttribute("checked") == "true")? "italic" : "inherit";
+  sample.style.fontWeight = (document.getElementById("inforss.bold").getAttribute("checked") == "true") ? "bolder" : "inherit";
+  sample.style.fontStyle = (document.getElementById("inforss.italic").getAttribute("checked") == "true") ? "italic" : "inherit";
 
   sample = document.getElementById("sample2");
 
@@ -868,7 +885,7 @@ function changeColor(arg)
         }
         else
         {
-          sample.style.color = ((eval(rouge)  + eval(vert) + eval(bleu)) < (3 * 85))? "white" : "black";
+          sample.style.color = ((eval(rouge) + eval(vert) + eval(bleu)) < (3 * 85)) ? "white" : "black";
         }
       }
       else
@@ -938,8 +955,8 @@ function accept()
     {
       returnValue = false;
       var acceptButton = document.getElementById('inforssOption').getButton("accept");
-      acceptButton.setAttribute("disabled","true");
-      window.setTimeout(closeOptionDialog,2300);
+      acceptButton.setAttribute("disabled", "true");
+      window.setTimeout(closeOptionDialog, 2300);
     }
   }
   catch (e)
@@ -960,7 +977,7 @@ function _apply()
     {
       inforssSave();
       var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-        observerService.notifyObservers(null,"reload", gRemovedUrl);
+      observerService.notifyObservers(null, "reload", gRemovedUrl);
       returnValue = true;
     }
   }
@@ -977,233 +994,233 @@ function storeValue()
   var returnValue = false;
   try
   {
-     if (validDialog() == true)
-     {
-       if (currentRSS != null)
-       {
-         var rss = currentRSS;
-         switch (rss.getAttribute("type"))
-         {
-           case "rss":
-           case "atom":
-           case "html":
-           case "nntp":
-           {
-             rss.setAttribute("nbItem", (document.getElementById('nbitem').selectedIndex == 0)? "9999" : document.getElementById('nbitem1').value);
-             rss.setAttribute("lengthItem", (document.getElementById('lengthitem').selectedIndex == 0)? "9999" : document.getElementById('lengthitem1').value);
-             rss.setAttribute("title", document.getElementById('optionTitle').value);
-             if (rss.getAttribute("url") != document.getElementById('optionUrl').value)
-             {
-               updateGroup(rss.getAttribute("url"), document.getElementById('optionUrl').value);
-               updateReport();
-             }
-             rss.setAttribute("url", document.getElementById('optionUrl').value);
-             rss.setAttribute("link", document.getElementById('optionLink').value);
-             rss.setAttribute("description", document.getElementById('optionDescription').value);
-             var refresh1 = document.getElementById('inforss.refresh').selectedIndex;
-             rss.setAttribute("refresh", (refresh1 == 0)? 60*24 : (refresh1 == 1)? 60 : document.getElementById('refresh1').value);
-             rss.setAttribute("filter", ((document.getElementById("inforss.filter.anyall").selectedIndex == 0)? "all" : "any"));
-             rss.setAttribute("icon", document.getElementById('iconurl').value);
-             rss.setAttribute("playPodcast", (document.getElementById('playPodcast').selectedIndex == 0)? "true" : "false");
-	         rss.setAttribute("savePodcastLocation", (document.getElementById('savePodcastLocation2').selectedIndex == 1)? "" : document.getElementById('savePodcastLocation3').value);
-             rss.setAttribute("browserHistory", (document.getElementById('browserHistory').selectedIndex == 0)? "true" : "false");
-             rss.setAttribute("filterCaseSensitive", (document.getElementById('filterCaseSensitive').selectedIndex == 0)? "true" : "false");
-             rss.setAttribute("purgeHistory", document.getElementById('purgeHistory').value);
-             break;
-           }
-           case "group":
-           {
-             rss.setAttribute("url", document.getElementById('groupName').value);
-             rss.setAttribute("title", document.getElementById('groupName').value);
-             rss.setAttribute("description", document.getElementById('groupName').value);
-             rss.setAttribute("filterPolicy", document.getElementById("inforss.filter.policy").selectedIndex);
-             rss.setAttribute("icon", document.getElementById('iconurlgroup').value);
-             rss.setAttribute("filterCaseSensitive", (document.getElementById('filterCaseSensitive').selectedIndex == 0)? "true" : "false");
-             rss.setAttribute("filter", ((document.getElementById("inforss.filter.anyall").selectedIndex == 0)? "all" : "any"));
-             rss.setAttribute("playlist", (document.getElementById('playlistoption').selectedIndex == 0)? "true" : "false");
-             var child = rss.firstChild;
-             var next = null;
-             while (child != null)
-             {
-               next = child.nextSibling;
-               if (child.nodeName.indexOf("GROUP") != -1)
-               {
-                 rss.removeChild(child);
-               }
-               child = next;
-             }
-             var listbox = document.getElementById("group-list-rss");
-             var listitem = null;
-             var checkbox = null;
-             var label = null;
-             for (var i = 1; i < listbox.childNodes.length; i++)
-             {
-               listitem = listbox.childNodes[i];
-               checkbox = listitem.childNodes[0];
-               label = listitem.childNodes[1];
-               if (checkbox.getAttribute("checked") == "true")
-               {
-                 var child = rss.parentNode.parentNode.createElement("GROUP");
-                 child.setAttribute("url",label.getAttribute("url"));
-                 rss.appendChild(child);
-               }
-             }
-             var playLists = rss.getElementsByTagName("playLists");
-             if (playLists.length != 0)
-             {
-               rss.removeChild(playLists[0]);
-             }
-             if (document.getElementById('playlistoption').selectedIndex == 0) // playlist == true
-             {
-               playLists = document.createElement("playLists");
-               rss.appendChild(playLists);
-               listbox = document.getElementById("group-playlist");
-               var richListItem = null;
-               var playList = null;
-               for (var i=0; i < listbox.childNodes.length; i++)
-               {
-                 richListItem = listbox.childNodes[i];
-                 playList = document.createElement("playList");
-                 playLists.appendChild(playList);
-                 playList.setAttribute("url", richListItem.getAttribute("url"));
-                 playList.setAttribute("delay", richListItem.firstChild.firstChild.value);
-               }
-             }
-             break;
-           }
-         }
-         var child = rss.firstChild;
-         var next = null;
-         while (child != null)
-         {
-           next = child.nextSibling;
-           if (child.nodeName.indexOf("FILTER") != -1)
-           {
-             rss.removeChild(child);
-           }
-           child = next;
-         }
-         var vbox = document.getElementById("inforss.filter.vbox");
-         var hbox = vbox.childNodes[3]; // first filter
-         while (hbox != null)
-         {
-           var checkbox = hbox.childNodes[0];
-           var type = hbox.childNodes[1];
-           var deck = hbox.childNodes[2];
-           var filter = rss.parentNode.parentNode.createElement("FILTER");
-           filter.setAttribute("active", ((checkbox.getAttribute("checked") == "true")? "true" : "false"));
-           filter.setAttribute("type", type.selectedIndex);
-           filter.setAttribute("include", deck.childNodes[0].childNodes[0].selectedIndex);
-           filter.setAttribute("text", deck.childNodes[0].childNodes[1].value);
-           filter.setAttribute("compare", deck.childNodes[1].childNodes[0].selectedIndex);
-           filter.setAttribute("elapse", deck.childNodes[1].childNodes[1].selectedIndex);
-           filter.setAttribute("unit", deck.childNodes[1].childNodes[2].selectedIndex);
-           filter.setAttribute("hlcompare", deck.childNodes[2].childNodes[0].selectedIndex);
-           filter.setAttribute("nb", deck.childNodes[2].childNodes[1].selectedIndex);
-           rss.appendChild(filter);
-           hbox = hbox.nextSibling;
-         }
-       }
+    if (validDialog() == true)
+    {
+      if (currentRSS != null)
+      {
+        var rss = currentRSS;
+        switch (rss.getAttribute("type"))
+        {
+          case "rss":
+          case "atom":
+          case "html":
+          case "nntp":
+            {
+              rss.setAttribute("nbItem", (document.getElementById('nbitem').selectedIndex == 0) ? "9999" : document.getElementById('nbitem1').value);
+              rss.setAttribute("lengthItem", (document.getElementById('lengthitem').selectedIndex == 0) ? "9999" : document.getElementById('lengthitem1').value);
+              rss.setAttribute("title", document.getElementById('optionTitle').value);
+              if (rss.getAttribute("url") != document.getElementById('optionUrl').value)
+              {
+                updateGroup(rss.getAttribute("url"), document.getElementById('optionUrl').value);
+                updateReport();
+              }
+              rss.setAttribute("url", document.getElementById('optionUrl').value);
+              rss.setAttribute("link", document.getElementById('optionLink').value);
+              rss.setAttribute("description", document.getElementById('optionDescription').value);
+              var refresh1 = document.getElementById('inforss.refresh').selectedIndex;
+              rss.setAttribute("refresh", (refresh1 == 0) ? 60 * 24 : (refresh1 == 1) ? 60 : document.getElementById('refresh1').value);
+              rss.setAttribute("filter", ((document.getElementById("inforss.filter.anyall").selectedIndex == 0) ? "all" : "any"));
+              rss.setAttribute("icon", document.getElementById('iconurl').value);
+              rss.setAttribute("playPodcast", (document.getElementById('playPodcast').selectedIndex == 0) ? "true" : "false");
+              rss.setAttribute("savePodcastLocation", (document.getElementById('savePodcastLocation2').selectedIndex == 1) ? "" : document.getElementById('savePodcastLocation3').value);
+              rss.setAttribute("browserHistory", (document.getElementById('browserHistory').selectedIndex == 0) ? "true" : "false");
+              rss.setAttribute("filterCaseSensitive", (document.getElementById('filterCaseSensitive').selectedIndex == 0) ? "true" : "false");
+              rss.setAttribute("purgeHistory", document.getElementById('purgeHistory').value);
+              break;
+            }
+          case "group":
+            {
+              rss.setAttribute("url", document.getElementById('groupName').value);
+              rss.setAttribute("title", document.getElementById('groupName').value);
+              rss.setAttribute("description", document.getElementById('groupName').value);
+              rss.setAttribute("filterPolicy", document.getElementById("inforss.filter.policy").selectedIndex);
+              rss.setAttribute("icon", document.getElementById('iconurlgroup').value);
+              rss.setAttribute("filterCaseSensitive", (document.getElementById('filterCaseSensitive').selectedIndex == 0) ? "true" : "false");
+              rss.setAttribute("filter", ((document.getElementById("inforss.filter.anyall").selectedIndex == 0) ? "all" : "any"));
+              rss.setAttribute("playlist", (document.getElementById('playlistoption').selectedIndex == 0) ? "true" : "false");
+              var child = rss.firstChild;
+              var next = null;
+              while (child != null)
+              {
+                next = child.nextSibling;
+                if (child.nodeName.indexOf("GROUP") != -1)
+                {
+                  rss.removeChild(child);
+                }
+                child = next;
+              }
+              var listbox = document.getElementById("group-list-rss");
+              var listitem = null;
+              var checkbox = null;
+              var label = null;
+              for (var i = 1; i < listbox.childNodes.length; i++)
+              {
+                listitem = listbox.childNodes[i];
+                checkbox = listitem.childNodes[0];
+                label = listitem.childNodes[1];
+                if (checkbox.getAttribute("checked") == "true")
+                {
+                  var child = rss.parentNode.parentNode.createElement("GROUP");
+                  child.setAttribute("url", label.getAttribute("url"));
+                  rss.appendChild(child);
+                }
+              }
+              var playLists = rss.getElementsByTagName("playLists");
+              if (playLists.length != 0)
+              {
+                rss.removeChild(playLists[0]);
+              }
+              if (document.getElementById('playlistoption').selectedIndex == 0) // playlist == true
+              {
+                playLists = document.createElement("playLists");
+                rss.appendChild(playLists);
+                listbox = document.getElementById("group-playlist");
+                var richListItem = null;
+                var playList = null;
+                for (var i = 0; i < listbox.childNodes.length; i++)
+                {
+                  richListItem = listbox.childNodes[i];
+                  playList = document.createElement("playList");
+                  playLists.appendChild(playList);
+                  playList.setAttribute("url", richListItem.getAttribute("url"));
+                  playList.setAttribute("delay", richListItem.firstChild.firstChild.value);
+                }
+              }
+              break;
+            }
+        }
+        var child = rss.firstChild;
+        var next = null;
+        while (child != null)
+        {
+          next = child.nextSibling;
+          if (child.nodeName.indexOf("FILTER") != -1)
+          {
+            rss.removeChild(child);
+          }
+          child = next;
+        }
+        var vbox = document.getElementById("inforss.filter.vbox");
+        var hbox = vbox.childNodes[3]; // first filter
+        while (hbox != null)
+        {
+          var checkbox = hbox.childNodes[0];
+          var type = hbox.childNodes[1];
+          var deck = hbox.childNodes[2];
+          var filter = rss.parentNode.parentNode.createElement("FILTER");
+          filter.setAttribute("active", ((checkbox.getAttribute("checked") == "true") ? "true" : "false"));
+          filter.setAttribute("type", type.selectedIndex);
+          filter.setAttribute("include", deck.childNodes[0].childNodes[0].selectedIndex);
+          filter.setAttribute("text", deck.childNodes[0].childNodes[1].value);
+          filter.setAttribute("compare", deck.childNodes[1].childNodes[0].selectedIndex);
+          filter.setAttribute("elapse", deck.childNodes[1].childNodes[1].selectedIndex);
+          filter.setAttribute("unit", deck.childNodes[1].childNodes[2].selectedIndex);
+          filter.setAttribute("hlcompare", deck.childNodes[2].childNodes[0].selectedIndex);
+          filter.setAttribute("nb", deck.childNodes[2].childNodes[1].selectedIndex);
+          rss.appendChild(filter);
+          hbox = hbox.nextSibling;
+        }
+      }
 
-       RSSList.firstChild.setAttribute("defaultNbItem", (document.getElementById('defaultnbitem').selectedIndex == 0)? "9999" : document.getElementById('defaultnbitem1').value);
-       RSSList.firstChild.setAttribute("defaultLenghtItem", (document.getElementById('defaultlengthitem').selectedIndex == 0)? "9999" : document.getElementById('defaultlengthitem1').value);
-       var refresh1 = document.getElementById('inforss.defaultrefresh').selectedIndex;
-       RSSList.firstChild.setAttribute("refresh", (refresh1 == 0)? 60*24 : (refresh1 == 1)? 60 : document.getElementById('defaultrefresh1').value);
-       RSSList.firstChild.setAttribute("defaultBrowserHistory", (document.getElementById('defaultBrowserHistory').selectedIndex == 0)? "true" : "false");
-       if (document.getElementById("backgroundColor").selectedIndex == 0)
-       {
-         RSSList.firstChild.setAttribute("red", "-1");
-         RSSList.firstChild.setAttribute("green", "-1");
-         RSSList.firstChild.setAttribute("blue", "-1");
-       }
-       else
-       {
-         RSSList.firstChild.setAttribute("red", document.getElementById("red1").value);
-         RSSList.firstChild.setAttribute("green", document.getElementById("green1").value);
-         RSSList.firstChild.setAttribute("blue", document.getElementById("blue1").value);
-       }
-       RSSList.firstChild.setAttribute("delay", document.getElementById("delay1").value);
-       RSSList.firstChild.setAttribute("switch", (document.getElementById('activity').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("submenu", (document.getElementById('submenu').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("scrolling", document.getElementById('scrolling').selectedIndex);
-       RSSList.firstChild.setAttribute("separateLine", (document.getElementById('linePosition').selectedIndex == 0)? "false" : "true");
-       RSSList.firstChild.setAttribute("linePosition", (document.getElementById('linePosition').selectedIndex == 1)? "top" : "bottom");
-       RSSList.firstChild.setAttribute("debug", (document.getElementById('debug').selectedIndex == 0)? "true" : "bottom");
-       RSSList.firstChild.setAttribute("log", (document.getElementById('log').selectedIndex == 0)? "true" : "bottom");
-       RSSList.firstChild.setAttribute("statusbar", (document.getElementById('statusbar').selectedIndex == 0)? "true" : "bottom");
-       RSSList.firstChild.setAttribute("net", (document.getElementById('net').selectedIndex == 0)? "true" : "bottom");
-       RSSList.firstChild.setAttribute("bold", (document.getElementById('inforss.bold').getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("italic", (document.getElementById('inforss.italic').getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("currentfeed", (document.getElementById('currentfeed').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("livemark", (document.getElementById('livemark').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("clipboard", (document.getElementById('clipboard').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("scrollingspeed", document.getElementById("scrollingspeed1").value);
-       RSSList.firstChild.setAttribute("scrollingIncrement", document.getElementById("scrollingIncrement1").value);
-       RSSList.firstChild.setAttribute("font", document.getElementById("fresh-font").value);
-       RSSList.firstChild.setAttribute("favicon", (document.getElementById('favicon').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("foregroundColor", (document.getElementById('foregroundColor').selectedIndex == 0)? "auto" : document.getElementById('manualColor').color);
-       RSSList.firstChild.setAttribute("defaultForegroundColor", (document.getElementById('defaultForegroundColor').selectedIndex == 0)? "default" : (document.getElementById('defaultForegroundColor').selectedIndex == 1)? "sameas" : document.getElementById('defaultManualColor').color);
-       RSSList.firstChild.setAttribute("hideViewed", (document.getElementById('hideViewed').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("tooltip", (document.getElementById('tooltip').selectedIndex == 0)? "description" : (document.getElementById('tooltip').selectedIndex == 1)? "title" : (document.getElementById('tooltip').selectedIndex == 2)? "allInfo" : "article" );
-       RSSList.firstChild.setAttribute("clickHeadline", document.getElementById('clickHeadline').selectedIndex);
-       RSSList.firstChild.setAttribute("hideOld", (document.getElementById('hideOld').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("sortedMenu", (document.getElementById('sortedMenu').selectedIndex == 0)? "no" : ((document.getElementById('sortedMenu').selectedIndex == 1)? "asc" : "des"));
-       RSSList.firstChild.setAttribute("hideHistory", (document.getElementById('hideHistory').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("includeAssociated", (document.getElementById('includeAssociated').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("cycling", (document.getElementById('cycling').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("cyclingDelay", document.getElementById("cyclingDelay1").value);
-       RSSList.firstChild.setAttribute("nextFeed", (document.getElementById('nextFeed').selectedIndex == 0)? "next" : "random");
-       RSSList.firstChild.setAttribute("defaultPurgeHistory", document.getElementById("defaultPurgeHistory").value);
-       RSSList.firstChild.setAttribute("timeslice", document.getElementById("timeslice").value);
-       RSSList.firstChild.setAttribute("fontSize", (document.getElementById('fontSize').selectedIndex == 0)? "auto" : document.getElementById('fontSize1').value);
-       RSSList.firstChild.setAttribute("stopscrolling", (document.getElementById('stopscrolling').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("defaultGroupIcon", document.getElementById("defaultGroupIcon").value);
-       RSSList.firstChild.setAttribute("cycleWithinGroup", (document.getElementById('cycleWithinGroup').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("scrollingdirection", (document.getElementById('scrollingdirection').selectedIndex == 0)? "rtl" : "ltr");
-       RSSList.firstChild.setAttribute("synchronizeIcon", (document.getElementById('synchronizeIcon').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("flashingIcon", (document.getElementById('flashingIcon').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("mouseEvent", (document.getElementById('mouseEvent').selectedIndex == 0)? "0" : "-1");
-       RSSList.firstChild.setAttribute("popupMessage", (document.getElementById('popupMessage').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("playSound", (document.getElementById('playSound').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("defaultPlayPodcast", (document.getElementById('defaultPlayPodcast').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("displayEnclosure", (document.getElementById('displayEnclosure').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("displayBanned", (document.getElementById('displayBanned').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("savePodcastLocation", (document.getElementById('savePodcastLocation').selectedIndex == 0)? document.getElementById('savePodcastLocation1').value : "");
-       RSSList.firstChild.setAttribute("collapseBar", (document.getElementById('collapseBar').selectedIndex == 0)? "true" : "false");
-       RSSList.firstChild.setAttribute("mouseWheelScroll", (document.getElementById('mouseWheelScroll').selectedIndex == 0)? "pixel" : (document.getElementById('mouseWheelScroll').selectedIndex == 1)? "pixels" : "headline");
+      RSSList.firstChild.setAttribute("defaultNbItem", (document.getElementById('defaultnbitem').selectedIndex == 0) ? "9999" : document.getElementById('defaultnbitem1').value);
+      RSSList.firstChild.setAttribute("defaultLenghtItem", (document.getElementById('defaultlengthitem').selectedIndex == 0) ? "9999" : document.getElementById('defaultlengthitem1').value);
+      var refresh1 = document.getElementById('inforss.defaultrefresh').selectedIndex;
+      RSSList.firstChild.setAttribute("refresh", (refresh1 == 0) ? 60 * 24 : (refresh1 == 1) ? 60 : document.getElementById('defaultrefresh1').value);
+      RSSList.firstChild.setAttribute("defaultBrowserHistory", (document.getElementById('defaultBrowserHistory').selectedIndex == 0) ? "true" : "false");
+      if (document.getElementById("backgroundColor").selectedIndex == 0)
+      {
+        RSSList.firstChild.setAttribute("red", "-1");
+        RSSList.firstChild.setAttribute("green", "-1");
+        RSSList.firstChild.setAttribute("blue", "-1");
+      }
+      else
+      {
+        RSSList.firstChild.setAttribute("red", document.getElementById("red1").value);
+        RSSList.firstChild.setAttribute("green", document.getElementById("green1").value);
+        RSSList.firstChild.setAttribute("blue", document.getElementById("blue1").value);
+      }
+      RSSList.firstChild.setAttribute("delay", document.getElementById("delay1").value);
+      RSSList.firstChild.setAttribute("switch", (document.getElementById('activity').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("submenu", (document.getElementById('submenu').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("scrolling", document.getElementById('scrolling').selectedIndex);
+      RSSList.firstChild.setAttribute("separateLine", (document.getElementById('linePosition').selectedIndex == 0) ? "false" : "true");
+      RSSList.firstChild.setAttribute("linePosition", (document.getElementById('linePosition').selectedIndex == 1) ? "top" : "bottom");
+      RSSList.firstChild.setAttribute("debug", (document.getElementById('debug').selectedIndex == 0) ? "true" : "bottom");
+      RSSList.firstChild.setAttribute("log", (document.getElementById('log').selectedIndex == 0) ? "true" : "bottom");
+      RSSList.firstChild.setAttribute("statusbar", (document.getElementById('statusbar').selectedIndex == 0) ? "true" : "bottom");
+      RSSList.firstChild.setAttribute("net", (document.getElementById('net').selectedIndex == 0) ? "true" : "bottom");
+      RSSList.firstChild.setAttribute("bold", (document.getElementById('inforss.bold').getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("italic", (document.getElementById('inforss.italic').getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("currentfeed", (document.getElementById('currentfeed').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("livemark", (document.getElementById('livemark').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("clipboard", (document.getElementById('clipboard').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("scrollingspeed", document.getElementById("scrollingspeed1").value);
+      RSSList.firstChild.setAttribute("scrollingIncrement", document.getElementById("scrollingIncrement1").value);
+      RSSList.firstChild.setAttribute("font", document.getElementById("fresh-font").value);
+      RSSList.firstChild.setAttribute("favicon", (document.getElementById('favicon').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("foregroundColor", (document.getElementById('foregroundColor').selectedIndex == 0) ? "auto" : document.getElementById('manualColor').color);
+      RSSList.firstChild.setAttribute("defaultForegroundColor", (document.getElementById('defaultForegroundColor').selectedIndex == 0) ? "default" : (document.getElementById('defaultForegroundColor').selectedIndex == 1) ? "sameas" : document.getElementById('defaultManualColor').color);
+      RSSList.firstChild.setAttribute("hideViewed", (document.getElementById('hideViewed').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("tooltip", (document.getElementById('tooltip').selectedIndex == 0) ? "description" : (document.getElementById('tooltip').selectedIndex == 1) ? "title" : (document.getElementById('tooltip').selectedIndex == 2) ? "allInfo" : "article");
+      RSSList.firstChild.setAttribute("clickHeadline", document.getElementById('clickHeadline').selectedIndex);
+      RSSList.firstChild.setAttribute("hideOld", (document.getElementById('hideOld').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("sortedMenu", (document.getElementById('sortedMenu').selectedIndex == 0) ? "no" : ((document.getElementById('sortedMenu').selectedIndex == 1) ? "asc" : "des"));
+      RSSList.firstChild.setAttribute("hideHistory", (document.getElementById('hideHistory').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("includeAssociated", (document.getElementById('includeAssociated').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("cycling", (document.getElementById('cycling').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("cyclingDelay", document.getElementById("cyclingDelay1").value);
+      RSSList.firstChild.setAttribute("nextFeed", (document.getElementById('nextFeed').selectedIndex == 0) ? "next" : "random");
+      RSSList.firstChild.setAttribute("defaultPurgeHistory", document.getElementById("defaultPurgeHistory").value);
+      RSSList.firstChild.setAttribute("timeslice", document.getElementById("timeslice").value);
+      RSSList.firstChild.setAttribute("fontSize", (document.getElementById('fontSize').selectedIndex == 0) ? "auto" : document.getElementById('fontSize1').value);
+      RSSList.firstChild.setAttribute("stopscrolling", (document.getElementById('stopscrolling').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("defaultGroupIcon", document.getElementById("defaultGroupIcon").value);
+      RSSList.firstChild.setAttribute("cycleWithinGroup", (document.getElementById('cycleWithinGroup').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("scrollingdirection", (document.getElementById('scrollingdirection').selectedIndex == 0) ? "rtl" : "ltr");
+      RSSList.firstChild.setAttribute("synchronizeIcon", (document.getElementById('synchronizeIcon').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("flashingIcon", (document.getElementById('flashingIcon').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("mouseEvent", (document.getElementById('mouseEvent').selectedIndex == 0) ? "0" : "-1");
+      RSSList.firstChild.setAttribute("popupMessage", (document.getElementById('popupMessage').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("playSound", (document.getElementById('playSound').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("defaultPlayPodcast", (document.getElementById('defaultPlayPodcast').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("displayEnclosure", (document.getElementById('displayEnclosure').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("displayBanned", (document.getElementById('displayBanned').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("savePodcastLocation", (document.getElementById('savePodcastLocation').selectedIndex == 0) ? document.getElementById('savePodcastLocation1').value : "");
+      RSSList.firstChild.setAttribute("collapseBar", (document.getElementById('collapseBar').selectedIndex == 0) ? "true" : "false");
+      RSSList.firstChild.setAttribute("mouseWheelScroll", (document.getElementById('mouseWheelScroll').selectedIndex == 0) ? "pixel" : (document.getElementById('mouseWheelScroll').selectedIndex == 1) ? "pixels" : "headline");
 
-       RSSList.firstChild.setAttribute("readAllIcon", (document.getElementById("readAllIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("viewAllIcon", (document.getElementById("viewAllIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("shuffleIcon", (document.getElementById("shuffleIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("directionIcon", (document.getElementById("directionIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("scrollingIcon", (document.getElementById("scrollingIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("previousIcon", (document.getElementById("previousIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("pauseIcon", (document.getElementById("pauseIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("nextIcon", (document.getElementById("nextIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("refreshIcon", (document.getElementById("refreshIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("hideOldIcon", (document.getElementById("hideOldIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("hideViewedIcon", (document.getElementById("hideViewedIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("synchronizationIcon", (document.getElementById("synchronizationIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("homeIcon", (document.getElementById("homeIcon").getAttribute("checked") == "true")? "true" : "false");
-       RSSList.firstChild.setAttribute("filterIcon", (document.getElementById("filterIcon").getAttribute("checked") == "true")? "true" : "false");
+      RSSList.firstChild.setAttribute("readAllIcon", (document.getElementById("readAllIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("viewAllIcon", (document.getElementById("viewAllIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("shuffleIcon", (document.getElementById("shuffleIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("directionIcon", (document.getElementById("directionIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("scrollingIcon", (document.getElementById("scrollingIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("previousIcon", (document.getElementById("previousIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("pauseIcon", (document.getElementById("pauseIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("nextIcon", (document.getElementById("nextIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("refreshIcon", (document.getElementById("refreshIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("hideOldIcon", (document.getElementById("hideOldIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("hideViewedIcon", (document.getElementById("hideViewedIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("synchronizationIcon", (document.getElementById("synchronizationIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("homeIcon", (document.getElementById("homeIcon").getAttribute("checked") == "true") ? "true" : "false");
+      RSSList.firstChild.setAttribute("filterIcon", (document.getElementById("filterIcon").getAttribute("checked") == "true") ? "true" : "false");
 
 
-       inforssXMLRepository.setServerInfo(document.getElementById('inforss.repo.urltype').value,
-                                          document.getElementById('ftpServer').value,
-                                          document.getElementById('repoDirectory').value,
-                                          document.getElementById('repoLogin').value,
-                                          document.getElementById('repoPassword').value,
-                                          (document.getElementById('repoAutoSync').selectedIndex == 0)? true : false
-                                          );
+      inforssXMLRepository.setServerInfo(document.getElementById('inforss.repo.urltype').value,
+        document.getElementById('ftpServer').value,
+        document.getElementById('repoDirectory').value,
+        document.getElementById('repoLogin').value,
+        document.getElementById('repoPassword').value,
+        (document.getElementById('repoAutoSync').selectedIndex == 0) ? true : false
+      );
 
-       returnValue = true;
-     }
-   }
-   catch (e)
-   {
-     inforssDebug(e);
-   }
-   return returnValue;
+      returnValue = true;
+    }
+  }
+  catch (e)
+  {
+    inforssDebug(e);
+  }
+  return returnValue;
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -1212,13 +1229,13 @@ function updateGroup(oldUrl, newUrl)
   try
   {
     var items = RSSList.getElementsByTagName("RSS");
-    for (var i=0; i < items.length; i++)
+    for (var i = 0; i < items.length; i++)
     {
       if (items[i].getAttribute("type") == "group")
       {
-      	var groupList = items[i].getElementsByTagName("GROUP");
-	    for (var j = 0; j < groupList.length; j++)
-	    {
+        var groupList = items[i].getElementsByTagName("GROUP");
+        for (var j = 0; j < groupList.length; j++)
+        {
           if (groupList[j].getAttribute("url") == oldUrl)
           {
             groupList[j].setAttribute("url", newUrl);
@@ -1235,51 +1252,51 @@ function updateGroup(oldUrl, newUrl)
 //-----------------------------------------------------------------------------------------------------
 function resetSettingDisabled(flag)
 {
-   var radio = document.getElementById('nbitem');
-   radio.setAttribute("disabled", flag);
-   radio.childNodes[0].setAttribute("disabled", flag);
-   radio.childNodes[1].setAttribute("disabled", flag);
-   var slider = document.getElementById('nbitem1');
-   slider.disabled = flag;
-   
-   radio = document.getElementById('lengthitem');
-   radio.setAttribute("disabled", flag);
-   radio.childNodes[0].setAttribute("disabled", flag);
-   radio.childNodes[1].setAttribute("disabled", flag);
-   slider = document.getElementById('lengthitem1');
-   slider.disabled = flag;
-   
-   radio = document.getElementById('inforss.refresh');
-   radio.setAttribute("disabled", flag);
-   radio.childNodes[0].setAttribute("disabled", flag);
-   radio.childNodes[1].setAttribute("disabled", flag);
-   radio.childNodes[2].setAttribute("disabled", flag);
-   slider = document.getElementById('refresh1');
-   slider.disabled = flag;
-   
-   slider = document.getElementById('purgeHistory');
-   slider.disabled = flag;
-   var button = document.getElementById('purgeHistory.button');
-   button.disabled = flag;
-   
-   radio = document.getElementById('playPodcast');
-   radio.setAttribute("disabled", flag);
-   radio.childNodes[0].setAttribute("disabled", flag);
-   radio.childNodes[1].setAttribute("disabled", flag);
-   
-   radio = document.getElementById('savePodcastLocation2');
-   radio.setAttribute("disabled", flag);
-   radio.childNodes[0].setAttribute("disabled", flag);
-   radio.childNodes[1].setAttribute("disabled", flag);
-   radio.nextSibling.childNodes[1].setAttribute("disabled", flag);
-   var textbox = document.getElementById('savePodcastLocation3');
-   textbox.disabled = flag;
-   textbox.nextSibling.setAttribute("disabled", flag);
-   
-   radio = document.getElementById('browserHistory');
-   radio.setAttribute("disabled", flag);
-   radio.childNodes[0].setAttribute("disabled", flag);
-   radio.childNodes[1].setAttribute("disabled", flag);  
+  var radio = document.getElementById('nbitem');
+  radio.setAttribute("disabled", flag);
+  radio.childNodes[0].setAttribute("disabled", flag);
+  radio.childNodes[1].setAttribute("disabled", flag);
+  var slider = document.getElementById('nbitem1');
+  slider.disabled = flag;
+
+  radio = document.getElementById('lengthitem');
+  radio.setAttribute("disabled", flag);
+  radio.childNodes[0].setAttribute("disabled", flag);
+  radio.childNodes[1].setAttribute("disabled", flag);
+  slider = document.getElementById('lengthitem1');
+  slider.disabled = flag;
+
+  radio = document.getElementById('inforss.refresh');
+  radio.setAttribute("disabled", flag);
+  radio.childNodes[0].setAttribute("disabled", flag);
+  radio.childNodes[1].setAttribute("disabled", flag);
+  radio.childNodes[2].setAttribute("disabled", flag);
+  slider = document.getElementById('refresh1');
+  slider.disabled = flag;
+
+  slider = document.getElementById('purgeHistory');
+  slider.disabled = flag;
+  var button = document.getElementById('purgeHistory.button');
+  button.disabled = flag;
+
+  radio = document.getElementById('playPodcast');
+  radio.setAttribute("disabled", flag);
+  radio.childNodes[0].setAttribute("disabled", flag);
+  radio.childNodes[1].setAttribute("disabled", flag);
+
+  radio = document.getElementById('savePodcastLocation2');
+  radio.setAttribute("disabled", flag);
+  radio.childNodes[0].setAttribute("disabled", flag);
+  radio.childNodes[1].setAttribute("disabled", flag);
+  radio.nextSibling.childNodes[1].setAttribute("disabled", flag);
+  var textbox = document.getElementById('savePodcastLocation3');
+  textbox.disabled = flag;
+  textbox.nextSibling.setAttribute("disabled", flag);
+
+  radio = document.getElementById('browserHistory');
+  radio.setAttribute("disabled", flag);
+  radio.childNodes[0].setAttribute("disabled", flag);
+  radio.childNodes[1].setAttribute("disabled", flag);
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -1296,8 +1313,8 @@ function validDialog()
         case "atom":
         case "html":
         case "html":
-        {
-          if ((document.getElementById('optionTitle').value == null) ||
+          {
+            if ((document.getElementById('optionTitle').value == null) ||
               (document.getElementById('optionTitle').value == "") ||
               (document.getElementById('optionUrl').value == null) ||
               (document.getElementById('optionUrl').value == "") ||
@@ -1307,61 +1324,61 @@ function validDialog()
               (document.getElementById('optionDescription').value == "") ||
               (document.getElementById('iconurl').value == null) ||
               (document.getElementById('iconurl').value == ""))
-          {
-            returnValue = false;
-            alert(document.getElementById("bundle_inforss").getString("inforss.pref.mandatory"));
-          }
-          if ((currentRSS.getAttribute("type") == "html") && (returnValue == true))
-          {
-            if ((currentRSS.getAttribute("regexp") == null) || (currentRSS.getAttribute("regexp") == ""))
             {
               returnValue = false;
-              alert(document.getElementById("bundle_inforss").getString("inforss.html.mandatory"));
+              alert(document.getElementById("bundle_inforss").getString("inforss.pref.mandatory"));
             }
-            else
+            if ((currentRSS.getAttribute("type") == "html") && (returnValue == true))
             {
-              if ((currentRSS.getAttribute("htmlTest") == null) || (currentRSS.getAttribute("htmlTest") == "") || (currentRSS.getAttribute("htmlTest") == "false"))
+              if ((currentRSS.getAttribute("regexp") == null) || (currentRSS.getAttribute("regexp") == ""))
               {
                 returnValue = false;
-                alert(document.getElementById("bundle_inforss").getString("inforss.html.test"));
+                alert(document.getElementById("bundle_inforss").getString("inforss.html.mandatory"));
+              }
+              else
+              {
+                if ((currentRSS.getAttribute("htmlTest") == null) || (currentRSS.getAttribute("htmlTest") == "") || (currentRSS.getAttribute("htmlTest") == "false"))
+                {
+                  returnValue = false;
+                  alert(document.getElementById("bundle_inforss").getString("inforss.html.test"));
+                }
               }
             }
+            break;
           }
-          break;
-        }
         case "group":
-        {
-          if ((document.getElementById("groupName").value == null) ||
+          {
+            if ((document.getElementById("groupName").value == null) ||
               (document.getElementById("groupName").value == "") ||
               (document.getElementById('iconurlgroup').value == null) ||
               (document.getElementById('iconurlgroup').value == ""))
-          {
-            returnValue = false;
-            alert(document.getElementById("bundle_inforss").getString("inforss.pref.mandatory"));
-          }
-          else
-          {
-            if (document.getElementById('playlistoption').selectedIndex == 0) // playlist = true
             {
-              var listbox = document.getElementById("group-playlist");
-              var richListItem = listbox.firstChild;
-              while ((richListItem != null) && (returnValue == true))
+              returnValue = false;
+              alert(document.getElementById("bundle_inforss").getString("inforss.pref.mandatory"));
+            }
+            else
+            {
+              if (document.getElementById('playlistoption').selectedIndex == 0) // playlist = true
               {
-                if ((richListItem.firstChild.firstChild.value == null) ||
+                var listbox = document.getElementById("group-playlist");
+                var richListItem = listbox.firstChild;
+                while ((richListItem != null) && (returnValue == true))
+                {
+                  if ((richListItem.firstChild.firstChild.value == null) ||
                     (richListItem.firstChild.firstChild.value == ""))
-                {
-                  returnValue = false;
-                  alert(document.getElementById("bundle_inforss").getString("inforss.delay.mandatory"));
-                }
-                else
-                {
-                  richListItem = richListItem.nextSibling;
+                  {
+                    returnValue = false;
+                    alert(document.getElementById("bundle_inforss").getString("inforss.delay.mandatory"));
+                  }
+                  else
+                  {
+                    richListItem = richListItem.nextSibling;
+                  }
                 }
               }
             }
+            break;
           }
-          break;
-        }
       }
       if (returnValue == true)
       {
@@ -1388,7 +1405,7 @@ function validDialog()
     if (returnValue == true)
     {
       if ((document.getElementById('defaultGroupIcon').value == null) ||
-          (document.getElementById('defaultGroupIcon').value == ""))
+        (document.getElementById('defaultGroupIcon').value == ""))
       {
         returnValue = false;
         alert(document.getElementById("bundle_inforss").getString("inforss.icongroup.mandatory"));
@@ -1398,12 +1415,12 @@ function validDialog()
     if (returnValue == true)
     {
       if ((document.getElementById('repoAutoSync').selectedIndex == 0) &&
-          (checkServerInfoValue() == false))
+        (checkServerInfoValue() == false))
       {
         returnValue = false;
         document.getElementById('inforss.option.tab').selectedIndex = 1;
         document.getElementById('inforss.listbox2').selectedIndex = 4;
-        document.getElementById('inforssTabpanelsAdvance').selectedIndex=3
+        document.getElementById('inforssTabpanelsAdvance').selectedIndex = 3
       }
     }
 
@@ -1411,34 +1428,34 @@ function validDialog()
     {
       if (document.getElementById('savePodcastLocation').selectedIndex == 0)
       {
-		if ((document.getElementById('savePodcastLocation1').value == null) ||
-		    (document.getElementById('savePodcastLocation1').value == ""))
+        if ((document.getElementById('savePodcastLocation1').value == null) ||
+          (document.getElementById('savePodcastLocation1').value == ""))
         {
-		  returnValue = false;
+          returnValue = false;
           alert(document.getElementById("bundle_inforss").getString("inforss.podcast.mandatory"));
-	    }
-	    else
-	    {
-		  try
-		  {
-	        var dir = Components.classes['@mozilla.org/file/local;1'].createInstance(Components.interfaces.nsILocalFile);
+        }
+        else
+        {
+          try
+          {
+            var dir = Components.classes['@mozilla.org/file/local;1'].createInstance(Components.interfaces.nsILocalFile);
             dir.initWithPath(document.getElementById('savePodcastLocation1').value);
             if ((dir.exists() == false) || (dir.isDirectory() == false))
             {
-		      returnValue = false;
-		    }
-		  }
-		  catch(ex)
-		  {
-		    returnValue = false;
-		  }
-		  if (returnValue == false)
-		  {
+              returnValue = false;
+            }
+          }
+          catch (ex)
+          {
+            returnValue = false;
+          }
+          if (returnValue == false)
+          {
             alert(document.getElementById("bundle_inforss").getString("inforss.podcast.location.notfound"));
-		  }
-		}
-		if (returnValue == false)
-		{
+          }
+        }
+        if (returnValue == false)
+        {
           document.getElementById('inforss.option.tab').selectedIndex = 1;
           document.getElementById('inforss.listbox2').selectedIndex = 0;
           document.getElementById('inforssTabpanelsAdvance').selectedIndex = 0
@@ -1450,34 +1467,34 @@ function validDialog()
     {
       if (document.getElementById('savePodcastLocation2').selectedIndex == 0)
       {
-		if ((document.getElementById('savePodcastLocation3').value == null) ||
-		    (document.getElementById('savePodcastLocation3').value == ""))
+        if ((document.getElementById('savePodcastLocation3').value == null) ||
+          (document.getElementById('savePodcastLocation3').value == ""))
         {
-		  returnValue = false;
+          returnValue = false;
           alert(document.getElementById("bundle_inforss").getString("inforss.podcast.mandatory"));
-	    }
-	    else
-	    {
-		  try
-		  {
-	        var dir = Components.classes['@mozilla.org/file/local;1'].createInstance(Components.interfaces.nsILocalFile);
+        }
+        else
+        {
+          try
+          {
+            var dir = Components.classes['@mozilla.org/file/local;1'].createInstance(Components.interfaces.nsILocalFile);
             dir.initWithPath(document.getElementById('savePodcastLocation3').value);
             if ((dir.exists() == false) || (dir.isDirectory() == false))
             {
-		      returnValue = false;
-		    }
-		  }
-		  catch(ex)
-		  {
-		    returnValue = false;
-		  }
-		  if (returnValue == false)
-		  {
+              returnValue = false;
+            }
+          }
+          catch (ex)
+          {
+            returnValue = false;
+          }
+          if (returnValue == false)
+          {
             alert(document.getElementById("bundle_inforss").getString("inforss.podcast.location.notfound"));
-		  }
-		}
-		if (returnValue == false)
-		{
+          }
+        }
+        if (returnValue == false)
+        {
           document.getElementById('inforss.option.tab').selectedIndex = 0;
           document.getElementById('inforss.listbox1').selectedIndex = 0;
           document.getElementById('inforssTabpanelsBasic').selectedIndex = 3;
@@ -1517,7 +1534,7 @@ function _remove()
       }
       if (confirm(document.getElementById("bundle_inforss").getString(key)))
       {
-        gRemovedUrl = ((gRemovedUrl == null)? "" : gRemovedUrl) + currentRSS.getAttribute("url") + "|";
+        gRemovedUrl = ((gRemovedUrl == null) ? "" : gRemovedUrl) + currentRSS.getAttribute("url") + "|";
         var parent = menuItem.parentNode;
         menuItem.parentNode.removeChild(menuItem);
         currentRSS.parentNode.removeChild(currentRSS);
@@ -1540,7 +1557,7 @@ function _remove()
             listitem = nextHbox;
           }
           var items = RSSList.getElementsByTagName("RSS");
-          for (var i = 0; i < items.length ; i++)
+          for (var i = 0; i < items.length; i++)
           {
             if (items[i].getAttribute("type") == "group")
             {
@@ -1587,11 +1604,16 @@ function newGroup()
 {
   try
   {
-     var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
-     var name1 = { value: document.getElementById("bundle_inforss").getString("inforss.group.defaultname")};
-     var valid  = promptService.prompt(window,document.getElementById("bundle_inforss").getString("inforss.group.newgroup"),
-                          document.getElementById("bundle_inforss").getString("inforss.group.newgroup"),
-                          name1, null, {value: null});
+    var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
+    var name1 = {
+      value: document.getElementById("bundle_inforss").getString("inforss.group.defaultname")
+    };
+    var valid = promptService.prompt(window, document.getElementById("bundle_inforss").getString("inforss.group.newgroup"),
+      document.getElementById("bundle_inforss").getString("inforss.group.newgroup"),
+      name1, null,
+      {
+        value: null
+      });
     var name = name1.value;
     if ((valid == true) && (name != null) && (name != ""))
     {
@@ -1602,26 +1624,26 @@ function newGroup()
       else
       {
         var rss = RSSList.createElement("RSS");
-        rss.setAttribute("url",name);
-        rss.setAttribute("title",name);
-        rss.setAttribute("description",name);
-        rss.setAttribute("type","group");
-        rss.setAttribute("icon","chrome://inforss/skin/group.png");
-        rss.setAttribute("filterPolicy","0");
-        rss.setAttribute("selected","false");
-        rss.setAttribute("filterCaseSensitive","true");
+        rss.setAttribute("url", name);
+        rss.setAttribute("title", name);
+        rss.setAttribute("description", name);
+        rss.setAttribute("type", "group");
+        rss.setAttribute("icon", "chrome://inforss/skin/group.png");
+        rss.setAttribute("filterPolicy", "0");
+        rss.setAttribute("selected", "false");
+        rss.setAttribute("filterCaseSensitive", "true");
         rss.setAttribute("activity", "true");
         rss.setAttribute("playlist", "false");
         RSSList.firstChild.appendChild(rss);
         var element = document.getElementById("rss-select-menu").appendItem(name, "newgroup");
-        element.setAttribute("class","menuitem-iconic");
-        element.setAttribute("image",rss.getAttribute("icon"));
+        element.setAttribute("class", "menuitem-iconic");
+        element.setAttribute("image", rss.getAttribute("icon"));
         element.setAttribute("url", name);
         document.getElementById("rss-select-menu").selectedIndex = gNbRss;
         gNbRss++;
         selectRSS(element);
 
-      	document.getElementById("inforss.group.treecell1").parentNode.setAttribute("url", rss.getAttribute("url"));
+        document.getElementById("inforss.group.treecell1").parentNode.setAttribute("url", rss.getAttribute("url"));
         document.getElementById("inforss.group.treecell1").setAttribute("properties", "on");
         document.getElementById("inforss.group.treecell2").setAttribute("properties", "unactive");
         document.getElementById("inforss.group.treecell3").setAttribute("label", "");
@@ -1642,84 +1664,92 @@ function newRss(type)
 {
   try
   {
-    var returnValue = {title:null, type:null, search:null, 
-                       keyword:null, url:null, user:null, 
-                       password:null, valid:false, regexp:null,
-                       regexpTitle:null,
-                       regexpDescription:null,
-                       regexpLink:null,
-                       regexpStartAfter:null,
-                       htmlDirection:null,
-                       htmlTest:null };
-    window.openDialog("chrome://inforss/content/inforssCaptureNewFeed.xul","_blank","modal,centerscreen,resizable=yes, dialog=yes", returnValue);
+    var returnValue = {
+      title: null,
+      type: null,
+      search: null,
+      keyword: null,
+      url: null,
+      user: null,
+      password: null,
+      valid: false,
+      regexp: null,
+      regexpTitle: null,
+      regexpDescription: null,
+      regexpLink: null,
+      regexpStartAfter: null,
+      htmlDirection: null,
+      htmlTest: null
+    };
+    window.openDialog("chrome://inforss/content/inforssCaptureNewFeed.xul", "_blank", "modal,centerscreen,resizable=yes, dialog=yes", returnValue);
     var type = returnValue.type;
     if (returnValue.valid == true)
-    { 
+    {
       switch (type)
-      { 
+      {
         case "rss":
         case "html":
         case "search":
-        case "twitter":	
-        {
-          var url = returnValue.url;
-          if (nameAlreadyExists(url) == true)
+        case "twitter":
           {
-            alert(document.getElementById("bundle_inforss").getString("inforss.rss.alreadyexists"));
-          }
-          else
-          {
-            var title = returnValue.title;
-            var user = returnValue.user;
-            var password = returnValue.password;
-            if (gRssTimeout != null)
+            var url = returnValue.url;
+            if (nameAlreadyExists(url) == true)
             {
-              window.clearTimeout(gRssTimeout);
-              gRssTimeout = null;
+              alert(document.getElementById("bundle_inforss").getString("inforss.rss.alreadyexists"));
             }
-            if (gRssXmlHttpRequest != null)
+            else
             {
-              gRssXmlHttpRequest.abort();
-            }
-            gRssTimeout = window.setTimeout("rssTimeout()", 10000);
-            gRssXmlHttpRequest = new XMLHttpRequest();
-            gRssXmlHttpRequest.open("GET", url, true, user, password);
-            gRssXmlHttpRequest.url = url;
-            gRssXmlHttpRequest.user = user;
-            gRssXmlHttpRequest.title = title;
-            gRssXmlHttpRequest.password = password;
-            document.getElementById("inforss.new.feed").setAttribute("disabled","true");
-            if ((type == "rss") || (type == "twitter")) // rss
-            {
-              gRssXmlHttpRequest.onload = processRss;
-              gRssXmlHttpRequest.onerror = rssTimeout;
-              gRssXmlHttpRequest.overrideMimeType("application/xml");
-            }
-            else 
-            {
-              gRssXmlHttpRequest.feedType = type;
-              gRssXmlHttpRequest.onload = processHtml;
-              gRssXmlHttpRequest.onerror = rssTimeout;
-              if (type == "search")
+              var title = returnValue.title;
+              var user = returnValue.user;
+              var password = returnValue.password;
+              if (gRssTimeout != null)
               {
-                gRssXmlHttpRequest.regexp = returnValue.regexp;
-                gRssXmlHttpRequest.regexpTitle = returnValue.regexpTitle;
-                gRssXmlHttpRequest.regexpDescription = returnValue.regexpDescription;
-                gRssXmlHttpRequest.regexpLink = returnValue.regexpLink;
-                gRssXmlHttpRequest.regexpStartAfter = returnValue.regexpStartAfter;
-                gRssXmlHttpRequest.htmlDirection = returnValue.htmlDirection;             
-                gRssXmlHttpRequest.htmlTest = returnValue.htmlTest;
+                window.clearTimeout(gRssTimeout);
+                gRssTimeout = null;
               }
+              if (gRssXmlHttpRequest != null)
+              {
+                gRssXmlHttpRequest.abort();
+              }
+              gRssTimeout = window.setTimeout("rssTimeout()", 10000);
+              gRssXmlHttpRequest = new XMLHttpRequest();
+              gRssXmlHttpRequest.open("GET", url, true, user, password);
+              gRssXmlHttpRequest.url = url;
+              gRssXmlHttpRequest.user = user;
+              gRssXmlHttpRequest.title = title;
+              gRssXmlHttpRequest.password = password;
+              document.getElementById("inforss.new.feed").setAttribute("disabled", "true");
+              if ((type == "rss") || (type == "twitter")) // rss
+              {
+                gRssXmlHttpRequest.onload = processRss;
+                gRssXmlHttpRequest.onerror = rssTimeout;
+                gRssXmlHttpRequest.overrideMimeType("application/xml");
+              }
+              else
+              {
+                gRssXmlHttpRequest.feedType = type;
+                gRssXmlHttpRequest.onload = processHtml;
+                gRssXmlHttpRequest.onerror = rssTimeout;
+                if (type == "search")
+                {
+                  gRssXmlHttpRequest.regexp = returnValue.regexp;
+                  gRssXmlHttpRequest.regexpTitle = returnValue.regexpTitle;
+                  gRssXmlHttpRequest.regexpDescription = returnValue.regexpDescription;
+                  gRssXmlHttpRequest.regexpLink = returnValue.regexpLink;
+                  gRssXmlHttpRequest.regexpStartAfter = returnValue.regexpStartAfter;
+                  gRssXmlHttpRequest.htmlDirection = returnValue.htmlDirection;
+                  gRssXmlHttpRequest.htmlTest = returnValue.htmlTest;
+                }
+              }
+              gRssXmlHttpRequest.send(null);
             }
-            gRssXmlHttpRequest.send(null);
+            break;
           }
-          break;
-        }
         case "nntp":
-        {
-          newNntp(returnValue);
-          break;
-        }
+          {
+            newNntp(returnValue);
+            break;
+          }
       }
     }
   }
@@ -1735,74 +1765,74 @@ function newNntp(type)
   try
   {
     var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
-        if (nameAlreadyExists(type.url) == true)
+    if (nameAlreadyExists(type.url) == true)
+    {
+      alert(document.getElementById("bundle_inforss").getString("inforss.nntp.alreadyexists"));
+    }
+    else
+    {
+      var test = testValidNntpUrl(type.url, type.user, type.password);
+      if (test.valid == false)
+      {
+        alert(document.getElementById("bundle_inforss").getString("inforss.nntp.malformedurl"));
+      }
+      else
+      {
+        var rss = RSSList.createElement("RSS");
+        rss.setAttribute("url", type.url);
+        var mainWebSite = test.url.substring(test.url.indexOf("."));
+        var index = mainWebSite.indexOf(":");
+        if (index != -1)
         {
-          alert(document.getElementById("bundle_inforss").getString("inforss.nntp.alreadyexists"));
+          mainWebSite = mainWebSite.substring(0, index);
         }
-        else
+        rss.setAttribute("link", "http://www" + mainWebSite);
+        rss.setAttribute("title", type.title);
+        rss.setAttribute("description", test.group);
+        rss.setAttribute("type", "nntp");
+        rss.setAttribute("icon", "chrome://inforss/skin/nntp.png");
+        rss.setAttribute("filterPolicy", "0");
+        rss.setAttribute("selected", "false");
+        rss.setAttribute("filterCaseSensitive", "true");
+        rss.setAttribute("activity", "true");
+
+        rss.setAttribute("filterPolicy", "0");
+
+        rss.setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
+        rss.setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
+        rss.setAttribute("playPodcast", RSSList.firstChild.getAttribute("defaultPlayPodcast"));
+        rss.setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
+        rss.setAttribute("savePodcastLocation", RSSList.firstChild.getAttribute("savePodcastLocation"));
+        rss.setAttribute("browserHistory", RSSList.firstChild.getAttribute("defaultBrowserHistory"));
+        rss.setAttribute("refresh", RSSList.firstChild.getAttribute("refresh"));
+        rss.setAttribute("user", type.user);
+        if ((type.user != null) && (type.user != ""))
         {
-          var test = testValidNntpUrl(type.url, type.user, type.password);
-          if (test.valid == false)
-          {
-            alert(document.getElementById("bundle_inforss").getString("inforss.nntp.malformedurl"));
-          }
-          else
-          {
-            var rss = RSSList.createElement("RSS");
-            rss.setAttribute("url", type.url);
-            var mainWebSite = test.url.substring(test.url.indexOf("."));
-            var index = mainWebSite.indexOf(":");
-            if (index != -1)
-            {
-              mainWebSite = mainWebSite.substring(0, index);
-            }
-            rss.setAttribute("link", "http://www" + mainWebSite);
-            rss.setAttribute("title", type.title);
-            rss.setAttribute("description", test.group);
-            rss.setAttribute("type","nntp");
-            rss.setAttribute("icon","chrome://inforss/skin/nntp.png");
-            rss.setAttribute("filterPolicy","0");
-            rss.setAttribute("selected","false");
-            rss.setAttribute("filterCaseSensitive","true");
-            rss.setAttribute("activity", "true");
-
-            rss.setAttribute("filterPolicy","0");
-
-            rss.setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
-            rss.setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
-            rss.setAttribute("playPodcast", RSSList.firstChild.getAttribute("defaultPlayPodcast"));
-            rss.setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
-            rss.setAttribute("savePodcastLocation", RSSList.firstChild.getAttribute("savePodcastLocation"));
-            rss.setAttribute("browserHistory", RSSList.firstChild.getAttribute("defaultBrowserHistory"));
-            rss.setAttribute("refresh",RSSList.firstChild.getAttribute("refresh"));
-            rss.setAttribute("user", type.user);
-            if ((type.user != null) && (type.user != ""))
-            {
-              inforssXMLRepository.storePassword(type.url, type.user, type.password);
-            }
-
-            rss.setAttribute("filter","all");
-            rss.setAttribute("filterCaseSensitive","true");
-            rss.setAttribute("encoding", "");
-
-
-            RSSList.firstChild.appendChild(rss);
-            var element = document.getElementById("rss-select-menu").appendItem(test.group, "nntp");
-            element.setAttribute("class","menuitem-iconic");
-            element.setAttribute("image",rss.getAttribute("icon"));
-            element.setAttribute("url", type.url);
-            document.getElementById("rss-select-menu").selectedIndex = gNbRss;
-            gNbRss++;
-            selectRSS(element);
-
-            document.getElementById("inforss.group.treecell1").parentNode.setAttribute("url", rss.getAttribute("url"));
-            document.getElementById("inforss.group.treecell1").setAttribute("properties", "on");
-            document.getElementById("inforss.group.treecell2").setAttribute("properties", "unactive");
-            document.getElementById("inforss.group.treecell3").setAttribute("label", "");
-            document.getElementById("inforss.group.treecell4").setAttribute("label", "");
-            document.getElementById("inforss.group.treecell5").setAttribute("label", ""); 
-          }
+          inforssXMLRepository.storePassword(type.url, type.user, type.password);
         }
+
+        rss.setAttribute("filter", "all");
+        rss.setAttribute("filterCaseSensitive", "true");
+        rss.setAttribute("encoding", "");
+
+
+        RSSList.firstChild.appendChild(rss);
+        var element = document.getElementById("rss-select-menu").appendItem(test.group, "nntp");
+        element.setAttribute("class", "menuitem-iconic");
+        element.setAttribute("image", rss.getAttribute("icon"));
+        element.setAttribute("url", type.url);
+        document.getElementById("rss-select-menu").selectedIndex = gNbRss;
+        gNbRss++;
+        selectRSS(element);
+
+        document.getElementById("inforss.group.treecell1").parentNode.setAttribute("url", rss.getAttribute("url"));
+        document.getElementById("inforss.group.treecell1").setAttribute("properties", "on");
+        document.getElementById("inforss.group.treecell2").setAttribute("properties", "unactive");
+        document.getElementById("inforss.group.treecell3").setAttribute("label", "");
+        document.getElementById("inforss.group.treecell4").setAttribute("label", "");
+        document.getElementById("inforss.group.treecell5").setAttribute("label", "");
+      }
+    }
   }
   catch (e)
   {
@@ -1813,7 +1843,9 @@ function newNntp(type)
 //-----------------------------------------------------------------------------------------------------
 function testValidNntpUrl(url, user, passwd)
 {
-  var returnValue = {valid: false};
+  var returnValue = {
+    valid: false
+  };
   try
   {
     if ((url.indexOf("news://") == 0) && (url.lastIndexOf("/") > 7))
@@ -1821,10 +1853,12 @@ function testValidNntpUrl(url, user, passwd)
       var newsHost = url.substring(7, url.lastIndexOf("/"));
       var group = url.substring(url.lastIndexOf("/") + 1);
 
-      var dataListener = 
-      {
-        onStartRequest: function(request, context){ },
-        onStopRequest: function(request, context, status){ instream.close(); },
+      var dataListener = {
+        onStartRequest: function(request, context) {},
+        onStopRequest: function(request, context, status)
+        {
+          instream.close();
+        },
         onDataAvailable: function(request, context, inputStream, offset, count)
         {
           var data = scriptablestream.read(count);
@@ -1836,49 +1870,49 @@ function testValidNntpUrl(url, user, passwd)
             switch (res[0])
             {
               case "200": // WELCOME
-              {
-                if ((user != null) && (user != ""))
                 {
-                  var outputData = "AUTHINFO USER " + user + "\r\n";
+                  if ((user != null) && (user != ""))
+                  {
+                    var outputData = "AUTHINFO USER " + user + "\r\n";
+                  }
+                  else
+                  {
+                    var outputData = "GROUP " + group + "\r\n";
+                  }
+                  outstream.write(outputData, outputData.length);
+                  pump.asyncRead(dataListener, null);
+                  break;
                 }
-                else
+              case "381": // USER
+                {
+                  var outputData = "AUTHINFO PASS " + passwd + "\r\n";
+                  outstream.write(outputData, outputData.length);
+                  pump.asyncRead(dataListener, null);
+                  break;
+                }
+              case "281": // PASS
                 {
                   var outputData = "GROUP " + group + "\r\n";
+                  outstream.write(outputData, outputData.length);
+                  pump.asyncRead(dataListener, null);
+                  break;
                 }
-                outstream.write(outputData, outputData.length);
-                pump.asyncRead(dataListener, null);
-                break;
-              }
-              case "381": // USER
-              {
-                var outputData = "AUTHINFO PASS " + passwd + "\r\n";
-                outstream.write(outputData, outputData.length);
-                pump.asyncRead(dataListener, null);                  
-                break;
-              }
-              case "281": // PASS
-              {
-                var outputData = "GROUP " + group + "\r\n";
-                outstream.write(outputData, outputData.length);
-                pump.asyncRead(dataListener, null);                  
-                break;
-              }
               case "211": // GROUP
-              {
-                instream.close();
-                break;
-              }
+                {
+                  instream.close();
+                  break;
+                }
               case "411": // BAD GROUP
-              {
-                alert(document.getElementById("bundle_inforss").getString("inforss.nntp.badgroup"));
-                instream.close();
-                break;
-              }
+                {
+                  alert(document.getElementById("bundle_inforss").getString("inforss.nntp.badgroup"));
+                  instream.close();
+                  break;
+                }
               default: // default
-              {
-                alert(document.getElementById("bundle_inforss").getString("inforss.nntp.error"));
-                instream.close();
-              }
+                {
+                  alert(document.getElementById("bundle_inforss").getString("inforss.nntp.error"));
+                  instream.close();
+                }
             }
           }
           else
@@ -1899,15 +1933,19 @@ function testValidNntpUrl(url, user, passwd)
       }
       var transport = transportService.createTransport(null, 0, newsUrl, port, null);
       transport.setTimeout(0, 3000);
-      var outstream = transport.openOutputStream(0,0,0);
-      var instream = transport.openInputStream(0,0,0);
+      var outstream = transport.openOutputStream(0, 0, 0);
+      var instream = transport.openInputStream(0, 0, 0);
       var scriptablestream = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
       scriptablestream.init(instream);
       var pump = Components.classes["@mozilla.org/network/input-stream-pump;1"].createInstance(Components.interfaces.nsIInputStreamPump);
       pump.init(instream, -1, -1, 0, 0, false);
-      pump.asyncRead(dataListener, null);    
-     
-      returnValue = {valid: true, url: newsHost, group: group};
+      pump.asyncRead(dataListener, null);
+
+      returnValue = {
+        valid: true,
+        url: newsHost,
+        group: group
+      };
     }
   }
   catch (e)
@@ -2020,12 +2058,12 @@ function setGroupCheckBox(rss)
     var checkbox = null;
     var label = null;
     var flag = document.getElementById("viewAllViewSelected").selectedIndex;
-    for (var i=1; i < listbox.childNodes.length; i++)
+    for (var i = 1; i < listbox.childNodes.length; i++)
     {
       listitem = listbox.childNodes[i];
       checkbox = listitem.childNodes[0];
       label = listitem.childNodes[1];
-      var selectedList = (rss == null)? null : rss.getElementsByTagName("GROUP");
+      var selectedList = (rss == null) ? null : rss.getElementsByTagName("GROUP");
       var find = false;
       var j = 0;
       if (selectedList != null)
@@ -2042,25 +2080,25 @@ function setGroupCheckBox(rss)
           }
         }
       }
-      checkbox.setAttribute("checked", (find == true)? "true" : "false");
+      checkbox.setAttribute("checked", (find == true) ? "true" : "false");
       if (flag == 0)
       {
-		listitem.setAttribute("collapsed", "false");
-	  }
-	  else
-	  {
-		if (find == true)
-		{
-		  listitem.setAttribute("collapsed", "false");
-		}
-		else
-		{
-		  listitem.setAttribute("collapsed", "true");
-		}
-	  }
+        listitem.setAttribute("collapsed", "false");
+      }
+      else
+      {
+        if (find == true)
+        {
+          listitem.setAttribute("collapsed", "false");
+        }
+        else
+        {
+          listitem.setAttribute("collapsed", "true");
+        }
+      }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2071,19 +2109,19 @@ function checkAll(obj)
 {
   try
   {
-    var flag = (obj.getAttribute("checked") == "true")? "false" : "true";
+    var flag = (obj.getAttribute("checked") == "true") ? "false" : "true";
     var listbox = document.getElementById("group-list-rss");
     var listitem = null;
     var checkbox = null;
     var label = null;
-    for (var i=1; i < listbox.childNodes.length; i++)
+    for (var i = 1; i < listbox.childNodes.length; i++)
     {
       listitem = listbox.childNodes[i];
       checkbox = listitem.childNodes[0];
       checkbox.setAttribute("checked", flag);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2095,9 +2133,9 @@ function selectRSS1(url, user)
   try
   {
     var password = inforssXMLRepository.readPassword(url, user);
-    document.getElementById("inforss.previous.rss").setAttribute("disabled","true");
-    document.getElementById("inforss.next.rss").setAttribute("disabled","true");
-    document.getElementById("inforss.new.feed").setAttribute("disabled","true");
+    document.getElementById("inforss.previous.rss").setAttribute("disabled", "true");
+    document.getElementById("inforss.next.rss").setAttribute("disabled", "true");
+    document.getElementById("inforss.new.feed").setAttribute("disabled", "true");
     if (gRssTimeout != null)
     {
       window.clearTimeout(gRssTimeout);
@@ -2114,9 +2152,9 @@ function selectRSS1(url, user)
     }
     var rss = inforssGetItemFromUrl(url);
     selectRSS2(rss);
-    
+
     currentRSS = rss;
-    document.getElementById("inforss.filter.anyall").selectedIndex = (rss.getAttribute("filter") == "all")? 0 : 1;
+    document.getElementById("inforss.filter.anyall").selectedIndex = (rss.getAttribute("filter") == "all") ? 0 : 1;
 
 
     resetFilter();
@@ -2135,12 +2173,12 @@ function selectRSS1(url, user)
     {
       initListCategories(null)
     }
-    
+
     document.getElementById("inforss.make.current").setAttribute("disabled", rss.getAttribute("selected") == "true");
-    document.getElementById("inforss.make.current.background").style.backgroundColor = (rss.getAttribute("selected") == "true")? "rgb(192,255,192)" : "inherit";
+    document.getElementById("inforss.make.current.background").style.backgroundColor = (rss.getAttribute("selected") == "true") ? "rgb(192,255,192)" : "inherit";
 
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2158,183 +2196,184 @@ function selectRSS2(rss)
       case "atom":
       case "html":
       case "nntp":
-      case "twitter":  
-      {
-        var br = document.getElementById("inforss.canvas.browser");
-        br.setAttribute("collapsed", "false");
+      case "twitter":
+        {
+          var br = document.getElementById("inforss.canvas.browser");
+          br.setAttribute("collapsed", "false");
 
-        br.docShell.allowAuth = false;  
-        br.docShell.allowImages = false;  
-        br.docShell.allowJavascript = false;  
-        br.docShell.allowMetaRedirects = false;  
-        br.docShell.allowPlugins = false;  
-        br.docShell.allowSubframes = false;
-        
-        if (rss.getAttribute("link").toLowerCase().indexOf("http") == 0)
-        {
-          br.setAttribute("src", rss.getAttribute("link"));
-        }
-        
-        document.getElementById("inforss.rsstype").selectedIndex = 0;
-        document.getElementById('optionTitle').value = rss.getAttribute("title");
-        document.getElementById('optionUrl').value = rss.getAttribute("url");
-        document.getElementById('optionLink').value = rss.getAttribute("link");
-        document.getElementById('inforss.homeLink').setAttribute("link", rss.getAttribute("link"));
-        document.getElementById('optionDescription').value = rss.getAttribute("description");
-        document.getElementById('inforss.filter.forgroup').setAttribute("collapsed","true");
-        document.getElementById('playListTabPanel').setAttribute("collapsed", "true");
-        
-        var canvas = document.getElementById("inforss.canvas");
-        canvas.setAttribute("link", rss.getAttribute("link"));
-        try
-        {
-          var ctx = canvas.getContext("2d");
-          if (applyScale == false)
+          br.docShell.allowAuth = false;
+          br.docShell.allowImages = false;
+          br.docShell.allowJavascript = false;
+          br.docShell.allowMetaRedirects = false;
+          br.docShell.allowPlugins = false;
+          br.docShell.allowSubframes = false;
+
+          if (rss.getAttribute("link").toLowerCase().indexOf("http") == 0)
           {
-            ctx.scale(0.5, 0.3);
-            applyScale = true;
+            br.setAttribute("src", rss.getAttribute("link"));
           }
-          ctx.clearRect(0, 0, 133, 100);
-          ctx.drawWindow(br.contentWindow, 0, 0, 800, 600, "rgb(255,255,255)");
-          refreshCount = 0;
-          window.setTimeout(updateCanvas, 2000);
-        }
-        catch(e1) {}
-        
-        var nbitem = rss.getAttribute("nbItem");
-        document.getElementById("nbitem").selectedIndex = (nbitem == "9999")? 0 : 1;
-        if (nbitem != "9999")
-        {
-          document.getElementById("nbitem1").value = nbitem;
-        }
-        var lengthitem = rss.getAttribute("lengthItem");
-        document.getElementById("lengthitem").selectedIndex = (lengthitem == "9999")? 0 : 1;
-        if (lengthitem != "9999")
-        {
-          document.getElementById('lengthitem1').value = lengthitem;
-        }
-        var refresh = rss.getAttribute("refresh");
-        if (refresh == 60*24)
-        {
-          document.getElementById("inforss.refresh").selectedIndex = 0;
-          document.getElementById("refresh1").value = 1;
-        }
-        else
-        {
-          document.getElementById("refresh1").value = refresh;
-          document.getElementById("inforss.refresh").selectedIndex = (refresh == 60)? 1 : 2;
-        }
-        document.getElementById("inforss.rss.icon").src = rss.getAttribute("icon");
-        document.getElementById("iconurl").value = rss.getAttribute("icon");
-        document.getElementById("inforss.rss.fetch").style.visibility = (rss.getAttribute("type") == "html")? "visible" : "hidden";
-        var playPodcast = rss.getAttribute("playPodcast");
-        document.getElementById("playPodcast").selectedIndex = (playPodcast == "true")? 0 : 1;
-        var savePodcastLocation = rss.getAttribute("savePodcastLocation");
-        document.getElementById("savePodcastLocation2").selectedIndex = (savePodcastLocation == "")? 1 : 0;
-        document.getElementById("savePodcastLocation3").value = savePodcastLocation;
-        var browserHistory = rss.getAttribute("browserHistory");
-        document.getElementById("browserHistory").selectedIndex = (browserHistory == "true")? 0 : 1;
-        var filterCaseSensitive = rss.getAttribute("filterCaseSensitive");
-        document.getElementById("filterCaseSensitive").selectedIndex = (filterCaseSensitive == "true")? 0 : 1;
-        document.getElementById("purgeHistory").value = rss.getAttribute("purgeHistory"); 
 
-    	var originalFeed = gInforssMediator.locateFeed(url);
-    	if (originalFeed != null)
-    	{
-    	  originalFeed = originalFeed.info;
-    	  if (originalFeed != null)
-    	  {
-    	    document.getElementById("inforss.feed.row1").setAttribute("selected","false");
-    	    document.getElementById("inforss.feed.row1").setAttribute("url",rss.getAttribute("url"));
-      	    document.getElementById("inforss.feed.treecell1").setAttribute("properties",(rss.getAttribute("activity") == "true")? "on" : "off");
-    	    document.getElementById("inforss.feed.treecell2").setAttribute("properties", (originalFeed.active == true)? "active" : "unactive");
-    	    document.getElementById("inforss.feed.treecell3").setAttribute("label", ((originalFeed.lastRefresh == null)? "" : inforssGetStringDate(originalFeed.lastRefresh)));
-    	    document.getElementById("inforss.feed.treecell4").setAttribute("label", (((originalFeed.lastRefresh == null) || (originalFeed.active == false) || (rss.getAttribute("activity") == "false"))? "" : inforssGetStringDate(new Date(eval(originalFeed.lastRefresh.getTime() + originalFeed.feedXML.getAttribute("refresh") * 60000)))));
-    	    document.getElementById("inforss.feed.treecell5").setAttribute("label", ((originalFeed.lastRefresh == null)? "" : originalFeed.getNbHeadlines()));
-    	    document.getElementById("inforss.feed.treecell6").setAttribute("label", ((originalFeed.lastRefresh == null)? "" : originalFeed.getNbUnread()));
-    	    document.getElementById("inforss.feed.treecell7").setAttribute("label", ((originalFeed.lastRefresh == null)? "" : originalFeed.getNbNew()));
-    	    document.getElementById("inforss.feed.treecell8").setAttribute("label", ((originalFeed.feedXML.getAttribute("groupAssociated") == "true")? "Y" : "N"));
-	      }
-        }
-        resetSettingDisabled(false);
-        break;
-      }
-      case "group":
-      {
-        document.getElementById("inforss.rsstype").selectedIndex = 1;
-        document.getElementById("groupName").value = rss.getAttribute("url");
-        document.getElementById("inforss.filter.policy").selectedIndex = rss.getAttribute("filterPolicy");
-        document.getElementById("inforss.group.icon").src = rss.getAttribute("icon");
-        document.getElementById("iconurlgroup").value = rss.getAttribute("icon");
-        document.getElementById('inforss.filter.forgroup').setAttribute("collapsed","false");
-        var filterCaseSensitive = rss.getAttribute("filterCaseSensitive");
-        document.getElementById("filterCaseSensitive").selectedIndex = (browserHistory == "true")? 0 : 1;
-        var playlist = rss.getAttribute("playlist");
-        document.getElementById("playlistoption").selectedIndex = (playlist == "true")? 0 : 1;
-        var listbox = document.getElementById("group-playlist");
-        while (listbox.firstChild != null)
-        {
-          listbox.removeChild(listbox.firstChild);
-        }
-        if (playlist == "true")
-        {
-          document.getElementById('playListTabPanel').setAttribute("collapsed", "false");
-          var playLists = rss.getElementsByTagName("playLists");
-          if (playLists.length != 0)
+          document.getElementById("inforss.rsstype").selectedIndex = 0;
+          document.getElementById('optionTitle').value = rss.getAttribute("title");
+          document.getElementById('optionUrl').value = rss.getAttribute("url");
+          document.getElementById('optionLink').value = rss.getAttribute("link");
+          document.getElementById('inforss.homeLink').setAttribute("link", rss.getAttribute("link"));
+          document.getElementById('optionDescription').value = rss.getAttribute("description");
+          document.getElementById('inforss.filter.forgroup').setAttribute("collapsed", "true");
+          document.getElementById('playListTabPanel').setAttribute("collapsed", "true");
+
+          var canvas = document.getElementById("inforss.canvas");
+          canvas.setAttribute("link", rss.getAttribute("link"));
+          try
           {
-            var platList = null;
-            var rss1 = null;
-            for (var i=0; i<playLists[0].childNodes.length; i++)
+            var ctx = canvas.getContext("2d");
+            if (applyScale == false)
             {
-              playList = playLists[0].childNodes[i];
-              rss1 = inforssGetItemFromUrl(playList.getAttribute("url"));
-              if (rss1 != null)
+              ctx.scale(0.5, 0.3);
+              applyScale = true;
+            }
+            ctx.clearRect(0, 0, 133, 100);
+            ctx.drawWindow(br.contentWindow, 0, 0, 800, 600, "rgb(255,255,255)");
+            refreshCount = 0;
+            window.setTimeout(updateCanvas, 2000);
+          }
+          catch (e1)
+          {}
+
+          var nbitem = rss.getAttribute("nbItem");
+          document.getElementById("nbitem").selectedIndex = (nbitem == "9999") ? 0 : 1;
+          if (nbitem != "9999")
+          {
+            document.getElementById("nbitem1").value = nbitem;
+          }
+          var lengthitem = rss.getAttribute("lengthItem");
+          document.getElementById("lengthitem").selectedIndex = (lengthitem == "9999") ? 0 : 1;
+          if (lengthitem != "9999")
+          {
+            document.getElementById('lengthitem1').value = lengthitem;
+          }
+          var refresh = rss.getAttribute("refresh");
+          if (refresh == 60 * 24)
+          {
+            document.getElementById("inforss.refresh").selectedIndex = 0;
+            document.getElementById("refresh1").value = 1;
+          }
+          else
+          {
+            document.getElementById("refresh1").value = refresh;
+            document.getElementById("inforss.refresh").selectedIndex = (refresh == 60) ? 1 : 2;
+          }
+          document.getElementById("inforss.rss.icon").src = rss.getAttribute("icon");
+          document.getElementById("iconurl").value = rss.getAttribute("icon");
+          document.getElementById("inforss.rss.fetch").style.visibility = (rss.getAttribute("type") == "html") ? "visible" : "hidden";
+          var playPodcast = rss.getAttribute("playPodcast");
+          document.getElementById("playPodcast").selectedIndex = (playPodcast == "true") ? 0 : 1;
+          var savePodcastLocation = rss.getAttribute("savePodcastLocation");
+          document.getElementById("savePodcastLocation2").selectedIndex = (savePodcastLocation == "") ? 1 : 0;
+          document.getElementById("savePodcastLocation3").value = savePodcastLocation;
+          var browserHistory = rss.getAttribute("browserHistory");
+          document.getElementById("browserHistory").selectedIndex = (browserHistory == "true") ? 0 : 1;
+          var filterCaseSensitive = rss.getAttribute("filterCaseSensitive");
+          document.getElementById("filterCaseSensitive").selectedIndex = (filterCaseSensitive == "true") ? 0 : 1;
+          document.getElementById("purgeHistory").value = rss.getAttribute("purgeHistory");
+
+          var originalFeed = gInforssMediator.locateFeed(url);
+          if (originalFeed != null)
+          {
+            originalFeed = originalFeed.info;
+            if (originalFeed != null)
+            {
+              document.getElementById("inforss.feed.row1").setAttribute("selected", "false");
+              document.getElementById("inforss.feed.row1").setAttribute("url", rss.getAttribute("url"));
+              document.getElementById("inforss.feed.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true") ? "on" : "off");
+              document.getElementById("inforss.feed.treecell2").setAttribute("properties", (originalFeed.active == true) ? "active" : "unactive");
+              document.getElementById("inforss.feed.treecell3").setAttribute("label", ((originalFeed.lastRefresh == null) ? "" : inforssGetStringDate(originalFeed.lastRefresh)));
+              document.getElementById("inforss.feed.treecell4").setAttribute("label", (((originalFeed.lastRefresh == null) || (originalFeed.active == false) || (rss.getAttribute("activity") == "false")) ? "" : inforssGetStringDate(new Date(eval(originalFeed.lastRefresh.getTime() + originalFeed.feedXML.getAttribute("refresh") * 60000)))));
+              document.getElementById("inforss.feed.treecell5").setAttribute("label", ((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbHeadlines()));
+              document.getElementById("inforss.feed.treecell6").setAttribute("label", ((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbUnread()));
+              document.getElementById("inforss.feed.treecell7").setAttribute("label", ((originalFeed.lastRefresh == null) ? "" : originalFeed.getNbNew()));
+              document.getElementById("inforss.feed.treecell8").setAttribute("label", ((originalFeed.feedXML.getAttribute("groupAssociated") == "true") ? "Y" : "N"));
+            }
+          }
+          resetSettingDisabled(false);
+          break;
+        }
+      case "group":
+        {
+          document.getElementById("inforss.rsstype").selectedIndex = 1;
+          document.getElementById("groupName").value = rss.getAttribute("url");
+          document.getElementById("inforss.filter.policy").selectedIndex = rss.getAttribute("filterPolicy");
+          document.getElementById("inforss.group.icon").src = rss.getAttribute("icon");
+          document.getElementById("iconurlgroup").value = rss.getAttribute("icon");
+          document.getElementById('inforss.filter.forgroup').setAttribute("collapsed", "false");
+          var filterCaseSensitive = rss.getAttribute("filterCaseSensitive");
+          document.getElementById("filterCaseSensitive").selectedIndex = (browserHistory == "true") ? 0 : 1;
+          var playlist = rss.getAttribute("playlist");
+          document.getElementById("playlistoption").selectedIndex = (playlist == "true") ? 0 : 1;
+          var listbox = document.getElementById("group-playlist");
+          while (listbox.firstChild != null)
+          {
+            listbox.removeChild(listbox.firstChild);
+          }
+          if (playlist == "true")
+          {
+            document.getElementById('playListTabPanel').setAttribute("collapsed", "false");
+            var playLists = rss.getElementsByTagName("playLists");
+            if (playLists.length != 0)
+            {
+              var platList = null;
+              var rss1 = null;
+              for (var i = 0; i < playLists[0].childNodes.length; i++)
               {
-                addToPlayList1(playList.getAttribute("delay"),
-                               rss1.getAttribute("icon"),
-                               rss1.getAttribute("title"),
-                               playList.getAttribute("url"));
+                playList = playLists[0].childNodes[i];
+                rss1 = inforssGetItemFromUrl(playList.getAttribute("url"));
+                if (rss1 != null)
+                {
+                  addToPlayList1(playList.getAttribute("delay"),
+                    rss1.getAttribute("icon"),
+                    rss1.getAttribute("title"),
+                    playList.getAttribute("url"));
+                }
               }
             }
           }
+          else
+          {
+            document.getElementById('playListTabPanel').setAttribute("collapsed", "true");
+          }
+          setGroupCheckBox(rss);
+          var originalFeed = gInforssMediator.locateFeed(url);
+          if (originalFeed != null)
+          {
+            originalFeed = originalFeed.info;
+            if (originalFeed != null)
+            {
+              document.getElementById("inforss.group.treecell1").parentNode.setAttribute("url", rss.getAttribute("url"));
+              document.getElementById("inforss.group.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true") ? "on" : "off");
+              document.getElementById("inforss.group.treecell2").setAttribute("properties", (originalFeed.active == true) ? "active" : "unactive");
+              document.getElementById("inforss.group.treecell3").setAttribute("label", originalFeed.getNbHeadlines());
+              document.getElementById("inforss.group.treecell4").setAttribute("label", originalFeed.getNbUnread());
+              document.getElementById("inforss.group.treecell5").setAttribute("label", originalFeed.getNbNew());
+            }
+          }
+          if (document.getElementById("inforss.checkall").hasAttribute("checked") == true)
+          {
+            document.getElementById("inforss.checkall").removeAttribute("checked");
+          }
+          document.getElementById("nbitem").selectedIndex = 0;
+          document.getElementById("nbitem1").value = 1;
+          document.getElementById("lengthitem").selectedIndex = 0;
+          document.getElementById('lengthitem1').value = 5;
+          document.getElementById("inforss.refresh").selectedIndex = 0;
+          document.getElementById("refresh1").value = 1;
+          document.getElementById("purgeHistory").value = 1;
+          document.getElementById("savePodcastLocation2").selectedIndex = 1;
+          resetSettingDisabled(true);
+          break;
         }
-        else
-        {
-          document.getElementById('playListTabPanel').setAttribute("collapsed", "true");
-        }
-        setGroupCheckBox(rss);
-    	var originalFeed = gInforssMediator.locateFeed(url);
-    	if (originalFeed != null)
-    	{
-    	  originalFeed = originalFeed.info;
-    	  if (originalFeed != null)
-    	  {
-      	    document.getElementById("inforss.group.treecell1").parentNode.setAttribute("url", rss.getAttribute("url"));
-      	    document.getElementById("inforss.group.treecell1").setAttribute("properties",(rss.getAttribute("activity") == "true")? "on" : "off");
-    	    document.getElementById("inforss.group.treecell2").setAttribute("properties", (originalFeed.active == true)? "active" : "unactive");
-    	    document.getElementById("inforss.group.treecell3").setAttribute("label", originalFeed.getNbHeadlines());
-    	    document.getElementById("inforss.group.treecell4").setAttribute("label", originalFeed.getNbUnread());
-    	    document.getElementById("inforss.group.treecell5").setAttribute("label", originalFeed.getNbNew());
-		  }
-        }
-        if (document.getElementById("inforss.checkall").hasAttribute("checked") == true)
-        {
-          document.getElementById("inforss.checkall").removeAttribute("checked");
-        }
-        document.getElementById("nbitem").selectedIndex =  0;
-        document.getElementById("nbitem1").value = 1;
-        document.getElementById("lengthitem").selectedIndex =  0;
-        document.getElementById('lengthitem1').value = 5;
-        document.getElementById("inforss.refresh").selectedIndex = 0;
-        document.getElementById("refresh1").value = 1;
-        document.getElementById("purgeHistory").value = 1;
-        document.getElementById("savePodcastLocation2").selectedIndex = 1;
-        resetSettingDisabled(true);
-        break;
-      }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2343,60 +2382,62 @@ function selectRSS2(rss)
 //-----------------------------------------------------------------------------------------------------
 function selectFeedReport(tree, event)
 {
-  var row = {}, colID = {}, type = {};
+  var row = {},
+    colID = {},
+    type = {};
 
   try
   {
     tree.treeBoxObject.getCellAt(event.clientX, event.clientY, row, colID, type);
     if (colID.value != null)
     {
-      if (typeof(colID.value) == "object")  //patch for firefox 1.1
+      if (typeof(colID.value) == "object") //patch for firefox 1.1
       {
         colID.value = colID.value.id;
       }
       if ((colID.value.indexOf(".report.activity") != -1) && (type.value == "image"))
       {
-    	    if (row.value >= gInforssNbFeed)
-	    {
-	      row.value--;
-	    }
+        if (row.value >= gInforssNbFeed)
+        {
+          row.value--;
+        }
         var row = tree.getElementsByTagName("treerow").item(row.value);
         var cell = row.firstChild;
         var treecols = tree.getElementsByTagName("treecols").item(0);
         var cell1 = treecols.firstChild;
         while (cell1.getAttribute("id").indexOf(".report.activity") == -1)
         {
-	      cell1 = cell1.nextSibling;
-	      if (cell1.nodeName != "splitter")
-	      {
-	        cell = cell.nextSibling;
+          cell1 = cell1.nextSibling;
+          if (cell1.nodeName != "splitter")
+          {
+            cell = cell.nextSibling;
           }
-	    }
-        cell.setAttribute("properties",(cell.getAttribute("properties").indexOf("on") != -1)? "off" : "on");
+        }
+        cell.setAttribute("properties", (cell.getAttribute("properties").indexOf("on") != -1) ? "off" : "on");
         var rss = inforssGetItemFromUrl(cell.parentNode.getAttribute("url"));
-        rss.setAttribute("activity", (rss.getAttribute("activity") == "true")? "false" : "true");
+        rss.setAttribute("activity", (rss.getAttribute("activity") == "true") ? "false" : "true");
         if (tree.getAttribute("id") != "inforss.tree3")
         {
-	  	  updateReport();
-	    }
-	    else
-	    {
-	      if (rss.getAttribute("url") == currentRSS.getAttribute("url"))
-	      {
-	        if (rss.getAttribute("type") != "group")
-	        {
-      	      document.getElementById("inforss.feed.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true")? "on" : "off");
-      	    }
-      	    else
-      	    {
-      	      document.getElementById("inforss.group.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true")? "on" : "off");
-      	    }
-	      }
-	    }
-	  }
+          updateReport();
+        }
+        else
+        {
+          if (rss.getAttribute("url") == currentRSS.getAttribute("url"))
+          {
+            if (rss.getAttribute("type") != "group")
+            {
+              document.getElementById("inforss.feed.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true") ? "on" : "off");
+            }
+            else
+            {
+              document.getElementById("inforss.group.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true") ? "on" : "off");
+            }
+          }
+        }
+      }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2412,16 +2453,16 @@ function addCell(str, parent, prop, type)
     if (type == "image")
     {
       treecell.setAttribute("src", str);
-	}
-	else
-	{
+    }
+    else
+    {
       treecell.setAttribute("label", str);
     }
     treecell.style.textAlign = "center";
-    treecell.setAttribute("properties","centered" + ((prop == null)? "" : " " +  prop));
+    treecell.setAttribute("properties", "centered" + ((prop == null) ? "" : " " + prop));
     parent.appendChild(treecell);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2430,31 +2471,31 @@ function addCell(str, parent, prop, type)
 //-----------------------------------------------------------------------------------------------------
 function resetFilter()
 {
-    var vbox = document.getElementById("inforss.filter.vbox");
-    var hbox = vbox.childNodes[3].nextSibling; // second filter
-    while (hbox != null)
-    {
-      var next = hbox.nextSibling;
-      hbox.parentNode.removeChild(hbox);
-      hbox = next;
-    }
-    var hbox = vbox.childNodes[3]; // first filter
-    changeStatusFilter1(hbox, "false");
+  var vbox = document.getElementById("inforss.filter.vbox");
+  var hbox = vbox.childNodes[3].nextSibling; // second filter
+  while (hbox != null)
+  {
+    var next = hbox.nextSibling;
+    hbox.parentNode.removeChild(hbox);
+    hbox = next;
+  }
+  var hbox = vbox.childNodes[3]; // first filter
+  changeStatusFilter1(hbox, "false");
 
-    hbox.childNodes[0].setAttribute("checked","false"); // checkbox
-    hbox.childNodes[1].selectedIndex = 0; //type
-    hbox.childNodes[2].selectedIndex = 0; //deck
-    hbox.childNodes[2].childNodes[0].childNodes[0].selectedIndex = 0; //include/exclude
-    hbox.childNodes[2].childNodes[0].childNodes[1].removeAllItems(); //text
-    var selectFolder = document.createElement("menupopup");
-    selectFolder.setAttribute("id","rss.filter.number.1");
-    hbox.childNodes[2].childNodes[0].childNodes[1].appendChild(selectFolder);
-    hbox.childNodes[2].childNodes[0].childNodes[1].value = ""; //text
-    hbox.childNodes[2].childNodes[1].childNodes[0].selectedIndex = 0; //more/less
-    hbox.childNodes[2].childNodes[1].childNodes[1].selectedIndex = 0; //1-100
-    hbox.childNodes[2].childNodes[1].childNodes[2].selectedIndex = 0; //sec, min,...
-    hbox.childNodes[2].childNodes[2].childNodes[0].selectedIndex = 0; //more/less
-    hbox.childNodes[2].childNodes[2].childNodes[1].selectedIndex = 0; //1-50
+  hbox.childNodes[0].setAttribute("checked", "false"); // checkbox
+  hbox.childNodes[1].selectedIndex = 0; //type
+  hbox.childNodes[2].selectedIndex = 0; //deck
+  hbox.childNodes[2].childNodes[0].childNodes[0].selectedIndex = 0; //include/exclude
+  hbox.childNodes[2].childNodes[0].childNodes[1].removeAllItems(); //text
+  var selectFolder = document.createElement("menupopup");
+  selectFolder.setAttribute("id", "rss.filter.number.1");
+  hbox.childNodes[2].childNodes[0].childNodes[1].appendChild(selectFolder);
+  hbox.childNodes[2].childNodes[0].childNodes[1].value = ""; //text
+  hbox.childNodes[2].childNodes[1].childNodes[0].selectedIndex = 0; //more/less
+  hbox.childNodes[2].childNodes[1].childNodes[1].selectedIndex = 0; //1-100
+  hbox.childNodes[2].childNodes[1].childNodes[2].selectedIndex = 0; //sec, min,...
+  hbox.childNodes[2].childNodes[2].childNodes[0].selectedIndex = 0; //more/less
+  hbox.childNodes[2].childNodes[2].childNodes[1].selectedIndex = 0; //1-50
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -2470,7 +2511,7 @@ function processCategories()
     gRssXmlHttpRequest = null;
     initListCategories(fm.getListOfCategories());
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2482,7 +2523,7 @@ function makeCurrent()
   try
   {
     var items = RSSList.getElementsByTagName("RSS");
-    for (var i = 0; i < items.length ; i++)
+    for (var i = 0; i < items.length; i++)
     {
       if (items[i].getAttribute("url") == currentRSS.getAttribute("url"))
       {
@@ -2500,7 +2541,7 @@ function makeCurrent()
     }
     makeCurrentInvoked = true;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2511,15 +2552,15 @@ function parseHtml()
 {
   try
   {
-    window.openDialog("chrome://inforss/content/inforssParseHtml.xul","_blank","chrome,centerscreen,resizable=yes, dialog=yes", currentRSS.getAttribute("url"), currentRSS.getAttribute("user"),
-                      currentRSS.getAttribute("regexp"), currentRSS.getAttribute("regexpTitle"),
-                      currentRSS.getAttribute("regexpDescription"), currentRSS.getAttribute("regexpPubDate"),
-                      currentRSS.getAttribute("regexpLink"), currentRSS.getAttribute("regexpCategory"),
-                      currentRSS.getAttribute("regexpStartAfter"), currentRSS.getAttribute("regexpStopBefore"),
-                      currentRSS.getAttribute("htmlDirection"), currentRSS.getAttribute("encoding"),
-                      currentRSS.getAttribute("htmlTest"));
+    window.openDialog("chrome://inforss/content/inforssParseHtml.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=yes", currentRSS.getAttribute("url"), currentRSS.getAttribute("user"),
+      currentRSS.getAttribute("regexp"), currentRSS.getAttribute("regexpTitle"),
+      currentRSS.getAttribute("regexpDescription"), currentRSS.getAttribute("regexpPubDate"),
+      currentRSS.getAttribute("regexpLink"), currentRSS.getAttribute("regexpCategory"),
+      currentRSS.getAttribute("regexpStartAfter"), currentRSS.getAttribute("regexpStopBefore"),
+      currentRSS.getAttribute("htmlDirection"), currentRSS.getAttribute("encoding"),
+      currentRSS.getAttribute("htmlTest"));
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2536,59 +2577,59 @@ function processRss()
     var fm = new FeedManager();
     fm.parse(gRssXmlHttpRequest);
     var rss = RSSList.createElement("RSS");
-    rss.setAttribute("title",fm.title);
-    rss.setAttribute("description",fm.description);
+    rss.setAttribute("title", fm.title);
+    rss.setAttribute("description", fm.description);
     rss.setAttribute("url", gRssXmlHttpRequest.url);
-    rss.setAttribute("link",fm.link);
-    rss.setAttribute("type",fm.type);
+    rss.setAttribute("link", fm.link);
+    rss.setAttribute("type", fm.type);
     rss.setAttribute("icon", inforssFindIcon(rss));
 
-    rss.setAttribute("filterPolicy","0");
+    rss.setAttribute("filterPolicy", "0");
 
-    rss.setAttribute("selected","false");
+    rss.setAttribute("selected", "false");
     rss.setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
     rss.setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
     rss.setAttribute("playPodcast", RSSList.firstChild.getAttribute("defaultPlayPodcast"));
     rss.setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
     rss.setAttribute("savePodcastLocation", RSSList.firstChild.getAttribute("savePodcastLocation"));
     rss.setAttribute("browserHistory", RSSList.firstChild.getAttribute("defaultBrowserHistory"));
-    rss.setAttribute("refresh",RSSList.firstChild.getAttribute("refresh"));
-    rss.setAttribute("user",gRssXmlHttpRequest.user);
+    rss.setAttribute("refresh", RSSList.firstChild.getAttribute("refresh"));
+    rss.setAttribute("user", gRssXmlHttpRequest.user);
     if ((gRssXmlHttpRequest.password != null) && (gRssXmlHttpRequest.password != ""))
     {
-    	inforssXMLRepository.storePassword(gRssXmlHttpRequest.url, gRssXmlHttpRequest.user, gRssXmlHttpRequest.password);
+      inforssXMLRepository.storePassword(gRssXmlHttpRequest.url, gRssXmlHttpRequest.user, gRssXmlHttpRequest.password);
     }
-    rss.setAttribute("filter","all");
-    rss.setAttribute("filterCaseSensitive","true");
+    rss.setAttribute("filter", "all");
+    rss.setAttribute("filterCaseSensitive", "true");
     rss.setAttribute("activity", "true");
     rss.setAttribute("encoding", "");
 
     RSSList.firstChild.appendChild(rss);
     var element = document.getElementById("rss-select-menu").appendItem(fm.title, "newrss");
-    element.setAttribute("class","menuitem-iconic");
-    element.setAttribute("image",rss.getAttribute("icon"));
+    element.setAttribute("class", "menuitem-iconic");
+    element.setAttribute("image", rss.getAttribute("icon"));
     element.setAttribute("url", gRssXmlHttpRequest.url);
     document.getElementById("rss-select-menu").selectedIndex = gNbRss;
     gNbRss++;
     gRssXmlHttpRequest = null;
     addRssToVbox(rss);
     selectRSS(element);
-    document.getElementById("inforss.new.feed").setAttribute("disabled","false");
+    document.getElementById("inforss.new.feed").setAttribute("disabled", "false");
 
 
-    document.getElementById("inforss.feed.row1").setAttribute("selected","false");
-    document.getElementById("inforss.feed.row1").setAttribute("url",rss.getAttribute("url"));
-    document.getElementById("inforss.feed.treecell1").setAttribute("properties",(rss.getAttribute("activity") == "true")? "on" : "off");
+    document.getElementById("inforss.feed.row1").setAttribute("selected", "false");
+    document.getElementById("inforss.feed.row1").setAttribute("url", rss.getAttribute("url"));
+    document.getElementById("inforss.feed.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true") ? "on" : "off");
     document.getElementById("inforss.feed.treecell2").setAttribute("properties", "unactive");
-    document.getElementById("inforss.feed.treecell3").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell4").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell5").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell6").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell7").setAttribute("label", "" );
+    document.getElementById("inforss.feed.treecell3").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell4").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell5").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell6").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell7").setAttribute("label", "");
     document.getElementById("inforss.feed.treecell8").setAttribute("label", "N");
 
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2608,38 +2649,38 @@ function processHtml()
       rss.setAttribute("description", gRssXmlHttpRequest.title);
       rss.setAttribute("url", gRssXmlHttpRequest.url);
       rss.setAttribute("link", gRssXmlHttpRequest.url);
-      rss.setAttribute("type","html");
+      rss.setAttribute("type", "html");
       rss.setAttribute("icon", inforssFindIcon(rss));
       if (gRssXmlHttpRequest.feedType == "search")
       {
-         rss.setAttribute("regexp", gRssXmlHttpRequest.regexp);
-         rss.setAttribute("regexpTitle", gRssXmlHttpRequest.regexpTitle);
-         rss.setAttribute("regexpDescription", gRssXmlHttpRequest.regexpDescription);
-         rss.setAttribute("regexpLink", gRssXmlHttpRequest.regexpLink);
-         rss.setAttribute("regexpStartAfter", gRssXmlHttpRequest.regexpStartAfter);
-         rss.setAttribute("htmlDirection", gRssXmlHttpRequest.htmlDirection);        
-         rss.setAttribute("htmlTest", gRssXmlHttpRequest.htmlTest);        
+        rss.setAttribute("regexp", gRssXmlHttpRequest.regexp);
+        rss.setAttribute("regexpTitle", gRssXmlHttpRequest.regexpTitle);
+        rss.setAttribute("regexpDescription", gRssXmlHttpRequest.regexpDescription);
+        rss.setAttribute("regexpLink", gRssXmlHttpRequest.regexpLink);
+        rss.setAttribute("regexpStartAfter", gRssXmlHttpRequest.regexpStartAfter);
+        rss.setAttribute("htmlDirection", gRssXmlHttpRequest.htmlDirection);
+        rss.setAttribute("htmlTest", gRssXmlHttpRequest.htmlTest);
       }
-      rss.setAttribute("filterPolicy","0");
+      rss.setAttribute("filterPolicy", "0");
 
-      rss.setAttribute("selected","false");
+      rss.setAttribute("selected", "false");
       rss.setAttribute("nbItem", RSSList.firstChild.getAttribute("defaultNbItem"));
       rss.setAttribute("lengthItem", RSSList.firstChild.getAttribute("defaultLenghtItem"));
       rss.setAttribute("playPodcast", RSSList.firstChild.getAttribute("defaultPlayPodcast"));
       rss.setAttribute("purgeHistory", RSSList.firstChild.getAttribute("defaultPurgeHistory"));
       rss.setAttribute("savePodcastLocation", RSSList.firstChild.getAttribute("savePodcastLocation"));
       rss.setAttribute("browserHistory", RSSList.firstChild.getAttribute("defaultBrowserHistory"));
-      rss.setAttribute("refresh",RSSList.firstChild.getAttribute("refresh"));
-      rss.setAttribute("user",gRssXmlHttpRequest.user);
-      rss.setAttribute("filter","all");
-      rss.setAttribute("filterCaseSensitive","true");
+      rss.setAttribute("refresh", RSSList.firstChild.getAttribute("refresh"));
+      rss.setAttribute("user", gRssXmlHttpRequest.user);
+      rss.setAttribute("filter", "all");
+      rss.setAttribute("filterCaseSensitive", "true");
       rss.setAttribute("activity", "true");
       rss.setAttribute("encoding", "");
 
       RSSList.firstChild.appendChild(rss);
       var element = document.getElementById("rss-select-menu").appendItem(gRssXmlHttpRequest.title, "newrss");
-      element.setAttribute("class","menuitem-iconic");
-      element.setAttribute("image",rss.getAttribute("icon"));
+      element.setAttribute("class", "menuitem-iconic");
+      element.setAttribute("image", rss.getAttribute("icon"));
       element.setAttribute("url", gRssXmlHttpRequest.url);
       document.getElementById("rss-select-menu").selectedIndex = gNbRss;
       gNbRss++;
@@ -2651,22 +2692,22 @@ function processHtml()
     {
       alert(document.getElementById("bundle_inforss").getString("inforss.feed.issue"));
     }
-    document.getElementById("inforss.new.feed").setAttribute("disabled","false");
+    document.getElementById("inforss.new.feed").setAttribute("disabled", "false");
 
 
-    document.getElementById("inforss.feed.row1").setAttribute("selected","false");
-    document.getElementById("inforss.feed.row1").setAttribute("url",rss.getAttribute("url"));
-    document.getElementById("inforss.feed.treecell1").setAttribute("properties",(rss.getAttribute("activity") == "true")? "on" : "off");
+    document.getElementById("inforss.feed.row1").setAttribute("selected", "false");
+    document.getElementById("inforss.feed.row1").setAttribute("url", rss.getAttribute("url"));
+    document.getElementById("inforss.feed.treecell1").setAttribute("properties", (rss.getAttribute("activity") == "true") ? "on" : "off");
     document.getElementById("inforss.feed.treecell2").setAttribute("properties", "unactive");
-    document.getElementById("inforss.feed.treecell3").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell4").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell5").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell6").setAttribute("label", "" );
-    document.getElementById("inforss.feed.treecell7").setAttribute("label", "" );
+    document.getElementById("inforss.feed.treecell3").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell4").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell5").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell6").setAttribute("label", "");
+    document.getElementById("inforss.feed.treecell7").setAttribute("label", "");
     document.getElementById("inforss.feed.treecell8").setAttribute("label", "N");
 
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2688,15 +2729,15 @@ function initListCategories(listCategory)
     var vbox = document.getElementById("inforss.filter.vbox");
     var hbox = vbox.childNodes[3]; // first filter
     var menu = hbox.childNodes[2].childNodes[0].childNodes[1]; //text
-    for (var i=0; i<listCategory.length; i++)
+    for (var i = 0; i < listCategory.length; i++)
     {
       var newElem = document.createElement("menuitem");
       newElem.setAttribute("label", listCategory[i]);
-	  menu.firstChild.appendChild(newElem);
+      menu.firstChild.appendChild(newElem);
     }
     initFilter();
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2721,7 +2762,7 @@ function initFilter()
 
         checkbox.setAttribute("checked", items[i].getAttribute("active"));
         type.selectedIndex = items[i].getAttribute("type");
-        deck.selectedIndex = (type.selectedIndex <= 2)? 0 : ((type.selectedIndex <= 5)? 1 : 2);
+        deck.selectedIndex = (type.selectedIndex <= 2) ? 0 : ((type.selectedIndex <= 5) ? 1 : 2);
         deck.childNodes[0].childNodes[0].selectedIndex = items[i].getAttribute("include");
         deck.childNodes[0].childNodes[1].value = items[i].getAttribute("text");
         deck.childNodes[1].childNodes[0].selectedIndex = items[i].getAttribute("compare");
@@ -2755,10 +2796,10 @@ function initFilter()
       {
         document.getElementById("inforss.next.rss").setAttribute("disabled", false);
       }
-      document.getElementById("inforss.new.feed").setAttribute("disabled","false");
+      document.getElementById("inforss.new.feed").setAttribute("disabled", "false");
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2777,7 +2818,7 @@ function rssCategoryTimeout()
       gRssXmlHttpRequest = null;
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2795,19 +2836,18 @@ function rssTimeout()
         window.clearTimeout(gRssTimeout);
         gRssTimeout = null;
       }
-      catch(e)
-      {
-      }
+      catch (e)
+      {}
     }
     if (gRssXmlHttpRequest != null)
     {
       gRssXmlHttpRequest.abort();
       gRssXmlHttpRequest = null;
     }
-    document.getElementById("inforss.new.feed").setAttribute("disabled","false");
+    document.getElementById("inforss.new.feed").setAttribute("disabled", "false");
     alert(document.getElementById("bundle_inforss").getString("inforss.feed.issue"));
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2830,7 +2870,7 @@ function inforssGetItemFromUrl(url)
       i++;
     }
   }
-  return (find == true)? items[i] : null;
+  return (find == true) ? items[i] : null;
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -2840,7 +2880,7 @@ function resetRepository()
   {
     inforssRestoreRepository();
     var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-    observerService.notifyObservers(null,"rssChanged","total");
+    observerService.notifyObservers(null, "rssChanged", "total");
     init();
   }
 }
@@ -2849,7 +2889,7 @@ function resetRepository()
 function sendEventToMainWindow()
 {
   var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-  observerService.notifyObservers(null,"rssChanged","total");
+  observerService.notifyObservers(null, "rssChanged", "total");
 }
 
 
@@ -2859,7 +2899,7 @@ function clearRdf()
   if (confirm(document.getElementById("bundle_inforss").getString("inforss.reset.rdf")))
   {
     var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-    observerService.notifyObservers(null,"clearRdf","");
+    observerService.notifyObservers(null, "clearRdf", "");
   }
 }
 
@@ -2868,20 +2908,20 @@ function exportLivemark()
 {
   try
   {
-    kRDFRSCIID       = Components.interfaces.nsIRDFResource;
-    kRDFLITIID       = Components.interfaces.nsIRDFLiteral;
-    RDF              = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
-    RDFC             = Components.classes["@mozilla.org/rdf/container;1"].createInstance(Components.interfaces.nsIRDFContainer);
+    kRDFRSCIID = Components.interfaces.nsIRDFResource;
+    kRDFLITIID = Components.interfaces.nsIRDFLiteral;
+    RDF = Components.classes["@mozilla.org/rdf/rdf-service;1"].getService(Components.interfaces.nsIRDFService);
+    RDFC = Components.classes["@mozilla.org/rdf/container;1"].createInstance(Components.interfaces.nsIRDFContainer);
 
-    BMDS  = RDF.GetDataSource("rdf:bookmarks");
+    BMDS = RDF.GetDataSource("rdf:bookmarks");
     BMSVC = BMDS.QueryInterface(Components.interfaces.nsIBookmarksService);
 
-    RDFCU            = Components.classes["@mozilla.org/rdf/container-utils;1"].getService(Components.interfaces.nsIRDFContainerUtils);
+    RDFCU = Components.classes["@mozilla.org/rdf/container-utils;1"].getService(Components.interfaces.nsIRDFContainerUtils);
 
     var urlPredicateResource = RDF.GetResource("http://home.netscape.com/NC-rdf#Name");
     var urlTargetLiteral = RDF.GetLiteral("InfoRSS Feeds");
     var mainFolder = BMDS.GetSource(urlPredicateResource, urlTargetLiteral, true);
-    if ( mainFolder != null)
+    if (mainFolder != null)
     {
       RDFC.Init(BMDS, RDF.GetResource("NC:BookmarksRoot"));
       RDFC.RemoveElement(mainFolder, false);
@@ -2894,31 +2934,36 @@ function exportLivemark()
     var predicateName = RDF.GetResource("http://home.netscape.com/NC-rdf#Name");
 
     var items = RSSList.getElementsByTagName("RSS");
-    for (var i=0; i < items.length; i++)
+    for (var i = 0; i < items.length; i++)
     {
       if ((items[i].getAttribute("type") == "rss") || (items[i].getAttribute("type") == "atom"))
       {
         var feed = BMSVC.createFolderInContainer(items[i].getAttribute("title"), new_folder, null);
 
         var newValue = RDF.GetResource("http://home.netscape.com/NC-rdf#Livemark");
-        BMDS.Change(feed, predicateType, {}, newValue);
+        BMDS.Change(feed, predicateType,
+        {}, newValue);
 
         newValue = RDF.GetLiteral(items[i].getAttribute("title"));
-        BMDS.Change(feed, predicateName, {}, newValue);
+        BMDS.Change(feed, predicateName,
+        {}, newValue);
 
         newValue = RDF.GetLiteral(items[i].getAttribute("link"));
-        BMDS.Change(feed, predicateURL, {}, newValue);
+        BMDS.Change(feed, predicateURL,
+        {}, newValue);
 
         newValue = RDF.GetLiteral(items[i].getAttribute("url"));
-        BMDS.Change(feed, predicateFeedURL, {}, newValue);
+        BMDS.Change(feed, predicateFeedURL,
+        {}, newValue);
 
         newValue = RDF.GetLiteral(items[i].getAttribute("description"));
-        BMDS.Change(feed, predicateDescription, {}, newValue);
+        BMDS.Change(feed, predicateDescription,
+        {}, newValue);
       }
     }
     alert(document.getElementById("bundle_inforss").getString("inforss.export.livemark"));
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2932,15 +2977,15 @@ function exportBrowser()
     var topMostBrowser = getTopMostBrowser();
     if (topMostBrowser != null)
     {
-      var file = file=Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+      var file = file = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
       file.append(INFORSS_REPOSITORY);
-      if ( file.exists() == true )
+      if (file.exists() == true)
       {
         topMostBrowser.addTab("file:///" + file.path);
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -2949,20 +2994,20 @@ function exportBrowser()
 //-----------------------------------------------------------------------------------------------------
 function getTopMostBrowser()
 {
-	var topMostBrowser = null;
-	var windowManager = Components.classes['@mozilla.org/appshell/window-mediator;1'].getService(Components.interfaces.nsIWindowMediator);
-	var topMostWindow = windowManager.getMostRecentWindow("navigator:browser");
-	if (topMostWindow)
-	{
-	  topMostBrowser = topMostWindow.document.getElementById('content');
-	}
-	return topMostBrowser;
+  var topMostBrowser = null;
+  var windowManager = Components.classes['@mozilla.org/appshell/window-mediator;1'].getService(Components.interfaces.nsIWindowMediator);
+  var topMostWindow = windowManager.getMostRecentWindow("navigator:browser");
+  if (topMostWindow)
+  {
+    topMostBrowser = topMostWindow.document.getElementById('content');
+  }
+  return topMostBrowser;
 }
 
 //-----------------------------------------------------------------------------------------------------
 function changeFilterType(obj)
 {
-  obj.nextSibling.selectedIndex = ((obj.selectedIndex <= 2)? 0 : ((obj.selectedIndex <= 5)? 1 : 2));
+  obj.nextSibling.selectedIndex = ((obj.selectedIndex <= 2) ? 0 : ((obj.selectedIndex <= 5) ? 1 : 2));
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -2979,12 +3024,12 @@ function addFilter(obj)
     {
       hbox = obj.parentNode.cloneNode(true);
       obj.parentNode.parentNode.appendChild(hbox);
-      hbox.childNodes[0].setAttribute("checked","true");
+      hbox.childNodes[0].setAttribute("checked", "true");
       hbox.childNodes[2].childNodes[0].childNodes[1].value = ""; //text
       changeStatusFilter1(hbox, "false");
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3012,7 +3057,7 @@ function removeFilter(obj)
       }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3022,7 +3067,7 @@ function removeFilter(obj)
 function changeStatusFilter(button)
 {
   var hbox = button.parentNode;
-  var status = (button.getAttribute("checked") == "true")? "true" : "false";
+  var status = (button.getAttribute("checked") == "true") ? "true" : "false";
   changeStatusFilter1(hbox, status);
 }
 
@@ -3078,7 +3123,7 @@ function setHtmlFeed(url, regexp, headline, article, pubdate, link, category, st
     currentRSS.setAttribute("htmlTest", htmlTest);
     document.getElementById('optionUrl').value = url;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3097,7 +3142,7 @@ function resetIcon()
       document.getElementById('inforss.rss.icon').src = document.getElementById('iconurl').value;
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3116,7 +3161,7 @@ function resetIconGroup()
       document.getElementById('inforss.group.icon').src = document.getElementById('iconurlgroup').value;
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3132,7 +3177,7 @@ function resetDefaultIconGroup()
     document.getElementById('defaultGroupIcon').value = INFORSS_DEFAULT_GROUP_ICON;
     document.getElementById('inforss.defaultgroup.icon').src = document.getElementById('defaultGroupIcon').value;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3147,7 +3192,7 @@ function setIcon()
   {
     document.getElementById('inforss.rss.icon').src = document.getElementById('iconurl').value;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3161,7 +3206,7 @@ function updateCanvas()
   try
   {
     var br = document.getElementById("inforss.canvas.browser");
-        
+
     var canvas = document.getElementById("inforss.canvas");
     var ctx = canvas.getContext("2d");
     ctx.drawWindow(br.contentWindow, 0, 0, 800, 600, "rgb(255,255,255)");
@@ -3175,7 +3220,7 @@ function updateCanvas()
       br.setAttribute("collapsed", "true");
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3196,7 +3241,7 @@ function canvasOver(event)
     {
       newx = parseInt(canvas1.style.width) - parseInt(canvas.getAttribute("width")) - 2;
     }
-    if (newy > (parseInt(canvas1.style.height) - parseInt(canvas.getAttribute("height")) -5))
+    if (newy > (parseInt(canvas1.style.height) - parseInt(canvas.getAttribute("height")) - 5))
     {
       newy = parseInt(canvas1.style.height) - parseInt(canvas.getAttribute("height")) - 5;
     }
@@ -3211,9 +3256,10 @@ function canvasOver(event)
       ctx.drawWindow(br.contentWindow, 0, 0, 800, 600, "rgb(255,255,255)");
       document.getElementById("inforss.magnify").style.visibility = "visible";
     }
-    catch(e1) {}
+    catch (e1)
+    {}
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3228,7 +3274,7 @@ function canvasOut()
   {
     document.getElementById("inforss.magnify").style.visibility = "hidden";
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3243,7 +3289,7 @@ function canvasMove(event)
   {
     var br = document.getElementById("inforss.canvas.browser");
 
-        
+
     var canvas = document.getElementById("inforss.magnify.canvas");
     var canvas1 = document.getElementById("inforss.canvas");
     var newx1 = eval(event.clientX - canvas1.offsetLeft);
@@ -3254,7 +3300,7 @@ function canvasMove(event)
     {
       newx = parseInt(canvas1.style.width) - parseInt(canvas.getAttribute("width")) - 2;
     }
-    if (newy > (parseInt(canvas1.style.height) - parseInt(canvas.getAttribute("height")) -5))
+    if (newy > (parseInt(canvas1.style.height) - parseInt(canvas.getAttribute("height")) - 5))
     {
       newy = parseInt(canvas1.style.height) - parseInt(canvas.getAttribute("height")) - 5;
     }
@@ -3270,15 +3316,16 @@ function canvasMove(event)
       ctx.drawWindow(br.contentWindow, 0, 0, 800, 600, "rgb(255,255,255)");
       ctx.restore();
     }
-    catch(e1) {}
+    catch (e1)
+    {}
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
   inforssTraceOut();
 }
-	
+
 //-----------------------------------------------------------------------------------------------------
 function setIconGroup()
 {
@@ -3287,7 +3334,7 @@ function setIconGroup()
   {
     document.getElementById('inforss.group.icon').src = document.getElementById('iconurlgroup').value;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3302,7 +3349,7 @@ function setDefaultIconGroup()
   {
     document.getElementById('inforss.defaultgroup.icon').src = document.getElementById('defaultGroupIcon').value;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3326,7 +3373,7 @@ function copyLocalToRemote()
       window.setTimeout(inforssCopyLocalToRemote, 100, protocol, server, directory, user, password, ftpUploadCallback, true);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3350,7 +3397,7 @@ function copyRemoteToLocal()
       window.setTimeout(inforssCopyRemoteToLocal, 100, protocol, server, directory, user, password, ftpDownloadCallback);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3365,19 +3412,19 @@ function checkServerInfoValue()
   try
   {
     if ((document.getElementById('ftpServer').value == null) ||
-        (document.getElementById('ftpServer').value == "") ||
-        (document.getElementById('repoDirectory').value == null) ||
-        (document.getElementById('repoDirectory').value == "") ||
-        (document.getElementById('repoLogin').value == null) ||
-        (document.getElementById('repoLogin').value == "") ||
-        (document.getElementById('repoPassword').value == null) ||
-        (document.getElementById('repoPassword').value == ""))
+      (document.getElementById('ftpServer').value == "") ||
+      (document.getElementById('repoDirectory').value == null) ||
+      (document.getElementById('repoDirectory').value == "") ||
+      (document.getElementById('repoLogin').value == null) ||
+      (document.getElementById('repoLogin').value == "") ||
+      (document.getElementById('repoPassword').value == null) ||
+      (document.getElementById('repoPassword').value == ""))
     {
       returnValue = false;
       alert(document.getElementById("bundle_inforss").getString("inforss.serverinfo.mandatory"));
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3402,7 +3449,7 @@ function ftpUploadCallback(step, status)
       defineVisibilityButton("false", "upload");
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3431,7 +3478,7 @@ function ftpDownloadCallback(step, status)
       setImportProgressionBar(100);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3444,21 +3491,21 @@ function defineVisibilityButton(flag, action)
   inforssTraceIn();
   try
   {
-      var accept = document.getElementById('inforssOption').getButton("accept");
-      accept.setAttribute("disabled", flag);
-      var apply = document.getElementById('inforss.apply');
-      apply.setAttribute("disabled", flag);
-      if (action == "download")
-      {
-        document.getElementById("inforss.deck.importfromremote").selectedIndex = (flag == "true")? 1 : 0;
-      }
-      else
-      {
-        document.getElementById("inforss.deck.exporttoremote").selectedIndex = (flag == "true")? 1 : 0;
-      }
-      setImportProgressionBar(0);
+    var accept = document.getElementById('inforssOption').getButton("accept");
+    accept.setAttribute("disabled", flag);
+    var apply = document.getElementById('inforss.apply');
+    apply.setAttribute("disabled", flag);
+    if (action == "download")
+    {
+      document.getElementById("inforss.deck.importfromremote").selectedIndex = (flag == "true") ? 1 : 0;
+    }
+    else
+    {
+      document.getElementById("inforss.deck.exporttoremote").selectedIndex = (flag == "true") ? 1 : 0;
+    }
+    setImportProgressionBar(0);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3480,7 +3527,7 @@ function setImportProgressionBar(value)
       document.getElementById("inforss.repo.synchronize.exporttoremote.exportProgressBar").value = value;
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3494,10 +3541,10 @@ function purgeNow()
   try
   {
     var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-    observerService.notifyObservers(null,"purgeRdf",null);
+    observerService.notifyObservers(null, "purgeRdf", null);
     observerService = null;
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3509,21 +3556,21 @@ function openURL(url)
 {
   if ((navigator.vendor == "Thunderbird") || (navigator.vendor == "Linspire Inc."))
   {
-    window.openDialog("chrome://inforss/content/inforssBrowser.xul","_blank","chrome,centerscreen,resizable=yes, dialog=no", url);
+    window.openDialog("chrome://inforss/content/inforssBrowser.xul", "_blank", "chrome,centerscreen,resizable=yes, dialog=no", url);
   }
   else
   {
     if (window.opener.getBrowser)
     {
-	  if (testCreateTab() == true)
-	  {
+      if (testCreateTab() == true)
+      {
         var newTab = window.opener.getBrowser().addTab(url);
         window.opener.getBrowser().selectedTab = newTab;
       }
       else
       {
         window.opener.getBrowser().loadURI(url);
-	  }
+      }
     }
     else
     {
@@ -3535,17 +3582,17 @@ function openURL(url)
 //-----------------------------------------------------------------------------------------------------
 function testCreateTab()
 {
-    var returnValue = true;
-    if (window.opener.getBrowser().browsers.length == 1)
+  var returnValue = true;
+  if (window.opener.getBrowser().browsers.length == 1)
+  {
+    if ((window.opener.getBrowser().currentURI == null) ||
+      ((window.opener.getBrowser().currentURI.spec == "") && (window.opener.getBrowser().selectedBrowser.webProgress.isLoadingDocument == true)) ||
+      (window.opener.getBrowser().currentURI.spec == "about:blank"))
     {
-      if ((window.opener.getBrowser().currentURI == null) ||
-          ((window.opener.getBrowser().currentURI.spec == "") && (window.opener.getBrowser().selectedBrowser.webProgress.isLoadingDocument == true)) ||
-          (window.opener.getBrowser().currentURI.spec == "about:blank"))
-      {
-        returnValue = false;
-      }
+      returnValue = false;
     }
-    return returnValue;
+  }
+  return returnValue;
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -3560,12 +3607,12 @@ function locateExportEnclosure(suf1, suf2)
     var response = dirPicker.show();
     if ((response == dirPicker.returnOK) || (response == dirPicker.returnReplace))
     {
-	  dirPath = dirPicker.file.path;
+      dirPath = dirPicker.file.path;
       document.getElementById("savePodcastLocation" + suf2).value = dirPath;
       document.getElementById("savePodcastLocation" + suf1).selectedIndex = 0;
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3579,28 +3626,28 @@ function viewAllViewSelected(flag)
     var listbox = document.getElementById("group-list-rss");
     var listitem = null;
     var checkbox = null;
-    for (var i=1; i < listbox.childNodes.length; i++)
+    for (var i = 1; i < listbox.childNodes.length; i++)
     {
       listitem = listbox.childNodes[i];
       if (flag == true)
       {
-		listitem.setAttribute("collapsed", "false");
-	  }
-	  else
-	  {
+        listitem.setAttribute("collapsed", "false");
+      }
+      else
+      {
         checkbox = listitem.childNodes[0];
         if (checkbox.getAttribute("checked") == "true")
         {
-		  listitem.setAttribute("collapsed", "false");
-		}
-		else
-		{
-		  listitem.setAttribute("collapsed", "true");
-		}
-	  }
+          listitem.setAttribute("collapsed", "false");
+        }
+        else
+        {
+          listitem.setAttribute("collapsed", "true");
+        }
+      }
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3619,12 +3666,12 @@ function addToPlayList()
         listbox.selectedItem.childNodes[0].setAttribute("checked", "true");
       }
       addToPlayList1("5",
-                     listbox.selectedItem.childNodes[1].getAttribute("image"),
-                     listbox.selectedItem.childNodes[1].getAttribute("label"),
-                     listbox.selectedItem.childNodes[1].getAttribute("url"));
+        listbox.selectedItem.childNodes[1].getAttribute("image"),
+        listbox.selectedItem.childNodes[1].getAttribute("label"),
+        listbox.selectedItem.childNodes[1].getAttribute("url"));
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3635,45 +3682,45 @@ function addToPlayList1(value, image, label, url)
 {
   try
   {
-      var richlistitem = document.createElement("richlistitem");
-      var hbox = document.createElement("hbox");
-      var input = document.createElement("textbox");
-      input.setAttribute("value", value);
-      input.style.maxWidth = "30px";
-      hbox.appendChild(input);
-      var vbox = document.createElement("vbox");
-      var spacer = document.createElement("spacer");
-      spacer.setAttribute("flex", "1");
-      vbox.appendChild(spacer);
-      var image1 = document.createElement("image");
-      image1.setAttribute("src", image);
-      image1.style.maxWidth = "16px";
-      image1.style.maxHeight = "16px";
-      vbox.appendChild(image1);
-      spacer = document.createElement("spacer");
-      spacer.setAttribute("flex", "1");
-      vbox.appendChild(spacer);
-      hbox.appendChild(vbox);
-      
-      vbox = document.createElement("vbox");
-      var spacer = document.createElement("spacer");
-      spacer.setAttribute("flex", "1");
-      vbox.appendChild(spacer);
-      var label1 = document.createElement("label");
-      label1.setAttribute("value", label);
-      vbox.appendChild(label1);
-      spacer = document.createElement("spacer");
-      spacer.setAttribute("flex", "1");
-      vbox.appendChild(spacer);
-      hbox.appendChild(vbox);
-      richlistitem.appendChild(hbox);
-      richlistitem.setAttribute("value", value);
-      richlistitem.setAttribute("label", label);
-      richlistitem.setAttribute("url", url);
+    var richlistitem = document.createElement("richlistitem");
+    var hbox = document.createElement("hbox");
+    var input = document.createElement("textbox");
+    input.setAttribute("value", value);
+    input.style.maxWidth = "30px";
+    hbox.appendChild(input);
+    var vbox = document.createElement("vbox");
+    var spacer = document.createElement("spacer");
+    spacer.setAttribute("flex", "1");
+    vbox.appendChild(spacer);
+    var image1 = document.createElement("image");
+    image1.setAttribute("src", image);
+    image1.style.maxWidth = "16px";
+    image1.style.maxHeight = "16px";
+    vbox.appendChild(image1);
+    spacer = document.createElement("spacer");
+    spacer.setAttribute("flex", "1");
+    vbox.appendChild(spacer);
+    hbox.appendChild(vbox);
 
-      document.getElementById("group-playlist").appendChild(richlistitem);
+    vbox = document.createElement("vbox");
+    var spacer = document.createElement("spacer");
+    spacer.setAttribute("flex", "1");
+    vbox.appendChild(spacer);
+    var label1 = document.createElement("label");
+    label1.setAttribute("value", label);
+    vbox.appendChild(label1);
+    spacer = document.createElement("spacer");
+    spacer.setAttribute("flex", "1");
+    vbox.appendChild(spacer);
+    hbox.appendChild(vbox);
+    richlistitem.appendChild(hbox);
+    richlistitem.setAttribute("value", value);
+    richlistitem.setAttribute("label", label);
+    richlistitem.setAttribute("url", url);
+
+    document.getElementById("group-playlist").appendChild(richlistitem);
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3690,7 +3737,7 @@ function removeFromPlayList()
       listbox.removeChild(listbox.selectedItem);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3712,7 +3759,7 @@ function moveUpInPlayList()
       richListitem.childNodes[0].childNodes[0].setAttribute("value", oldValue);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3741,7 +3788,7 @@ function moveDownInPlayList()
       richListitem.childNodes[0].childNodes[0].setAttribute("value", oldValue);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3756,64 +3803,63 @@ function changeDefaultValue()
     switch (applyto)
     {
       case 0: // apply to all
-      {
-        var items = RSSList.getElementsByTagName("RSS");
-        for (var i=0; i < items.length; i++)
         {
-	      changeDefaultValue1(items[i].getAttribute("url"));
-	    }
-        alert(document.getElementById("bundle_inforss").getString("inforss.feed.changed"));
+          var items = RSSList.getElementsByTagName("RSS");
+          for (var i = 0; i < items.length; i++)
+          {
+            changeDefaultValue1(items[i].getAttribute("url"));
+          }
+          alert(document.getElementById("bundle_inforss").getString("inforss.feed.changed"));
 
-		break;
-	  }
+          break;
+        }
 
-	  case 1: // the current feed
-	  {
-		if (theCurrentFeed.getType() == "group")
-		{
-		  if (confirm(document.getElementById("bundle_inforss").getString("inforss.apply.group")) == true)
-		  {
-            var feedList = theCurrentFeed.feedXML.getElementsByTagName("GROUP");
-            for (var j = 0; j < feedList.length; j++)
+      case 1: // the current feed
+        {
+          if (theCurrentFeed.getType() == "group")
+          {
+            if (confirm(document.getElementById("bundle_inforss").getString("inforss.apply.group")) == true)
             {
-	          changeDefaultValue1(feedList[j].getAttribute("url"));
+              var feedList = theCurrentFeed.feedXML.getElementsByTagName("GROUP");
+              for (var j = 0; j < feedList.length; j++)
+              {
+                changeDefaultValue1(feedList[j].getAttribute("url"));
+              }
+              alert(document.getElementById("bundle_inforss").getString("inforss.feed.changed"));
+            }
+          }
+          else
+          {
+            changeDefaultValue1(currentRSS.getAttribute("url"));
+            alert(document.getElementById("bundle_inforss").getString("inforss.feed.changed"));
+          }
+          break;
+        }
+
+      case 2: // apply to the selected feed
+        {
+          var selectedItems = document.getElementById("inforss.apply.list").selectedItems;
+          if (selectedItems.length == 0)
+          {
+            alert(document.getElementById("bundle_inforss").getString("inforss.rss.selectfirst"));
+          }
+          else
+          {
+            var listitem = null;
+            for (var j = 0; j < selectedItems.length; j++)
+            {
+              changeDefaultValue1(selectedItems[j].getAttribute("url"));
             }
             alert(document.getElementById("bundle_inforss").getString("inforss.feed.changed"));
           }
-		}
-		else
-		{
-	      changeDefaultValue1(currentRSS.getAttribute("url"));
-          alert(document.getElementById("bundle_inforss").getString("inforss.feed.changed"));
-		}
-		break;
-	  }
+          break;
+        }
 
-	  case 2: // apply to the selected feed
-	  {
-		var selectedItems = document.getElementById("inforss.apply.list").selectedItems;
-		if (selectedItems.length == 0)
-		{
-		  alert(document.getElementById("bundle_inforss").getString("inforss.rss.selectfirst"));
-		}
-		else
-		{
-		  var listitem = null;
-	      for (var j = 0; j < selectedItems.length; j++)
-	      {
-			changeDefaultValue1(selectedItems[j].getAttribute("url"));
-		  }
-          alert(document.getElementById("bundle_inforss").getString("inforss.feed.changed"));
-		}
-		break;
-	  }
-
-	  default:
-	  {
-	  }
-	}
+      default:
+        {}
+    }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3829,50 +3875,50 @@ function changeDefaultValue1(url)
     var checkbox = document.getElementById("inforss.checkbox.defaultnbitem");
     if (checkbox.getAttribute("checked") == "true")
     {
-	  rss.setAttribute("nbItem", (document.getElementById('defaultnbitem').selectedIndex == 0)? "9999" : document.getElementById('defaultnbitem1').value);
+      rss.setAttribute("nbItem", (document.getElementById('defaultnbitem').selectedIndex == 0) ? "9999" : document.getElementById('defaultnbitem1').value);
     }
 
     checkbox = document.getElementById("inforss.checkbox.defaultlengthitem");
     if (checkbox.getAttribute("checked") == "true")
     {
-	  rss.setAttribute("lengthItem", (document.getElementById('defaultlengthitem').selectedIndex == 0)? "9999" : document.getElementById('defaultlengthitem1').value);
+      rss.setAttribute("lengthItem", (document.getElementById('defaultlengthitem').selectedIndex == 0) ? "9999" : document.getElementById('defaultlengthitem1').value);
     }
 
     checkbox = document.getElementById("inforss.checkbox.defaultrefresh1");
     if (checkbox.getAttribute("checked") == "true")
     {
       var refresh1 = document.getElementById('inforss.defaultrefresh').selectedIndex;
-      rss.setAttribute("refresh", (refresh1 == 0)? 60*24 : (refresh1 == 1)? 60 : document.getElementById('defaultrefresh1').value);
+      rss.setAttribute("refresh", (refresh1 == 0) ? 60 * 24 : (refresh1 == 1) ? 60 : document.getElementById('defaultrefresh1').value);
     }
 
     checkbox = document.getElementById("inforss.checkbox.defaultPlayPodcast");
     if (checkbox.getAttribute("checked") == "true")
     {
-	  rss.setAttribute("playPodcast", (document.getElementById('defaultPlayPodcast').selectedIndex == 0)? "true" : "false");
+      rss.setAttribute("playPodcast", (document.getElementById('defaultPlayPodcast').selectedIndex == 0) ? "true" : "false");
     }
 
     checkbox = document.getElementById("inforss.checkbox.defaultPurgeHistory");
     if (checkbox.getAttribute("checked") == "true")
     {
-	  rss.setAttribute("purgeHistory", (document.getElementById('defaultPurgeHistory').value));
+      rss.setAttribute("purgeHistory", (document.getElementById('defaultPurgeHistory').value));
     }
 
     checkbox = document.getElementById("inforss.checkbox.defaultBrowserHistory");
     if (checkbox.getAttribute("checked") == "true")
     {
-	  rss.setAttribute("browserHistory", (document.getElementById('defaultBrowserHistory').selectedIndex == 0)? "true" : "false");
+      rss.setAttribute("browserHistory", (document.getElementById('defaultBrowserHistory').selectedIndex == 0) ? "true" : "false");
     }
 
     checkbox = document.getElementById("inforss.checkbox.defaultGroupIcon");
     if ((checkbox.getAttribute("checked") == "true") && (rss.getAttribute("type") == "group"))
     {
-	  rss.setAttribute("icon", document.getElementById('defaultGroupIcon').value);
+      rss.setAttribute("icon", document.getElementById('defaultGroupIcon').value);
     }
-    
+
     checkbox = document.getElementById("inforss.checkbox.defaultSavePodcast");
     if (checkbox.getAttribute("checked") == "true")
     {
-	  rss.setAttribute("savePodcastLocation", (document.getElementById('savePodcastLocation').selectedIndex == 1)? "" : document.getElementById('savePodcastLocation1').value);
+      rss.setAttribute("savePodcastLocation", (document.getElementById('savePodcastLocation').selectedIndex == 1) ? "" : document.getElementById('savePodcastLocation1').value);
     }
 
     if (document.getElementById("rss-select-menu").selectedItem.getAttribute("url") == url)
@@ -3880,7 +3926,7 @@ function changeDefaultValue1(url)
       selectRSS2(rss);
     }
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }
@@ -3893,7 +3939,7 @@ function locateRepository(ext)
   {
     var dir = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
     var localFile = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
-    localFile.initWithPath(dir.path );
+    localFile.initWithPath(dir.path);
     var filePicker = Components.classes["@mozilla.org/filepicker;1"].createInstance(Components.interfaces.nsIFilePicker);
     filePicker.appendFilter("", "*.rdf");
     filePicker.appendFilters(Components.interfaces.nsIFilePicker.filterXML);
@@ -3904,7 +3950,7 @@ function locateRepository(ext)
 
     var response = filePicker.show();
   }
-  catch(e)
+  catch (e)
   {
     inforssDebug(e);
   }

--- a/content/inforss/inforssParseHtml.js
+++ b/content/inforss/inforssParseHtml.js
@@ -132,7 +132,6 @@ function fetchHtml()
       gRssTimeout = window.setTimeout("window.opener.rssTimeout()", 10000);
       gRssXmlHttpRequest = new XMLHttpRequest();
       gRssXmlHttpRequest.open("GET", document.getElementById("inforss.url").value, true, gUser, gPassword);
-      gRssXmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
       gRssXmlHttpRequest.onload = fetchHtml1;
       gRssXmlHttpRequest.onerror = fetchHtml1;
 //    gRssXmlHttpRequest.overrideMimeType("text/html");

--- a/content/inforss/inforssPref.js
+++ b/content/inforss/inforssPref.js
@@ -198,7 +198,6 @@ var gRssXmlHttpRequest = null;
        gRssXmlHttpRequest.open("GET", url, true, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
        gRssXmlHttpRequest.onload = processCategories;
        gRssXmlHttpRequest.onerror = rssCategoryTimeout;
-       gRssXmlHttpRequest.setRequestHeader("User-Agent", "Mozilla/5.0");
 	   gRssXmlHttpRequest.overrideMimeType("application/xml");
 	   gRssXmlHttpRequest.send(null);
      }


### PR DESCRIPTION
- No longer fakes out the agent, so sites shouldn't end up blocking
- inforssDebug calls go to the browser log and don't need running with --console
- --console in/out trace includes call stack
- favicons are deduced properly, at least from the options screen