### PR TITLE
Deal better with guid/id elements and null links

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,9 +21,23 @@ Added documentation in `default/prefs.js` for all the inforss `about:config` ent
 Makes a much better attempt at getting the default icon for a feed.
 
 Lots of dead code removal, reformatting and jshinting.
-
-Dropped legacy drag-and-drop code, now using standard version
-* Cleaned up a lot of logic so it's clearer what can be dropped where
+* Removed code for legacy password API
+* Dropped legacy drag-and-drop code, now using standard version
+ * Cleaned up a lot of logic so it's clearer what can be dropped where
 
 Option screen will pop to front when you right click the main icon
 * I've also stopped right clicking on a feed in the menu from generating a new window every time you click it and it will bring forward the settings window if one already exists.
+
+Fixed the way history was accessed, which depended on a withdrawn API.
+
+Fixed some issues with the way guids (RSS) / ids (Atom) were handled.
+**Note:**
+* This might cause some old headlines to be redisplayed.
+* A log entry is made in the browser console where the guid and the link are different. This may be an issue as the code uses the guid for preference for RSS feeds, unless it is marked as 'not a perma link'.
+* Stories with no linked page are linked to the feeds home page.
+
+Choses which link to display for Atom feeds better.
+
+News items with empty titles are now displayed rather than dropped. They are given a title of "(no title)".
+
+Code no longer suppresses errors if it can't get hold of a feeds page (at least from settings window or when displaying pages as a sub-menu).

--- a/content/inforss/inforss.js
+++ b/content/inforss/inforss.js
@@ -1103,84 +1103,86 @@ function inforssAddItemToMenu(rss)
   inforssTraceIn();
   try
   {
-    if (document.getElementById("inforss-menupopup") != null)
+    let menuItem = null;
+    if (rss.getAttribute("groupAssociated") == "false" ||
+        inforssXMLRepository.isIncludeAssociated())
     {
-      let menuItem = null;
-      if ((rss.getAttribute("groupAssociated") == "false") || (inforssXMLRepository.isIncludeAssociated()))
+      const has_submenu = inforssXMLRepository.show_headlines_in_sub_menu() &&
+        (rss.getAttribute("type") == "rss" ||
+         rss.getAttribute("type") == "atom");
+
+      const typeObject = has_submenu ? "menu" : "menuitem";
+
+      const menu = document.getElementById("inforss-menupopup");
+      const item_num = menu.childElementCount;
+
+      menuItem = document.createElement(typeObject);
+
+      //This is moderately strange. it does what you expect if you
+      //display submenus, but then it doesn't indicate the currently
+      //selected feed. If however, you don't display as submenus, then
+      //you don't get icons but you do get a selected one.
+      //if you make this a radio button it completely removes the icons,
+      //unless they have submenus
+      //menuItem.setAttribute("type", "radio");
+      menuItem.setAttribute("label", rss.getAttribute("title"));
+      menuItem.setAttribute("value", rss.getAttribute("title"));
+
+      menuItem.setAttribute("data", rss.getAttribute("url"));
+      menuItem.setAttribute("url", rss.getAttribute("url"));
+      menuItem.setAttribute("checked", false);
+      menuItem.setAttribute("autocheck", false);
+      if (rss.getAttribute("description") != "")
       {
-        let typeObject = inforssXMLRepository.show_headlines_in_sub_menu() &&
-          (rss.getAttribute("type") == "rss" ||
-            rss.getAttribute("type") == "atom") ?
-          "menu" : "menuitem";
-
-        let items = document.getElementById("inforss-menupopup").getElementsByTagName(typeObject);
-
-        menuItem = document.createElement(typeObject);
-
-        //This is moderately strange. it does what you expect if you
-        //display submenus, but then it doesn't indicate the currently
-        //selected feed. If however, you don't display as submenus, then
-        //you don't get icons but you do get a selected one.
-        //if you make this a radio button it completely removes the icons,
-        //unless they have submenus
-        //menuItem.setAttribute("type", "radio");
-        menuItem.setAttribute("label", rss.getAttribute("title"));
-        menuItem.setAttribute("value", rss.getAttribute("title"));
-
-        menuItem.setAttribute("data", rss.getAttribute("url"));
-        menuItem.setAttribute("url", rss.getAttribute("url"));
-        menuItem.setAttribute("checked", false);
-        menuItem.setAttribute("autocheck", false);
-        if (rss.getAttribute("description") != "")
-        {
-          menuItem.setAttribute("tooltiptext", rss.getAttribute("description"));
-        }
-        menuItem.setAttribute("tooltip", null);
-        menuItem.setAttribute("image", rss.getAttribute("icon"));
-        menuItem.setAttribute("validate", "never");
-        menuItem.setAttribute("id", "inforss.menuitem-" + items.length);
-        menuItem.setAttribute("inforsstype", rss.getAttribute("type"));
-
-        menuItem.setAttribute("class", typeObject + "-iconic");
-        if (rss.getAttribute("activity") == "false")
-        {
-          menuItem.setAttribute("disabled", "true");
-        }
-
-        if (rss.getAttribute("type") == "group")
-        {
-          //Allow as drop target
-          menuItem.addEventListener("dragover", menu_observer.on_drag_over);
-          menuItem.addEventListener("drop", menu_observer.on_drop);
-        }
-
-        menuItem.addEventListener("dragstart", menu_observer.on_drag_start);
-
-        if (typeObject == "menu")
-        {
-          let menupopup = document.createElement("menupopup");
-          menupopup.setAttribute("type", rss.getAttribute("type"));
-          //FIXME Seriously. use addEventListener
-          menupopup.setAttribute("onpopupshowing", "return inforssSubMenu(" + items.length + ");");
-          menupopup.setAttribute("onpopuphiding", "return inforssSubMenu2();");
-          //?
-          menupopup.setAttribute("id", "inforss.menupopup-" + items.length);
-          inforssAddNoData(menupopup);
-          menuItem.appendChild(menupopup);
-        }
-
-        if (inforssXMLRepository.getSortedMenu() != "no")
-        {
-          let indexItem = inforssLocateMenuItem(rss.getAttribute("title"));
-          document.getElementById("inforss-menupopup").insertBefore(menuItem, indexItem);
-        }
-        else
-        {
-          document.getElementById("inforss-menupopup").appendChild(menuItem);
-        }
+        menuItem.setAttribute("tooltiptext", rss.getAttribute("description"));
       }
-      gInforssMediator.addFeed(rss, menuItem);
+      menuItem.setAttribute("tooltip", null);
+      menuItem.setAttribute("image", rss.getAttribute("icon"));
+      menuItem.setAttribute("validate", "never");
+      menuItem.setAttribute("id", "inforss.menuitem-" + item_num);
+      menuItem.setAttribute("inforsstype", rss.getAttribute("type"));
+
+      menuItem.setAttribute("class", typeObject + "-iconic");
+      if (rss.getAttribute("activity") == "false")
+      {
+        menuItem.setAttribute("disabled", "true");
+      }
+
+      if (rss.getAttribute("type") == "group")
+      {
+        //Allow as drop target
+        menuItem.addEventListener("dragover", menu_observer.on_drag_over);
+        menuItem.addEventListener("drop", menu_observer.on_drop);
+      }
+
+      menuItem.addEventListener("dragstart", menu_observer.on_drag_start);
+
+      if (has_submenu)
+      {
+        let menupopup = document.createElement("menupopup");
+        menupopup.setAttribute("type", rss.getAttribute("type"));
+        //FIXME Seriously. use addEventListener
+        menupopup.setAttribute("onpopupshowing",
+                               "return inforssSubMenu(" + item_num + ");");
+        menupopup.setAttribute("onpopuphiding", "return inforssSubMenu2();");
+        //?
+        menupopup.setAttribute("id", "inforss.menupopup-" + item_num);
+        inforssAddNoData(menupopup);
+        menuItem.appendChild(menupopup);
+      }
+
+      if (inforssXMLRepository.getSortedMenu() != "no")
+      {
+        let indexItem = inforssLocateMenuItem(rss.getAttribute("title"));
+        menu.insertBefore(menuItem, indexItem);
+      }
+      else
+      {
+        menu.appendChild(menuItem);
+      }
     }
+    //FIXME It is not obvious from the name why this is happening!
+    gInforssMediator.addFeed(rss, menuItem);
   }
   catch (e)
   {
@@ -1212,7 +1214,6 @@ function inforssSubMenu(index)
 }
 
 //------------------------------------------------------------------------------
