### PR TITLE
Fix very slow response when marking a large number of items read

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,11 @@
 ## Check install.rdf for new version number and compatibility
 ## Check the filename in phoebus.manifest
 
+# Changes for v 2.0.x.y
+
+Stop hanging the browser for a long time when marking a news feed as read if there are a lot if items (Issue #39)
+
+Fixes a silly error with cycling groups
 
 
 # Changes for v 2.0.2.0

--- a/source/content/inforss/inforssFeedManager.js
+++ b/source/content/inforss/inforssFeedManager.js
@@ -579,7 +579,7 @@ inforssFeedManager.prototype = {
         direction);
 
       //FIXME Optimisation needed it we cycle right back to the same one?
-      this.setSelected(informationList[i].getUrl());
+      this.setSelected(this.feed_list[i].getUrl());
     }
     catch (e)
     {
@@ -694,4 +694,4 @@ inforssFeedManager.find_next_feed = function(type, feeds, pos, direction)
       ++i;
     }
   return pos;
-}
+};

--- a/source/content/inforss/inforssOption.js
+++ b/source/content/inforss/inforssOption.js
@@ -47,6 +47,9 @@ Components.utils.import("chrome://inforss/content/modules/inforssUtils.jsm");
 
 Components.utils.import("chrome://inforss/content/modules/inforssPrompt.jsm");
 
+/* globals inforss_get_profile_dir */
+Components.utils.import("chrome://inforss/content/modules/inforssVersion.jsm");
+
 /* globals RSSList */
 /* globals inforssRead, inforssXMLRepository, inforssRDFRepository */
 /* globals inforssSave, inforssFindIcon, inforssGetItemFromUrl */
@@ -4023,7 +4026,7 @@ function locateRepository()
 {
   try
   {
-    var dir = Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+    var dir = inforss_get_profile_dir();
     var localFile = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
     localFile.initWithPath(dir.path);
     var filePicker = Components.classes["@mozilla.org/filepicker;1"].createInstance(Components.interfaces.nsIFilePicker);

--- a/source/content/inforss/inforssXMLRepository.js
+++ b/source/content/inforss/inforssXMLRepository.js
@@ -42,7 +42,8 @@
 /* globals inforssDebug, inforssTraceIn, inforssTraceOut */
 Components.utils.import("chrome://inforss/content/modules/inforssDebug.jsm");
 
-/* globals inforssGetResourceFile */
+/* globals inforssGetResourceFile, inforss_get_profile_dir */
+/* globals inforss_get_profile_file */
 Components.utils.import("chrome://inforss/content/modules/inforssVersion.jsm");
 
 //These should be in another module. Or at least not exported */
@@ -71,10 +72,6 @@ const FileOutputStream = Components.Constructor("@mozilla.org/network/file-outpu
   "nsIFileOutputStream",
   "init");
 
-const Properties = Components.classes["@mozilla.org/file/directory_service;1"]
-                 .getService(Components.interfaces.nsIProperties);
-const profile_dir = Properties.get("ProfD", Components.interfaces.nsIFile);
-
 const LoginManager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
 const LoginInfo = Components.Constructor("@mozilla.org/login-manager/loginInfo;1", Components.interfaces.nsILoginInfo, "init");
 
@@ -93,7 +90,6 @@ const MODE_APPEND = 0;
 /* exported MODE_REPLACE */
 const MODE_REPLACE = 1;
 
-//FIXME Should be hooked off profile_dir. The main problem is the rename below
 const INFORSS_REPOSITORY = "inforss.xml";
 
 /* exported INFORSS_DEFAULT_ICO */
@@ -176,9 +172,7 @@ XML_Repository.prototype = {
   //Get the full name of the configuration file.
   get_filepath()
   {
-    const path = profile_dir.clone();
-    path.append(INFORSS_REPOSITORY);
-    return path;
+    return inforss_get_profile_file(INFORSS_REPOSITORY);
   },
 
   //----------------------------------------------------------------------------
@@ -1239,8 +1233,7 @@ XML_Repository.prototype = {
       let file = this.get_filepath();
       if (file.exists())
       {
-        let backup = profile_dir.clone();
-        backup.append(INFORSS_BACKUP);
+        let backup = inforss_get_profile_file(INFORSS_BACKUP);
         if (backup.exists())
         {
           backup.remove(true);
@@ -1769,13 +1762,12 @@ XML_Repository.prototype = {
       if (file.exists())
       {
         const INFORSS_INERROR = "inforss_xml.inerror";
-        let dest = profile_dir.clone();
-        dest.append(INFORSS_INERROR);
+        let dest = inforss_get_profile_file(INFORSS_INERROR);
         if (dest.exists())
         {
           dest.remove(false);
         }
-        file.renameTo(profile_dir, INFORSS_INERROR);
+        file.renameTo(inforss_get_profile_dir(), INFORSS_INERROR);
       }
     }
 
@@ -1783,7 +1775,7 @@ XML_Repository.prototype = {
     let source = inforssGetResourceFile("inforss.default");
     if (source.exists())
     {
-      source.copyTo(profile_dir, INFORSS_REPOSITORY);
+      source.copyTo(inforss_get_profile_dir(), INFORSS_REPOSITORY);
     }
   },
 


### PR DESCRIPTION
Instead of flushing the rdf file to disk every operation, a flush will, if a flush is not outstanding, start a one second timer. The flush is performed on expiry of the timer.