-/* exported inforssSubMenu1 */
 //This is the timeout callback from above. ick.
 function inforssSubMenu1(index)
 {
@@ -1221,7 +1222,7 @@ function inforssSubMenu1(index)
   {
     gInforssCurrentMenuHandle = null;
 
-    let popup = document.getElementById("inforss.menupopup-" + index);
+    const popup = document.getElementById("inforss.menupopup-" + index);
     //Need to do this to stop the sub-menu disappearing
     popup.setAttribute("onpopupshowing", null);
 
@@ -1230,20 +1231,26 @@ function inforssSubMenu1(index)
     //with another one. so we have to change this element in place.
     remove_all_children(popup);
 
-    let item = document.getElementById("inforss.menuitem-" + index);
-    let url = item.getAttribute("url");
-    let rss = inforssGetItemFromUrl(url);
-    let xmlHttpRequest = new XMLHttpRequest();
-    xmlHttpRequest.open("GET", url, false, rss.getAttribute("user"), inforssXMLRepository.readPassword(url, rss.getAttribute("user")));
+    //FIXME the http request should be async
+    const item = document.getElementById("inforss.menuitem-" + index);
+    const url = item.getAttribute("url");
+    const rss = inforssGetItemFromUrl(url);
+    const xmlHttpRequest = new XMLHttpRequest();
+    const user = rss.getAttribute("user");
+    xmlHttpRequest.open("GET",
+                        url,
+                        false,
+                        user,
+                        inforssXMLRepository.readPassword(url, user));
     xmlHttpRequest.overrideMimeType("application/xml");
-    xmlHttpRequest.send(null);
+    xmlHttpRequest.send();
 
-    let fm = new FeedManager();
+    const fm = new FeedManager();
     fm.parse(xmlHttpRequest);
     let max = Math.min(INFORSS_MAX_SUBMENU, fm.rssFeeds.length);
     for (let i = 0; i < max; i++)
     {
-      let newElem = document.createElement("menuitem");
+      const newElem = document.createElement("menuitem");
       let newTitle = inforssFeed.htmlFormatConvert(fm.rssFeeds[i].title);
       if (newTitle != null)
       {
@@ -1351,6 +1358,7 @@ function inforssPopulateMenuItem()
     let feed_flag = "rss";
 
     var format = objDoc.documentElement.nodeName;
+    //FIXME More duplex code
     if (format == "feed")
     {
       str_description = "tagline";

--- a/content/inforss/inforssFeed.js
+++ b/content/inforss/inforssFeed.js
@@ -409,6 +409,7 @@ function inforssFeed(feedXML, manager, menuItem)
         let items = objDoc.getElementsByTagName(this.caller.itemAttribute);
         let re = new RegExp('\n', 'gi');
         let receivedDate = new Date();
+        //FIXME Replace with a sequence of promises
         window.setTimeout(this.caller.readFeed1, 0, items.length - 1, items, receivedDate, home, url, re, this.caller);
       }
       objDoc = null;
@@ -436,33 +437,32 @@ function inforssFeed(feedXML, manager, menuItem)
     {
       if (i >= 0)
       {
-        var label = inforssFeed.getNodeValue(items[i].getElementsByTagName(caller.titleAttribute));
+        const item = items[i];
+        let label = inforssFeed.getNodeValue(item.getElementsByTagName(caller.titleAttribute));
         if (label != null)
         {
           label = inforssFeed.htmlFormatConvert(label).replace(re, ' ');
         }
-        var guid = caller.getLink(items[i].getElementsByTagName(caller.alternateLinkAttribute));
-
-        var link = caller.getLink(items[i].getElementsByTagName(caller.linkAttribute));
-        if ((link == null) || (link == ""))
+        else
         {
-          link = caller.getLink(items[i].getElementsByTagName(caller.alternateLinkAttribute));
+          /**/console.log("is this borked - label is null so we won't add it", item)
         }
-
-        var description = null;
+        const guid = caller.get_guid(item);
+        const link = caller.get_link(item);
+        let description = null;
         if (caller.itemDescriptionAttribute.indexOf("|") == -1)
         {
-          description = inforssFeed.getNodeValue(items[i].getElementsByTagName(caller.itemDescriptionAttribute));
+          description = inforssFeed.getNodeValue(item.getElementsByTagName(caller.itemDescriptionAttribute));
         }
         else
         {
-          var pos = caller.itemDescriptionAttribute.indexOf("|");
-          var des1 = caller.itemDescriptionAttribute.substring(0, pos);
-          description = inforssFeed.getNodeValue(items[i].getElementsByTagName(des1));
+          const pos = caller.itemDescriptionAttribute.indexOf("|");
+          let des1 = caller.itemDescriptionAttribute.substring(0, pos);
+          description = inforssFeed.getNodeValue(item.getElementsByTagName(des1));
           if (description == null)
           {
             des1 = caller.itemDescriptionAttribute.substring(pos + 1);
-            description = inforssFeed.getNodeValue(items[i].getElementsByTagName(des1));
+            description = inforssFeed.getNodeValue(item.getElementsByTagName(des1));
           }
         }
         if (description != null)
@@ -470,10 +470,10 @@ function inforssFeed(feedXML, manager, menuItem)
           description = inforssFeed.htmlFormatConvert(description).replace(re, ' ');
           description = inforssFeed.removeScript(description);
         }
-        var category = inforssFeed.getNodeValue(items[i].getElementsByTagName("category"));
-        var pubDate = caller.getPubDate(items[i]);
+        const category = inforssFeed.getNodeValue(item.getElementsByTagName("category"));
+        const pubDate = caller.getPubDate(item);
 
-        var enclosure = items[i].getElementsByTagName("enclosure");
+        const enclosure = item.getElementsByTagName("enclosure");
         var enclosureUrl = null;
         var enclosureType = null;
         var enclosureSize = null;
@@ -485,26 +485,17 @@ function inforssFeed(feedXML, manager, menuItem)
         }
         else
         {
-          if ((link != null) && (link.indexOf(".mp3") != -1))
+          if (link != null && link.indexOf(".mp3") != -1)
           {
             enclosureUrl = link;
             enclosureType = "audio/mp3";
           }
         }
 
-        if ((caller.findHeadline(url, label, guid) == null) && (label != null))
+        if (caller.findHeadline(url, label, guid) == null && label != null)
         {
           caller.addHeadline(receivedDate, pubDate, label, guid, link, description, url, home, category, enclosureUrl, enclosureType, enclosureSize);
         }
-        label = null;
-        link = null;
-        description = null;
-        category = null;
-        pubDate = null;
-        enclosure = null;
-        enclosureUrl = null;
-        enclosureType = null;
-        enclosureSize = null;
       }
       i--;
       if (i >= 0)
@@ -546,7 +537,7 @@ function inforssFeed(feedXML, manager, menuItem)
             {
               label = inforssFeed.htmlFormatConvert(label).replace(re, ' ');
             }
-            guid = caller.getLink(items[j].getElementsByTagName(caller.alternateLinkAttribute));
+            guid = caller.get_guid(items[j]);
             if ((guid != null) && (caller.headlines[i].guid != null))
             {
               if (caller.headlines[i].guid == guid)

--- a/content/inforss/inforssFeed.js
+++ b/content/inforss/inforssFeed.js
@@ -439,13 +439,13 @@ function inforssFeed(feedXML, manager, menuItem)
       {
         const item = items[i];
         let label = inforssFeed.getNodeValue(item.getElementsByTagName(caller.titleAttribute));
-        if (label != null)
+        if (label == null)
         {
-          label = inforssFeed.htmlFormatConvert(label).replace(re, ' ');
+          label = "";
         }
         else
         {
-          /**/console.log("is this borked - label is null so we won't add it", item)
+          label = inforssFeed.htmlFormatConvert(label).replace(re, ' ');
         }
         const guid = caller.get_guid(item);
         const link = caller.get_link(item);
@@ -492,7 +492,7 @@ function inforssFeed(feedXML, manager, menuItem)
           }
         }
 
-        if (caller.findHeadline(url, label, guid) == null && label != null)
+        if (caller.findHeadline(url, label, guid) == null)
         {
           caller.addHeadline(receivedDate, pubDate, label, guid, link, description, url, home, category, enclosureUrl, enclosureType, enclosureSize);
         }
@@ -500,11 +500,11 @@ function inforssFeed(feedXML, manager, menuItem)
       i--;
       if (i >= 0)
       {
-        window.setTimeout(caller.readFeed1, eval(inforssXMLRepository.getTimeSlice()), i, items, receivedDate, home, url, re, caller);
+        window.setTimeout(caller.readFeed1, inforssXMLRepository.getTimeSlice(), i, items, receivedDate, home, url, re, caller);
       }
       else
       {
-        window.setTimeout(caller.readFeed2, eval(inforssXMLRepository.getTimeSlice()), 0, items, home, url, re, caller);
+        window.setTimeout(caller.readFeed2, inforssXMLRepository.getTimeSlice(), 0, items, home, url, re, caller);
       }
     }
     catch (e)
@@ -573,7 +573,7 @@ function inforssFeed(feedXML, manager, menuItem)
       i++;
       if (i < caller.headlines.length)
       {
-        window.setTimeout(caller.readFeed2, eval(inforssXMLRepository.getTimeSlice()), i, items, home, url, re, caller);
+        window.setTimeout(caller.readFeed2, inforssXMLRepository.getTimeSlice(), i, items, home, url, re, caller);
       }
       else
       {
@@ -651,6 +651,7 @@ function inforssFeed(feedXML, manager, menuItem)
       }
       else
       {
+        //FIXME Oh, come on. Dates are in RFC format.
         if (reg1.exec(pubDate) != null)
         {
           pubDate = new Date(pubDate);

--- a/content/inforss/inforssFeed.js
+++ b/content/inforss/inforssFeed.js
@@ -447,7 +447,6 @@ function inforssFeed(feedXML, manager, menuItem)
         {
           label = inforssFeed.htmlFormatConvert(label).replace(re, ' ');
         }
-        const guid = caller.get_guid(item);
         const link = caller.get_link(item);
         let description = null;
         if (caller.itemDescriptionAttribute.indexOf("|") == -1)
@@ -492,6 +491,11 @@ function inforssFeed(feedXML, manager, menuItem)
           }
         }
 
+        let guid = caller.get_guid(item);
+        if (guid == null || guid == "")
+        {
+          guid = link;
+        }
         if (caller.findHeadline(url, label, guid) == null)
         {
           caller.addHeadline(receivedDate, pubDate, label, guid, link, description, url, home, category, enclosureUrl, enclosureType, enclosureSize);

--- a/content/inforss/inforssFeedAtom.js
+++ b/content/inforss/inforssFeedAtom.js
@@ -46,15 +46,9 @@
 function inforssFeedAtom(feedXML, manager, menuItem)
 {
   var self = new inforssFeed(feedXML, manager, menuItem);
-  self.descriptionAttribute = "title";
   self.itemAttribute = "entry";
   self.titleAttribute = "title";
   self.itemDescriptionAttribute = "summary|content";
-
-  self.parse = function()
-  {
-    return new Array(this);
-  };
 
   self.get_guid = function(item)
   {
@@ -64,48 +58,26 @@ function inforssFeedAtom(feedXML, manager, menuItem)
 
   self.get_link = function(item)
   {
-    var returnValue = null;
-    let obj = item.getElementsByTagName("link");
-    if ((obj != null) || (obj.length != 0))
+    //FIXME Make this into a querySelector
+    for (let entry of item.getElementsByTagName("link"))
     {
-      var find = false;
-      var i = 0;
-      while ((i < obj.length) && (find == false))
+      if (entry.hasAttribute("href") &&
+          (! entry.hasAttribute("rel") || entry.getAttribute("rel") == "alternate"))
       {
-        if (obj[i].getAttribute("href") != null)
+        if (! entry.hasAttribute("type") ||
+            entry.getAttribute("type") == "text/html" ||
+            entry.getAttribute("type") == "application/xhtml+xml")
         {
-          if (obj[i].getAttribute("type") == null)
-          {
-            find = true;
-          }
-          else
-          {
-            if ((obj[i].getAttribute("type") == "text/html") ||
-              (obj[i].getAttribute("type") == "application/xhtml+xml"))
-            {
-              find = true;
-            }
-            else
-            {
-              i++;
-            }
-          }
+          return entry.getAttribute("href");
         }
-        else
-        {
-          i++;
-        }
-      }
-      if (find)
-      {
-        returnValue = obj[i].getAttribute("href");
       }
     }
-    return returnValue;
+    return null;
   };
 
   self.getPubDate = function(obj)
   {
+    //FIXME Make this into a querySelector
     var pubDate = inforssFeed.getNodeValue(obj.getElementsByTagName("modified"));
     if (pubDate == null)
     {

--- a/content/inforss/inforssFeedAtom.js
+++ b/content/inforss/inforssFeedAtom.js
@@ -34,18 +34,20 @@
  * the terms of any one of the MPL, the GPL or the LGPL.
  *
  * ***** END LICENSE BLOCK ***** */
-//-------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // inforssFeedAtom
 // Author : Didier Ernotte 2005
 // Inforss extension
-//-------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+/* globals inforssFeed */
+
+/* exported inforssFeedAtom */
 function inforssFeedAtom(feedXML, manager, menuItem)
 {
   var self = new inforssFeed(feedXML, manager, menuItem);
   self.descriptionAttribute = "title";
   self.itemAttribute = "entry";
-  self.linkAttribute = "link"
-  self.alternateLinkAttribute = "link";
   self.titleAttribute = "title";
   self.itemDescriptionAttribute = "summary|content";
 
@@ -54,9 +56,16 @@ function inforssFeedAtom(feedXML, manager, menuItem)
     return new Array(this);
   };
 
-  self.getLink = function(obj)
+  self.get_guid = function(item)
+  {
+    let elems = item.getElementsByTagName("id");
+    return elems.length == 0 ? null : elems[0].textContent;
+  };
+
+  self.get_link = function(item)
   {
     var returnValue = null;
+    let obj = item.getElementsByTagName("link");
     if ((obj != null) || (obj.length != 0))
     {
       var find = false;
@@ -89,7 +98,7 @@ function inforssFeedAtom(feedXML, manager, menuItem)
       }
       if (find)
       {
-        returnValue = obj[i].getAttribute("href")
+        returnValue = obj[i].getAttribute("href");
       }
     }
     return returnValue;
@@ -107,7 +116,7 @@ function inforssFeedAtom(feedXML, manager, menuItem)
       }
     }
     return pubDate;
-  }
+  };
 
   return self;
 }

--- a/content/inforss/inforssFeedRss.js
+++ b/content/inforss/inforssFeedRss.js
@@ -46,15 +46,9 @@
 function inforssFeedRss(feedXML, manager, menuItem)
 {
   var self = new inforssFeed(feedXML, manager, menuItem);
-  self.descriptionAttribute = "description";
   self.itemAttribute = "item";
   self.titleAttribute = "title";
   self.itemDescriptionAttribute = "description";
-
-  self.parse = function()
-  {
-    return new Array(this);
-  };
 
   self.get_guid = function(item)
   {
@@ -75,7 +69,8 @@ function inforssFeedRss(feedXML, manager, menuItem)
       if (linke.length != 0 && linke[0].textContent != elems[0].textContent)
       {
         //Logging for now in case I care
-        console.log("link and guid different", item, elems, linke);
+        console.log("link '" + linke[0].textContent + "' and guid '" +
+                    elems[0].textContent + "' are different", item);
         //One place where I have noticed an issue:
         //link "http://salamanstra.keenspot.com/d/20161223.html"
         //guid "http://salamanstra.keenspot.com/d/20161223.html "
@@ -89,6 +84,7 @@ function inforssFeedRss(feedXML, manager, menuItem)
 
   self.getPubDate = function(obj)
   {
+    //FIXME Make this into a querySelector
     var pubDate = inforssFeed.getNodeValue(obj.getElementsByTagName("pubDate"));
     if (pubDate == null)
     {
@@ -98,7 +94,6 @@ function inforssFeedRss(feedXML, manager, menuItem)
         pubDate = inforssFeed.getNodeValue(obj.getElementsByTagName("dc:date"));
       }
     }
-    //dump("##### pubdate=" + pubDate + "\n");
     return pubDate;
   };
 

--- a/content/inforss/inforssFeedRss.js
+++ b/content/inforss/inforssFeedRss.js
@@ -65,17 +65,24 @@ function inforssFeedRss(feedXML, manager, menuItem)
         (! elems[0].hasAttribute("isPermaLink") ||
          elems[0].getAttribute("isPermalink") == "true"))
     {
-      let linke = item.getElementsByTagName("link");
-      if (linke.length != 0 && linke[0].textContent != elems[0].textContent)
+      if (elems[0].textContent == "")
       {
-        //Logging for now in case I care
-        console.log("link '" + linke[0].textContent + "' and guid '" +
-                    elems[0].textContent + "' are different", item);
-        //One place where I have noticed an issue:
-        //link "http://salamanstra.keenspot.com/d/20161223.html"
-        //guid "http://salamanstra.keenspot.com/d/20161223.html "
+        console.log("Explicit empty guid", item);
       }
-      return elems[0].textContent;
+      else
+      {
+        let linke = item.getElementsByTagName("link");
+        if (linke.length != 0 && linke[0].textContent != elems[0].textContent)
+        {
+          //Logging for now in case I care
+          console.log("link '" + linke[0].textContent + "' and guid '" +
+                      elems[0].textContent + "' are different", item);
+          //One place where I have noticed an issue:
+          //link "http://salamanstra.keenspot.com/d/20161223.html"
+          //guid "http://salamanstra.keenspot.com/d/20161223.html "
+        }
+        return elems[0].textContent;
+      }
     }
 
     elems = item.getElementsByTagName("link");

--- a/content/inforss/inforssFeedRss.js
+++ b/content/inforss/inforssFeedRss.js
@@ -34,18 +34,20 @@
  * the terms of any one of the MPL, the GPL or the LGPL.
  *
  * ***** END LICENSE BLOCK ***** */
-//-------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // inforssFeedRss
 // Author : Didier Ernotte 2005
 // Inforss extension
-//-------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+/* global inforssFeed */
+
+/*exported inforssFeedRss */
 function inforssFeedRss(feedXML, manager, menuItem)
 {
   var self = new inforssFeed(feedXML, manager, menuItem);
   self.descriptionAttribute = "description";
   self.itemAttribute = "item";
-  self.linkAttribute = "link"
-  self.alternateLinkAttribute = "guid";
   self.titleAttribute = "title";
   self.itemDescriptionAttribute = "description";
 
@@ -54,9 +56,35 @@ function inforssFeedRss(feedXML, manager, menuItem)
     return new Array(this);
   };
 
-  self.getLink = function(obj)
+  self.get_guid = function(item)
   {
-    return inforssFeed.getNodeValue(obj);
+    let elems = item.getElementsByTagName("guid");
+    return elems.length == 0 ? null : elems[0].textContent;
+  };
+
+  self.get_link = function(item)
+  {
+    //If we have a permanent link instead of a feed user that for preference,
+    //as I think some feeds are broken
+    let elems = item.getElementsByTagName("guid");
+    if (elems.length != 0 &&
+        (! elems[0].hasAttribute("isPermaLink") ||
+         elems[0].getAttribute("isPermalink") == "true"))
+    {
+      let linke = item.getElementsByTagName("link");
+      if (linke.length != 0 && linke[0].textContent != elems[0].textContent)
+      {
+        //Logging for now in case I care
+        console.log("link and guid different", item, elems, linke);
+        //One place where I have noticed an issue:
+        //link "http://salamanstra.keenspot.com/d/20161223.html"
+        //guid "http://salamanstra.keenspot.com/d/20161223.html "
+      }
+      return elems[0].textContent;
+    }
+
+    elems = item.getElementsByTagName("link");
+    return elems.length == 0 ? null : elems[0].textContent;
   };
 
   self.getPubDate = function(obj)
@@ -72,7 +100,7 @@ function inforssFeedRss(feedXML, manager, menuItem)
     }
     //dump("##### pubdate=" + pubDate + "\n");
     return pubDate;
-  }
+  };
 
   return self;
 }

--- a/content/inforss/inforssHeadline.js
+++ b/content/inforss/inforssHeadline.js
@@ -42,9 +42,16 @@
 /* globals inforssDebug, inforssTraceIn, inforssTraceOut */
 Components.utils.import("chrome://inforss/content/modules/inforssDebug.jsm");
 
+/* globals inforssXMLRepository, inforssHeadlineDisplay */
 
 function inforssHeadline(receivedDate, pubDate, title, guid, link, description, url, home, category, enclosureUrl, enclosureType, enclosureSize, feed)
 {
+  if (link == null || link == "")
+  {
+    console.log("null link, using home page " + home);
+    link = home;
+  }
+
   this.readDate = null;
   this.publishedDate = pubDate;
   this.receivedDate = receivedDate;
@@ -105,10 +112,11 @@ function inforssHeadline(receivedDate, pubDate, title, guid, link, description, 
         oldViewed = null;
         oldBanned = null;
       }
-      if ((enclosureUrl != null) && (enclosureUrl != "") &&
-        (enclosureType != null) && (enclosureType.indexOf("audio") == 0) &&
-        ((feed.getAttribute(link, title, "savedPodcast") == null) || (feed.getAttribute(link, title, "savedPodcast") == "false")) &&
-        (feed.getSavePodcastLocation() != ""))
+      if (enclosureUrl != null && enclosureUrl != "" &&
+          enclosureType != null && enclosureType.indexOf("audio") == 0 &&
+          (feed.getAttribute(link, title, "savedPodcast") == null ||
+           feed.getAttribute(link, title, "savedPodcast") == "false") &&
+          feed.getSavePodcastLocation() != "")
       {
         inforssHeadline.podcastArray.push(
         {
@@ -295,7 +303,6 @@ inforssHeadline.prototype = {
   {
     //dump("savePodcastCallback\n");
     inforssTraceIn();
-    var returnValue = true;
     try
     {
       if (step == "send")
@@ -473,6 +480,9 @@ inforssHeadline.prototype = {
 inforssHeadline.podcastArray = new Array();
 inforssHeadline.downloadTimeout = null;
 
+//FIXME I do not know how well this is tested (or even if it is ever executed),
+//because lnt spews messages about undefined values
+
 var myInforssListener = {
   dl: null,
   link: null,
@@ -554,4 +564,4 @@ var myInforssListener = {
   {
     return dl.onLinkIconAvailable();
   }
-}
+};

--- a/content/inforss/inforssHeadline.js
+++ b/content/inforss/inforssHeadline.js
@@ -415,29 +415,21 @@ inforssHeadline.prototype = {
   },
 
   //-------------------------------------------------------------------------------------------------------------
-  compare: function(target)
+  matches: function(target)
   {
-    var returnValue = false;
     if (this.link == target.link)
     {
-      if ((this.guid != null) || (target.guid != null))
+      if (this.guid != null || target.guid != null)
       {
-        if (this.guid == target.guid)
-        {
-          returnValue = true;
-        }
+        return this.guid == target.guid;
       }
       else
       {
-        if (this.title == target.title)
-        {
-          //FIXME This can't be right - not sure where it'd be an issue though
-          returnValue == true; //???
-        }
+        return this.title == target.title;
       }
     }
 
-    return returnValue;
+    return false;
   },
 
   //-------------------------------------------------------------------------------------------------------------

--- a/content/inforss/inforssHeadlineDisplay.js
+++ b/content/inforss/inforssHeadlineDisplay.js
@@ -278,7 +278,7 @@ inforssHeadlineDisplay.prototype = {
           var j = 0;
           while ((j < newList.length) && (find == false))
           {
-            if (oldList[i].compare(newList[j]))
+            if (oldList[i].matches(newList[j]))
             {
               find = true;
             }
@@ -372,6 +372,10 @@ inforssHeadlineDisplay.prototype = {
       if (rss.getAttribute("icon") == INFORSS_DEFAULT_ICO)
       {
         label = "(" + ((rss.getAttribute("title").length > 10) ? rss.getAttribute("title").substring(0, 10) : rss.getAttribute("title")) + "):" + label;
+      }
+      else if (label == "")
+      {
+        label = "(no title)";
       }
       itemLabel.setAttribute("value", label);
       if ((headline.enclosureType != null) && (inforssXMLRepository.isDisplayEnclosure()))

--- a/content/inforss/inforssParser.js
+++ b/content/inforss/inforssParser.js
@@ -70,6 +70,8 @@ function addFeed(title, description, link, category)
 }
 
 //-----------------------------------------------------------------------------------------------------
+//FIXME This function does the same as the factory in inforssFeed but not as
+//well (and should use the factory)
 function parse(xmlHttpRequest)
 {
   //Note: I've only seen this called when you have 'display as submenu'

--- a/content/inforss/inforssRDFRepository.js
+++ b/content/inforss/inforssRDFRepository.js
@@ -41,10 +41,10 @@
 //------------------------------------------------------------------------------
 /* globals inforssDebug */ //also inforssTraceIn, inforssTraceOut */
 Components.utils.import("chrome://inforss/content/modules/inforssDebug.jsm");
+/* globals inforssGetResourceFile */
 Components.utils.import("chrome://inforss/content/modules/inforssVersion.jsm");
 
-/* globals inforssXMLRepository */
-
+/* globals inforssXMLRepository, inforssGetItemFromUrl */
 const INFORSS_RDF_REPOSITORY = "inforss.rdf";
 const INFORSS_DEFAULT_RDF_REPOSITORY = "inforss_rdf.default";
 
@@ -98,7 +98,6 @@ inforssRDFRepository.prototype = {
   {
     let find = false;
     let findLocalHistory = false;
-    url = this.convertUrl(url);
     try
     {
       let subject = RdfService.GetResource(inforssFeed.htmlFormatConvert(url) + "#" + escape(title));
@@ -145,7 +144,6 @@ inforssRDFRepository.prototype = {
   {
     try
     {
-      url = this.convertUrl(url);
       //dump("assert : " + inforssFeed.htmlFormatConvert(url) + "#" + escape(title) + " " + receivedDate + "\n");
       var subject = RdfService.GetResource(inforssFeed.htmlFormatConvert(url) + "#" + escape(title));
       var predicate = RdfService.GetResource("http://inforss.mozdev.org/rdf/inforss/receivedDate");
@@ -207,7 +205,6 @@ inforssRDFRepository.prototype = {
   getAttribute: function(url, title, attribute)
   {
     //dump("getAttribute\n");
-    url = this.convertUrl(url);
     var value = null;
     try
     {
@@ -229,7 +226,6 @@ inforssRDFRepository.prototype = {
   //-------------------------------------------------------------------------------------------------------------
   setAttribute: function(url, title, attribute, value)
   {
-    url = this.convertUrl(url);
     //dump("setAttribute : " + inforssFeed.htmlFormatConvert(url) + " " + title + " " + attribute + " " + value + "\n");
     try
     {
@@ -304,16 +300,6 @@ inforssRDFRepository.prototype = {
     //dump("fin clearRdf\n");
   },
 
-  //-------------------------------------------------------------------------------------------------------------
-  convertUrl: function(url)
-  {
-    if (url == null || url == "")
-    {
-      inforssDebug(new Error("wtf"), this);
-      return "http://inforss.mozdev.org/rdf/inforss";
-    }
-    return url;
-  },
 
   //----------------------------------------------------------------------------
   purge_after: function(time)

--- a/content/inforss/inforssXMLRepository.js
+++ b/content/inforss/inforssXMLRepository.js
@@ -34,11 +34,11 @@
  * the terms of any one of the MPL, the GPL or the LGPL.
  *
  * ***** END LICENSE BLOCK ***** */
-//------------------------------------------------------------------------------
+//----------------------------------------------------------------------------
 // inforssXMLRepository
 // Author : Didier Ernotte 2005
 // Inforss extension
-//------------------------------------------------------------------------------
+//----------------------------------------------------------------------------
 /* globals inforssDebug, inforssTraceIn, inforssTraceOut */
 Components.utils.import("chrome://inforss/content/modules/inforssDebug.jsm");
 
@@ -72,6 +72,9 @@ const Properties = Components.classes["@mozilla.org/file/directory_service;1"]
                  .getService(Components.interfaces.nsIProperties);
 const profile_dir = Properties.get("ProfD", Components.interfaces.nsIFile);
 
+const LoginManager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
+const LoginInfo = Components.Constructor("@mozilla.org/login-manager/loginInfo;1", Components.interfaces.nsILoginInfo, "init");
+
 //FIXME Turn this into a module, once we have all access to RSSList in here
 //Note that inforssOption should have its own instance which is then copied
 //once we do an apply. Jury is out on whether OPML import/export should work on
@@ -93,7 +96,7 @@ const MODE_REPLACE = 1;
 /* exported INFORSS_REPOSITORY */
 const INFORSS_REPOSITORY = "inforss.xml";
 
-//------------------------------------------------------------------------------
+//----------------------------------------------------------------------------
 const opml_attributes = [
   "acknowledgeDate",
   "activity",
@@ -134,19 +137,19 @@ function XML_Repository()
 }
 
 XML_Repository.prototype = {
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   is_valid()
   {
     return RSSList != null;
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getTimeSlice()
   {
-    return RSSList.firstChild.getAttribute("timeslice");
+    return parseInt(RSSList.firstChild.getAttribute("timeslice"), 10);
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   //FIXME Replace these two with one function returning 3 values
   //Headlines_At_Top, Headlines_At_Bottom, Headlines_In_Statusbar
   getSeparateLine()
@@ -154,429 +157,429 @@ XML_Repository.prototype = {
     return RSSList.firstChild.getAttribute("separateLine");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getLinePosition()
   {
     return RSSList.firstChild.getAttribute("linePosition");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getMouseEvent()
   {
     return eval(RSSList.firstChild.getAttribute("mouseEvent"));
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getMouseWheelScroll()
   {
     return RSSList.firstChild.getAttribute("mouseWheelScroll");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultPlayPodcast()
   {
     return RSSList.firstChild.getAttribute("defaultPlayPodcast");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getSavePodcastLocation()
   {
     return RSSList.firstChild.getAttribute("savePodcastLocation");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultBrowserHistory()
   {
     return RSSList.firstChild.getAttribute("defaultBrowserHistory");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultNbItem()
   {
     return RSSList.firstChild.getAttribute("defaultNbItem");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultLengthItem()
   {
     return RSSList.firstChild.getAttribute("defaultLenghtItem");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultRefresh()
   {
     return RSSList.firstChild.getAttribute("refresh");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getScrollingIncrement()
   {
     return eval(RSSList.firstChild.getAttribute("scrollingIncrement"));
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getScrollingArea()
   {
     return RSSList.firstChild.getAttribute("scrollingArea");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   setScrollingArea(width)
   {
     RSSList.firstChild.setAttribute("scrollingArea", width);
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isHideViewed()
   {
     return RSSList.firstChild.getAttribute("hideViewed") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   setHideViewed(value)
   {
     RSSList.firstChild.setAttribute("hideViewed", value);
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isHideOld()
   {
     return RSSList.firstChild.getAttribute("hideOld") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   setHideOld(value)
   {
     RSSList.firstChild.setAttribute("hideOld", value);
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isHideHistory()
   {
     return RSSList.firstChild.getAttribute("hideHistory") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isIncludeAssociated()
   {
     return RSSList.firstChild.getAttribute("includeAssociated") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getGroupLengthItem()
   {
     return RSSList.firstChild.getAttribute("groupLenghtItem");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getGroupNbItem()
   {
     return RSSList.firstChild.getAttribute("groupNbItem");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getGroupRefresh()
   {
     return RSSList.firstChild.getAttribute("groupRefresh");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   show_headlines_in_sub_menu()
   {
     return RSSList.firstChild.getAttribute("submenu") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultPurgeHistory()
   {
     return RSSList.firstChild.getAttribute("defaultPurgeHistory");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getFontSize()
   {
     return RSSList.firstChild.getAttribute("fontSize");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getNextFeed()
   {
     return RSSList.firstChild.getAttribute("nextFeed");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getScrollingSpeed()
   {
     return (30 - eval(RSSList.firstChild.getAttribute("scrollingspeed"))) * 10;
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getFilterHeadlines(rss)
   {
     return rss.getAttribute("filterHeadlines");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isFavicon()
   {
     return RSSList.firstChild.getAttribute("favicon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getRed()
   {
     return RSSList.firstChild.getAttribute("red");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getGreen()
   {
     return RSSList.firstChild.getAttribute("green");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getBlue()
   {
     return RSSList.firstChild.getAttribute("blue");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDelay()
   {
     return RSSList.firstChild.getAttribute("delay");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getCyclingDelay()
   {
     return parseInt(RSSList.firstChild.getAttribute("cyclingDelay"), 10);
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isCycling()
   {
     return RSSList.firstChild.getAttribute("cycling") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isCycleWithinGroup()
   {
     return RSSList.firstChild.getAttribute("cycleWithinGroup") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getTooltip()
   {
     return RSSList.firstChild.getAttribute("tooltip");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getClickHeadline()
   {
     return RSSList.firstChild.getAttribute("clickHeadline");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getFont()
   {
     return (RSSList.firstChild.getAttribute("font") == "auto") ? "inherit" : RSSList.firstChild.getAttribute("font");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isActive()
   {
     return RSSList.firstChild.getAttribute("switch") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getBold()
   {
     return RSSList.firstChild.getAttribute("bold") == "true" ? "bolder" : "normal";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getItalic()
   {
     return RSSList.firstChild.getAttribute("italic") == "true" ? "italic" : "normal";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isScrolling()
   {
     return RSSList.firstChild.getAttribute("scrolling") == "1" ||
       RSSList.firstChild.getAttribute("scrolling") == "2";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isFadeIn()
   {
     return RSSList.firstChild.getAttribute("scrolling") == "2";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   toggleScrolling()
   {
     RSSList.firstChild.setAttribute("scrolling", this.isScrolling() ? "0" : "1");
     this.save();
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isStopScrolling()
   {
     return RSSList.firstChild.getAttribute("stopscrolling") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isCurrentFeed()
   {
     return RSSList.firstChild.getAttribute("currentfeed") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isLivemark()
   {
     return RSSList.firstChild.getAttribute("livemark") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isClipboard()
   {
     return RSSList.firstChild.getAttribute("clipboard") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getSortedMenu()
   {
     return RSSList.firstChild.getAttribute("sortedMenu");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getCollapseBar()
   {
     return RSSList.firstChild.getAttribute("collapseBar") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getForegroundColor()
   {
     return RSSList.firstChild.getAttribute("foregroundColor");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultForegroundColor()
   {
     return RSSList.firstChild.getAttribute("defaultForegroundColor");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getDefaultGroupIcon()
   {
     return RSSList.firstChild.getAttribute("defaultGroupIcon");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getScrollingDirection()
   {
     return RSSList.firstChild.getAttribute("scrollingdirection");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isReadAllIcon()
   {
     return RSSList.firstChild.getAttribute("readAllIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isViewAllIcon()
   {
     return RSSList.firstChild.getAttribute("viewAllIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isShuffleIcon()
   {
     return RSSList.firstChild.getAttribute("shuffleIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isDirectionIcon()
   {
     return RSSList.firstChild.getAttribute("directionIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isScrollingIcon()
   {
     return RSSList.firstChild.getAttribute("scrollingIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isPreviousIcon()
   {
     return RSSList.firstChild.getAttribute("previousIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isPauseIcon()
   {
     return RSSList.firstChild.getAttribute("pauseIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isNextIcon()
   {
     return RSSList.firstChild.getAttribute("nextIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isRefreshIcon()
   {
     return RSSList.firstChild.getAttribute("refreshIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isHideOldIcon()
   {
     return RSSList.firstChild.getAttribute("hideOldIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isHideViewedIcon()
   {
     return RSSList.firstChild.getAttribute("hideViewedIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isSynchronizationIcon()
   {
     return RSSList.firstChild.getAttribute("synchronizationIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isSynchronizeIcon()
   {
     return RSSList.firstChild.getAttribute("synchronizeIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isFlashingIcon()
   {
     return RSSList.firstChild.getAttribute("flashingIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isHomeIcon()
   {
     return RSSList.firstChild.getAttribute("homeIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isFilterIcon()
   {
     return RSSList.firstChild.getAttribute("filterIcon") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   setQuickFilter(active, filter)
   {
     RSSList.firstChild.setAttribute("quickFilterActif", active);
@@ -584,49 +587,49 @@ XML_Repository.prototype = {
     this.save();
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   getQuickFilter()
   {
     return RSSList.firstChild.getAttribute("quickFilter");
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isQuickFilterActif()
   {
     return RSSList.firstChild.getAttribute("quickFilterActif") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isPopupMessage()
   {
     return RSSList.firstChild.getAttribute("popupMessage") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isPlaySound()
   {
     return RSSList.firstChild.getAttribute("playSound") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isDisplayEnclosure()
   {
     return RSSList.firstChild.getAttribute("displayEnclosure") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isDisplayBanned()
   {
     return RSSList.firstChild.getAttribute("displayBanned") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   isPlayList()
   {
     return RSSList.firstChild.getAttribute("playlist") == "true";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   switchShuffle()
   {
     if (RSSList.firstChild.getAttribute("nextFeed") == "next")
@@ -640,7 +643,7 @@ XML_Repository.prototype = {
     this.save();
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   switchDirection()
   {
     if (RSSList.firstChild.getAttribute("scrollingdirection") == "rtl")
@@ -654,7 +657,7 @@ XML_Repository.prototype = {
     this.save();
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   //FIXME Why does this live in prefs and not in the xml (or why doesn't more live here?)
   getServerInfo()
   {
@@ -703,7 +706,7 @@ XML_Repository.prototype = {
     return serverInfo;
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   setServerInfo(protocol, server, directory, user, password, autosync)
   {
     var prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("inforss.");
@@ -719,93 +722,50 @@ XML_Repository.prototype = {
   },
 
 
-  //------------------------------------------------------------------------------
-  //FIXME I don't think any of these passowrd functions have anything to do with this class
-  //FIXME passwordManager is way dead.
+  //----------------------------------------------------------------------------
+  //FIXME I don't think any of these password functions have anything to do
+  //with this class
   storePassword(url, user, password)
   {
-    if ("@mozilla.org/login-manager;1" in Components.classes)
+    var loginInfo = new LoginInfo(url, 'User Registration', null, user, password, "", "");
+    try
     {
-      var loginManager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
-      var nsLoginInfo = new Components.Constructor("@mozilla.org/login-manager/loginInfo;1", Components.interfaces.nsILoginInfo, "init");
-      var loginInfo = new nsLoginInfo(url, 'User Registration', null, user, password, "", "");
-      try
-      {
-        loginManager.removeLogin(loginInfo);
-      }
-      catch (e)
-      {}
-      loginManager.addLogin(loginInfo);
+      LoginManager.removeLogin(loginInfo);
     }
-    else
-    {
-      var passwordManager = Components.classes["@mozilla.org/passwordmanager;1"].createInstance(Components.interfaces.nsIPasswordManager);
-      try
-      {
-        passwordManager.removeUser(url, user);
-      }
-      catch (e)
-      {}
-      passwordManager.addUser(url, user, password);
-    }
+    catch (e)
+    {}
+    LoginManager.addLogin(loginInfo);
   },
 
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   readPassword(url, user)
   {
-    var password = {
-      value: ""
-    };
-    if ("@mozilla.org/login-manager;1" in Components.classes)
+    try
     {
-      try
+      // Find users for the given parameters
+      let logins = LoginManager.findLogins({}, url, 'User Registration', null);
+      // Find user from returned array of nsILoginInfo objects
+      for (let login of logins)
       {
-        let loginManager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
-
-        // Find users for the given parameters
-        let logins = loginManager.findLogins(
-        {}, url, 'User Registration', null);
-
-        // Find user from returned array of nsILoginInfo objects
-        for (let i = 0; i < logins.length; i++)
+        if (login.username == user)
         {
-          if (logins[i].username == user)
-          {
-            password.value = logins[i].password;
-            break;
-          }
+          return login.password;
         }
       }
-      catch (ex)
-      {}
     }
-    else
-    {
-      try
-      {
-        let passManager = Components.classes["@mozilla.org/passwordmanager;1"].getService(Components.interfaces.nsIPasswordManagerInternal);
-        let host = {
-          value: ""
-        };
-        var login = {
-          value: ""
-        };
-        passManager.findPasswordEntry(url, user, "", host, login, password);
-      }
-      catch (ee)
-      {}
-    }
-    return password.value;
+    catch (ex)
+    {}
+    return "";
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   save()
   {
     this._save(RSSList);
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   _save(list)
   {
     try
@@ -828,7 +788,7 @@ XML_Repository.prototype = {
     }
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   add_item(title, description, url, link, user, password, feedFlag)
   {
     inforssTraceIn();
@@ -837,8 +797,7 @@ XML_Repository.prototype = {
       if (RSSList == null)
       {
         RSSList = new DOMParser().parseFromString('<LIST-RSS/>', 'text/xml');
-        /**/
-        console.log("created empty rss", RSSList);
+        /**/console.log("created empty rss", RSSList);
       }
       let elem = this._new_item(RSSList, title, description, url, link, user, password, feedFlag);
       return elem;
@@ -854,7 +813,7 @@ XML_Repository.prototype = {
     }
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   _new_item(list, title, description, url, link, user, password, type)
   {
     inforssTraceIn();
@@ -954,7 +913,7 @@ XML_Repository.prototype = {
     return sequence;
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
   backup()
   {
@@ -979,7 +938,7 @@ XML_Repository.prototype = {
     }
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
   import_from_OPML(text, mode, progress)
   {
@@ -1094,7 +1053,7 @@ XML_Repository.prototype = {
     return sequence;
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   //FIXME once this is all in its own class, this should be in the "constructor"
   //need to be a bit careful about alerting the error if it's possible to keep
   //the error handling outside of here.
@@ -1118,7 +1077,7 @@ XML_Repository.prototype = {
     RSSList = new_list;
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   _convert_4_to_5(list)
   {
     let config = list.firstChild;
@@ -1161,7 +1120,7 @@ XML_Repository.prototype = {
     }
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   _convert_5_to_6(list)
   {
     let config = list.firstChild;
@@ -1213,7 +1172,7 @@ XML_Repository.prototype = {
     this._set_defaults(list);
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   _adjust_repository(list)
   {
     let config = list.firstChild;
@@ -1267,7 +1226,7 @@ XML_Repository.prototype = {
 
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
   _set_defaults(list)
   {
@@ -1416,7 +1375,7 @@ XML_Repository.prototype = {
     }
   },
 
-  //------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
   reset_xml_to_default()
   {
@@ -1448,7 +1407,7 @@ XML_Repository.prototype = {
 };
 
 
-//------------------------------------------------------------------------------
+//----------------------------------------------------------------------------
 /* exported inforssGetItemFromUrl */
 //FIXME Should be a method of the above
 //FIXME replace with document.querySelector(RSS[url=url]) (i think)
@@ -1472,7 +1431,7 @@ function inforssGetItemFromUrl(url)
   return null;
 }
 
-//------------------------------------------------------------------------------
+//----------------------------------------------------------------------------
 /* exported getCurrentRSS */
 //FIXME Should be a method of the above
 //FIXME Use document.querySelector


### PR DESCRIPTION
Fixes #75 

- guid is not treated as a link if isPermaLink is set to false (or if it is completely empty)
- if a link is not supplied, the homepage is used. This is mainly for some sanity inside the code
- select the proper link on atom feeds with multiple links
- Also fixed a bug with the main menu selecting the wrong feed