### PR TITLE
Factor out tooltip management

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -110,6 +110,9 @@ rules:
   #- error
   #- property
 
+  # Allow multi-line strings
+  no-multi-str: off
+
   # Unary operators should not have spaces apart from !
   # I suspect the 1st two are default but the documentation is unclear.
   space-unary-ops:

--- a/.jshintrc
+++ b/.jshintrc
@@ -56,7 +56,7 @@
 //    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
 //    "laxcomma"      : false,     // true: Tolerate comma-first style coding
 //    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
-//    "multistr"      : false,     // true: Tolerate multi-line strings
+    "multistr"      : true,     // true: Tolerate multi-line strings
 //    "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
 //    "notypeof"      : false,     // true: Tolerate invalid typeof operator values
 //    "proto"         : false,     // true: Tolerate using the `__proto__` property

--- a/Changes.md
+++ b/Changes.md
@@ -4,9 +4,15 @@ When checking some css validation warnings, I discovered that the advanced/repor
 
 Added patches for a couple of feeds which had some rather custom behaviour.
 
-Add em:name to every localisation so this can be used on waterfox classic  - Issue #304
+Add em:name to every localisation so this can be used on waterfox classic - Issue #304
 
 Added a 'Refresh feed info' button to Options Window -> Basic -> Feed Group. This will update the feed url according to any permanent redirects, and update, title, description, link and favicon URL to match how feed is currently configured. See Issues #250 and #177
+
+Refactored the tooltip management considerably. This has two visible effects:
+* The tooltip style from the main icon (if you show feeds as submenus) is now controlled by the tooltip style option.
+* The 'Beginning of article' style is now referred to as article description.
+
+This fixes Issue #74, though I've raised another issue as I believe the way tooltips are being displayed is still wrong. It's just better than it was!
 
 # Changes for v 2.3.0.1
 

--- a/inforss.eslintrc.yaml
+++ b/inforss.eslintrc.yaml
@@ -120,7 +120,9 @@ rules:
 
   #-----------------------------------------------------------
   # mozilla rules
-  "mozilla/avoid-Date-timing": warn
+  #-----------------------------------------------------------
+  # This test flags almost any use of Date...
+  "mozilla/avoid-Date-timing": off
   "mozilla/avoid-removeChild": warn
   "mozilla/balanced-listeners": warn
   "mozilla/balanced-observers": warn

--- a/inforss.eslintrc.yaml
+++ b/inforss.eslintrc.yaml
@@ -65,13 +65,14 @@ rules:
     - MouseScrollEvent
     - PopupEvent
     - ProgressEvent
+    - XULCommandEvent
     # Mozilla classes
     - nsIAsyncVerifyRedirectCallback
     - nsiChannel
     - nsIIDRef
-    # Dom classes. Probably shouldn't be using any of these...
+    # Dom classes. Most of these are likely subclassed or subtyped
     - Document
-    - Element
+    #- Element
     - Node
     # Other web standard classes
     - XMLHttpRequest
@@ -80,9 +81,12 @@ rules:
     - Feed
     - Feed_Manager
     - Headline
+    - Main_Icon
     - Mediator
-    # Technically, these are elements...
+    # Technically, these are Elements...
     - hbox
+    - menuitem
+    - menupopup
     - tooltip
     - vbox
   "jsdoc/require-asterisk-prefix": warn

--- a/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
@@ -95,7 +95,7 @@ function get_link(collection)
  * The two special values are used in Feed_Page in order to set up enough of
  * a feed object to be able to process the xml read from a site.
  *
-*/
+ */
 function Atom_Feed(feedXML, options)
 {
   if ("url" in options)

--- a/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
@@ -205,7 +205,7 @@ Object.assign(Atom_Feed.prototype, {
 
   /** Read headlines for this feed
    *
-   * @param {XmlHttpRequest} request - resolved request
+   * @param {XMLHttpRequest} request - resolved request
    * @param {string} string - decoded string from request
    *
    * @returns {HTMLCollection} headlines

--- a/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
@@ -188,7 +188,7 @@ Object.assign(Atom_Feed.prototype, {
    *
    * @returns {string} summary content or null
    */
-  get_description(item)
+  get_description_impl(item)
   {
     //Note: We use this for the tooltip. It is possible for a huge wodge of html
     //to be put in the 'content' data, so we use summary for preference.

--- a/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
@@ -91,6 +91,10 @@ function get_link(collection)
  * @param {object} options - Passed to superclass, but we use two.
  * @param {URI} options.url - Feed URL.
  * @param {Document} options.doc - Feed xml.
+ *
+ * The two special values are used in Feed_Page in order to set up enough of
+ * a feed object to be able to process the xml read from a site.
+ *
 */
 function Atom_Feed(feedXML, options)
 {
@@ -202,16 +206,16 @@ Object.assign(Atom_Feed.prototype, {
    */
   read_headlines(request, string)
   {
-    return this.get_headlines(this.read_xml_feed(request, string));
+    return this._get_headlines(this.read_xml_feed(request, string));
   },
 
-  /** Get headlines for this feed
+  /** Get headlines for this feed.
    *
-   * @param {Document} doc - parsed xml
+   * @param {Document} doc - Parsed xml.
    *
-   * @returns {HTMLCollection} headlines
+   * @returns {HTMLCollection} The headlines.
    */
-  get_headlines(doc)
+  _get_headlines(doc)
   {
     return doc.getElementsByTagName("entry");
   }

--- a/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Atom_Feed.jsm
@@ -82,42 +82,32 @@ function get_link(collection)
   return null;
 }
 
-/** A feed which uses the Atom rfc
+/** A feed which uses the Atom rfc.
  *
  * @class
  * @extends Single_Feed
  *
- * @param {Object} feedXML - dom parsed xml config
- * @param {Array} args - arguments
- * either (normal usage)
- * param {Manager} manager - current feed manager
- * param {Object} menuItem - item in main menu for this feed. Really?
- * param {Mediator} mediator - for communicating with headline bar
- * param {Config} config - extension configuration
- * or (creating a feed object for configuration / menu display)
- * param {URI} url - feeds xml page
- * param {XMLDocument} doc - extension configuration
- */
-function Atom_Feed(feedXML, ...args)
+ * @param {object} feedXML - Dom parsed xml config.
+ * @param {object} options - Passed to superclass, but we use two.
+ * @param {URI} options.url - Feed URL.
+ * @param {Document} options.doc - Feed xml.
+*/
+function Atom_Feed(feedXML, options)
 {
-  if (args.length <= 2)
+  if ("url" in options)
   {
-    feedXML.setAttribute("url", args[0]);
-    if (args.length == 2)
-    {
-      const doc = args[1];
-      this.link = get_link(doc.querySelectorAll("feed >link"));
-      feedXML.setAttribute("link", this.link);
-      this.title = this.get_query_value(doc.querySelectorAll("feed >title"));
-      this.description =
-        this.get_query_value(doc.querySelectorAll("feed >tagline"));
-    }
-    Single_Feed.call(this, feedXML, null, null, null, null);
+    feedXML.setAttribute("url", options.url);
   }
-  else
+  if ("doc" in options)
   {
-    Single_Feed.call(this, feedXML, ...args);
+    const doc = options.doc;
+    this.link = get_link(doc.querySelectorAll("feed >link"));
+    feedXML.setAttribute("link", this.link);
+    this.title = this.get_query_value(doc.querySelectorAll("feed >title"));
+    this.description =
+      this.get_query_value(doc.querySelectorAll("feed >tagline"));
   }
+  Single_Feed.call(this, feedXML, options);
 }
 
 Atom_Feed.prototype = Object.create(Single_Feed.prototype);

--- a/source/content/inforss/feed_handlers/inforss_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Feed.jsm
@@ -76,20 +76,21 @@ const { Filter } = Components.utils.import(
  * state.
  *
  * @param {Element} feedXML - parsed xml tree for feed config
- * @param {Feed_Manager} manager - instance of manager controlling feed
- * @param {Element} _menu_entry - menuitem element for this feed. Why???
- * @param {Mediator} mediator - mediator object to communicate with display
- * @param {Config} config - extension configuration
+ * @param {object} options - these aren't really all that optional!
+ * @param {Feed_Manager} options.manager - Instance of manager controlling feed.
+ * @param {MenuItem} options.menu_entry - Menu for this feed. Why???
+ * @param {Mediator} options.mediator - Enables communicate with display.
+ * @param {Config} options.config - Extension configuration.
  */
-function Feed(feedXML, manager, _menu_entry, mediator, config)
+function Feed(feedXML, options)
 {
   this.active = false;
   this.disposed = false;
   this._update_xml(feedXML);
-  this.manager = manager;
-  this._menu_entry = _menu_entry;
-  this.mediator = mediator;
-  this.config = config;
+  this.manager = options.manager ?? null;
+  this._menu_entry = options.menu_entry ?? null;
+  this.mediator = options.mediator ?? null;
+  this.config = options.config ?? null;
   this.lastRefresh = null;
   this.next_refresh = null;
   this.publishing_enabled = true; //Set if this is currently part of a playlist

--- a/source/content/inforss/feed_handlers/inforss_Feed_Manager.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Feed_Manager.jsm
@@ -79,7 +79,6 @@ const { get_string } = Components.utils.import(
   {}
 );
 
-
 const { Added_New_Feed_Dialogue } = Components.utils.import(
   "chrome://inforss/content/windows/inforss_Added_New_Feed_Dialogue.jsm",
   {}
@@ -282,8 +281,10 @@ Feed_Manager.prototype = {
   //cycle to the next feed or group
   cycle_feed()
   {
-    //FIXME Does this do anything useful? This used to be in getNextGroupOrFeed
-    //but I don't see you could have a tooltip active whilst pressing a button.
+    //FIXME Does this do anything useful? This used to be in getNextGroupOrFeed.
+    //It is actually possible to triger this if you have a tooltip showing
+    //at the point when the feed is cycled (quite easy if you halt scrolling
+    //when mouse is over headline, AND you have a fairly short cycle time)
     if (this._mediator.isActiveTooltip())
     {
       this._cycle_timeout = setTimeout(event_binder(this.cycle_feed, this),

--- a/source/content/inforss/feed_handlers/inforss_Feed_Manager.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Feed_Manager.jsm
@@ -281,7 +281,6 @@ Feed_Manager.prototype = {
   //cycle to the next feed or group
   cycle_feed()
   {
-    //FIXME Does this do anything useful? This used to be in getNextGroupOrFeed.
     //It is actually possible to triger this if you have a tooltip showing
     //at the point when the feed is cycled (quite easy if you halt scrolling
     //when mouse is over headline, AND you have a fairly short cycle time)

--- a/source/content/inforss/feed_handlers/inforss_Feed_Manager.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Feed_Manager.jsm
@@ -373,11 +373,15 @@ Feed_Manager.prototype = {
     const old_feed = this.find_feed(feedXML.getAttribute("url"));
     if (old_feed === undefined)
     {
-      const info = feed_handlers.factory.create(feedXML,
-                                                this,
-                                                menuItem,
-                                                this._mediator,
-                                                this._config);
+      const info = feed_handlers.factory.create(
+        feedXML,
+        {
+          config: this._config,
+          manager: this,
+          mediator: this._mediator,
+          menu_entry: menuItem
+        }
+      );
       this._feed_list.push(info);
     }
     else

--- a/source/content/inforss/feed_handlers/inforss_HTML_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_HTML_Feed.jsm
@@ -109,7 +109,7 @@ Object.assign(HTML_Feed.prototype, {
     return item.category;
   },
 
-  get_description(item)
+  get_description_impl(item)
   {
     return item.description;
   },

--- a/source/content/inforss/feed_handlers/inforss_HTML_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_HTML_Feed.jsm
@@ -61,13 +61,13 @@ const { Single_Feed } = Components.utils.import(
   {}
 );
 
-/** A feed which scrapes HTML pages
+/** A feed which scrapes HTML pages.
  *
  * @class
  * @extends Single_Feed
  *
- * @param {object} feedXML - dom parsed xml config
- * @param {object} options - passed to superclass
+ * @param {object} feedXML - Dom parsed xml config.
+ * @param {object} options - Passed to superclass.
  */
 function HTML_Feed(feedXML, options)
 {

--- a/source/content/inforss/feed_handlers/inforss_HTML_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_HTML_Feed.jsm
@@ -66,15 +66,12 @@ const { Single_Feed } = Components.utils.import(
  * @class
  * @extends Single_Feed
  *
- * @param {Object} feedXML - dom parsed xml config
- * @param {Manager} manager - current feed manager
- * @param {Object} menuItem - item in main menu for this feed. Really?
- * @param {Mediator} mediator - for communicating with headline bar
- * @param {Config} config - extension configuration
+ * @param {object} feedXML - dom parsed xml config
+ * @param {object} options - passed to superclass
  */
-function HTML_Feed(feedXML, manager, menuItem, mediator, config)
+function HTML_Feed(feedXML, options)
 {
-  Single_Feed.call(this, feedXML, manager, menuItem, mediator, config);
+  Single_Feed.call(this, feedXML, options);
 }
 
 //FIXME I'd like to use 'super' in here (and groupedfeed) but everything gets

--- a/source/content/inforss/feed_handlers/inforss_NNTP_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_NNTP_Feed.jsm
@@ -173,7 +173,7 @@ Object.assign(NNTP_Feed.prototype, {
     return "";
   },
 
-  get_description(item)
+  get_description_impl(item)
   {
     return item.description;
   },

--- a/source/content/inforss/feed_handlers/inforss_NNTP_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_NNTP_Feed.jsm
@@ -141,21 +141,17 @@ function decodeQuotedPrintable(str)
   return null;
 }
 
-/** A feed which uses the NNTP news spec
+/** A feed which uses the NNTP news spec.
  *
  * @class
  * @extends Single_Feed
  *
- * @param {Object} feedXML - dom parsed xml config
- * @param {Manager} manager - current feed manager
- * @param {Object} menuItem - item in main menu for this feed. Really?
- * @param {Mediator} mediator - for communicating with headline bar
- * @param {Config} config - extension configuration
+ * @param {object} feedXML - Dom parsed xml config.
+ * @param {object} options - Passed to super class constructor.
  */
-function NNTP_Feed(feedXML, manager, menuItem, mediator, config)
+function NNTP_Feed(feedXML, options)
 {
-  Single_Feed.call(this, feedXML, manager, menuItem, mediator, config);
-  return this;
+  Single_Feed.call(this, feedXML, options);
 }
 
 NNTP_Feed.prototype = Object.create(Single_Feed.prototype);

--- a/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
@@ -172,7 +172,7 @@ Object.assign(RSS_Feed.prototype, {
     return this.get_text_value(item, "category");
   },
 
-  get_description(item)
+  get_description_impl(item)
   {
     return this.get_text_value(item, "description");
   },

--- a/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
@@ -179,7 +179,7 @@ Object.assign(RSS_Feed.prototype, {
 
   /** Read headlines for this feed
    *
-   * @param {XmlHttpRequest} request - resolved request
+   * @param {XMLHttpRequest} request - resolved request
    * @param {string} string - decoded string from request
    *
    * @returns {HTMLCollection} headlines

--- a/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
@@ -58,17 +58,19 @@ const { Single_Feed } = Components.utils.import(
 const { console } =
   Components.utils.import("resource://gre/modules/Console.jsm", {});
 
-//FIXME How is options.doc different to feedXML?
-//FIXME Why exactly do we need the optional parameters (for Feed_Page)
 /** A feed which uses the RSS spec.
  *
  * @class
  * @extends Single_Feed
  *
  * @param {object} feedXML - Dom parsed xml config.
- * @param {object} options - Passed to superclass, but we use two.
+ * @param {object} options - Passed to superclass, but we intercept two.
  * @param {URI} options.url - Feed URL.
  * @param {Document} options.doc - Feed xml.
+ *
+ * The two special values are used in Feed_Page in order to set up enough of
+ * a feed object to be able to process the xml read from a site.
+ *
  */
 function RSS_Feed(feedXML, options)
 {
@@ -178,7 +180,7 @@ Object.assign(RSS_Feed.prototype, {
    */
   read_headlines(request, string)
   {
-    return this.get_headlines(this.read_xml_feed(request, string));
+    return this._get_headlines(this.read_xml_feed(request, string));
   },
 
   /** Get headlines for this feed
@@ -187,7 +189,7 @@ Object.assign(RSS_Feed.prototype, {
    *
    * @returns {HTMLCollection} headlines
    */
-  get_headlines(doc)
+  _get_headlines(doc)
   {
     return doc.getElementsByTagName("item");
   }

--- a/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_RSS_Feed.jsm
@@ -58,42 +58,34 @@ const { Single_Feed } = Components.utils.import(
 const { console } =
   Components.utils.import("resource://gre/modules/Console.jsm", {});
 
-/** A feed which uses the RSS spec
+//FIXME How is options.doc different to feedXML?
+//FIXME Why exactly do we need the optional parameters (for Feed_Page)
+/** A feed which uses the RSS spec.
  *
  * @class
  * @extends Single_Feed
  *
- * @param {Object} feedXML - dom parsed xml config
- * @param {Array} args - arguments
- * either (normal usage)
- * param {Manager} manager - current feed manager
- * param {Object} menuItem - item in main menu for this feed. Really?
- * param {Mediator} mediator - for communicating with headline bar
- * param {Config} config - extension configuration
- * or (creating a feed object for configuration / menu display)
- * param {URI} url - feeds xml page
- * param {XMLDocument} doc - extension configuration
+ * @param {object} feedXML - Dom parsed xml config.
+ * @param {object} options - Passed to superclass, but we use two.
+ * @param {URI} options.url - Feed URL.
+ * @param {Document} options.doc - Feed xml.
  */
-function RSS_Feed(feedXML, ...args)
+function RSS_Feed(feedXML, options)
 {
-  if (args.length <= 2)
+  if ("url" in options)
   {
-    feedXML.setAttribute("url", args[0]);
-    if (args.length == 2)
-    {
-      const doc = args[1];
-      this.link = this.get_query_value(doc.querySelectorAll("channel >|link"));
-      feedXML.setAttribute("link", this.link);
-      this.title = this.get_query_value(doc.querySelectorAll("channel >title"));
-      this.description =
-        this.get_query_value(doc.querySelectorAll("channel >description"));
-    }
-    Single_Feed.call(this, feedXML, null, null, null, null);
+    feedXML.setAttribute("url", options.url);
   }
-  else
+  if ("doc" in options)
   {
-    Single_Feed.call(this, feedXML, ...args);
+    const doc = options.doc;
+    this.link = this.get_query_value(doc.querySelectorAll("channel >|link"));
+    feedXML.setAttribute("link", this.link);
+    this.title = this.get_query_value(doc.querySelectorAll("channel >title"));
+    this.description =
+      this.get_query_value(doc.querySelectorAll("channel >description"));
   }
+  Single_Feed.call(this, feedXML, options);
 }
 
 RSS_Feed.prototype = Object.create(Single_Feed.prototype);

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -434,7 +434,7 @@ complete_assign(Single_Feed.prototype, {
    *
    * @param {Headline} headline - headline in which we are interested
    *
-   * @returns {Object} enclosure information
+   * @returns {object} Enclosure information.
    */
   get_enclosure_info(headline)
   {

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -327,68 +327,68 @@ complete_assign(Single_Feed.prototype, {
    * republish the same story but with a different date (though in that case why
    * you'd not be supplying a guid is beyond me).
    *
-   * @param {Headline} headline - a headline object
+   * @param {object} item - a headline object
    *
    * @returns {string} hopefully a globally unique ID
    */
-  get_guid(headline)
+  get_guid(item)
   {
-    if (! ("guid" in headline))
+    if (! ("guid" in item))
     {
-      let guid = this.get_guid_impl(headline);
+      let guid = this.get_guid_impl(item);
       if (guid == null || guid == "")
       {
         if (guid == "")
         {
-          console.log("Explicit empty guid in " + this.getUrl(), headline);
+          console.log("Explicit empty guid in " + this.getUrl(), item);
         }
         //FIXME This should likely be replaced with
         //link + '#' + encoded title
-        guid = this.get_title(headline) + "::" + this.get_link(headline);
+        guid = this.get_title(item) + "::" + this.get_link(item);
       }
-      headline.guid = guid;
+      item.guid = guid;
     }
-    return headline.guid;
+    return item.guid;
   },
 
-  /** Get the target of the headline. If there isn't one, use the home page.
+  /** Get the target of the item. If there isn't one, use the home page.
    *
-   * @param {Object} headline - a headline
+   * @param {object} item - a a headline object
    *
    * @returns {URL} target link
    */
-  get_link(headline)
+  get_link(item)
   {
-    if (! ("link" in headline))
+    if (! ("link" in item))
     {
-      const href = this.get_link_impl(headline);
+      const href = this.get_link_impl(item);
       //It's not entirely clear with relative addresses what you are relative
       //to, so guessing this.
       const feed = this.getLinkAddress();
       if (href == null || href == "")
       {
-        console.log("Null link found in " + this.getUrl(), headline);
-        headline.link = feed;
+        console.log("Null link found in " + this.getUrl(), item);
+        item.link = feed;
       }
       else
       {
-        headline.link = (new URL(href, feed)).href;
+        item.link = (new URL(href, feed)).href;
       }
     }
-    return headline.link;
+    return item.link;
   },
 
-  /** Get the publication date of the headline.
+  /** Get the publication date of the item.
    *
-   * @param {Headline} headline - a headline
+   * @param {object} item - a a headline object
    *
    * @returns {Date} date of publication, or null
    */
-  get_pubdate(headline)
+  get_pubdate(item)
   {
-    if (! ("pubdate" in headline))
+    if (! ("pubdate" in item))
     {
-      let pubDate = this.get_pubdate_impl(headline);
+      let pubDate = this.get_pubdate_impl(item);
       if (pubDate != null)
       {
         let res = new Date(pubDate);
@@ -396,30 +396,30 @@ complete_assign(Single_Feed.prototype, {
         {
           console.log("Invalid date " + pubDate + " found in feed " +
                         this.getUrl(),
-                      headline);
+                      item);
           res = null;
         }
         pubDate = res;
       }
-      headline.pubdate = pubDate;
+      item.pubdate = pubDate;
     }
-    return headline.pubdate;
+    return item.pubdate;
   },
 
-  /** Get the description of the headline.
+  /** Get the description of the item.
    *
    * This will remove any script tags so that the description can be safely
    * displayed in a tooltip.
    *
    * @warning Do NOT overide this method. Override the impl method.
    *
-   * @param {Headline} headline - Headline in which we are interested.
+   * @param {object} item - a headline object.
    *
    * @returns {string} Sanitised description.
    */
-  get_description(headline)
+  get_description(item)
   {
-    let description = this.get_description_impl(headline);
+    let description = this.get_description_impl(item);
     if (description != null)
     {
       description = htmlFormatConvert(description).replace(NL_MATCHER, " ");
@@ -428,37 +428,37 @@ complete_assign(Single_Feed.prototype, {
     return description;
   },
 
-  /** Get the enclosure details of the headline.
+  /** Get the enclosure details of the item.
    *
    * @warning Do NOT overide this method. Override the impl method below.
    *
-   * @param {Headline} headline - headline in which we are interested
+   * @param {object} item - item in which we are interested
    *
    * @returns {object} Enclosure information.
    */
-  get_enclosure_info(headline)
+  get_enclosure_info(item)
   {
-    if (! ("enclosure_url" in headline))
+    if (! ("enclosure_url" in item))
     {
       const { enclosure_url, enclosure_type, enclosure_size } =
-        this.get_enclosure_impl(headline);
-      headline.enclosure_url = enclosure_url;
-      headline.enclosure_type = enclosure_type;
-      headline.enclosure_size = enclosure_size;
+        this.get_enclosure_impl(item);
+      item.enclosure_url = enclosure_url;
+      item.enclosure_type = enclosure_type;
+      item.enclosure_size = enclosure_size;
       if (enclosure_url == null)
       {
-        const link = this.get_link(headline);
+        const link = this.get_link(item);
         if (link != null && link.endsWith(".mp3"))
         {
-          headline.enclosure_url = link;
-          headline.enclosure_type = "audio/mp3";
+          item.enclosure_url = link;
+          item.enclosure_type = "audio/mp3";
         }
       }
     }
     return {
-      enclosure_url: headline.enclosure_url,
-      enclosure_type: headline.enclosure_type,
-      enclosure_size: headline.enclosure_size
+      enclosure_url: item.enclosure_url,
+      enclosure_type: item.enclosure_type,
+      enclosure_size: item.enclosure_size
     };
   },
 
@@ -466,13 +466,13 @@ complete_assign(Single_Feed.prototype, {
    *
    * Feeds should override this method if necessary.
    *
-   * @param {Headline} headline - headline to check for enclosure
+   * @param {object} item - item to check for enclosure
    *
    * @returns {object} Enclosure details.
    */
-  get_enclosure_impl(headline)
+  get_enclosure_impl(item)
   {
-    const enclosure = headline.getElementsByTagName("enclosure");
+    const enclosure = item.getElementsByTagName("enclosure");
     if (enclosure.length > 0)
     {
       return {
@@ -612,8 +612,6 @@ complete_assign(Single_Feed.prototype, {
           headline.getAttribute("guid"),
           headline.getAttribute("link"),
           headline.getAttribute("description"),
-          headline.getAttribute("url"),
-          headline.getAttribute("home"),
           headline.getAttribute("category"),
           headline.getAttribute("enclosureUrl"),
           headline.getAttribute("enclosureType"),
@@ -843,7 +841,6 @@ complete_assign(Single_Feed.prototype, {
                                     headlines.length - 1,
                                     headlines,
                                     this.lastRefresh,
-                                    home,
                                     url);
   },
 
@@ -851,8 +848,6 @@ complete_assign(Single_Feed.prototype, {
    *
    * @param {object} item - A headline extracted from feed xml.
    * @param {Date} received_date - When the headline was received.
-   * @param {string} home - feed home page (why do we store this in the headline?)
-   * @param {string} url - URL (of what? the feed??? and why do we store it?)
    * @param {boolean} remember_headlines - If true, then check against our
    *                  headline database to see if we've already received it
    * @param {string} save_podcast_location - if not blank, podcasts will be
@@ -861,8 +856,7 @@ complete_assign(Single_Feed.prototype, {
    * @returns {Headline} A beautiful headline object...
    */
   get_headline(
-    item, received_date, home, url,
-    remember_headlines = false, save_podcast_location = ""
+    item, received_date, remember_headlines = false, save_podcast_location = ""
   )
   {
     //FIXME does the htmlFormatConvert call do anything useful?
@@ -909,13 +903,11 @@ complete_assign(Single_Feed.prototype, {
 
     const headline = new Headline(
       received_date,
-      this.get_pubdate(item),
+      this.get_pubdate(item) ?? received_date,
       title,
       this.get_guid(item),
       link,
       this.get_description(item),
-      url,
-      home,
       this.get_category(item),
       enclosure_url,
       enclosure_type,
@@ -941,7 +933,7 @@ complete_assign(Single_Feed.prototype, {
   },
 
   //----------------------------------------------------------------------------
-  _read_feed_1(i, items, receivedDate, home, url)
+  _read_feed_1(i, items, receivedDate, url)
   {
     if (i >= 0)
     {
@@ -950,7 +942,7 @@ complete_assign(Single_Feed.prototype, {
       if (this.find_headline(guid) === undefined)
       {
         const headline = this.get_headline(
-          item, receivedDate, home, url, this.config.remember_headlines,
+          item, receivedDate, this.config.remember_headlines,
           this.getSavePodcastLocation()
         );
         this.headlines.unshift(headline);
@@ -964,7 +956,6 @@ complete_assign(Single_Feed.prototype, {
                                       i,
                                       items,
                                       receivedDate,
-                                      home,
                                       url);
     }
     else
@@ -973,7 +964,6 @@ complete_assign(Single_Feed.prototype, {
                                       this.config.headline_processing_backoff,
                                       0,
                                       items,
-                                      home,
                                       url);
     }
   },
@@ -984,7 +974,7 @@ complete_assign(Single_Feed.prototype, {
   //horribly inefficient as most of the headlines it's just put in.
   //FIXME why would one do that? should probably be an option if you leave your
   //browser up for a long while.
-  _read_feed_2(i, items, home, url)
+  _read_feed_2(i, items, url)
   {
     if (i < this.headlines.length && url.startsWith("http"))
     {
@@ -1010,7 +1000,6 @@ complete_assign(Single_Feed.prototype, {
                                       this.config.headline_processing_backoff,
                                       i,
                                       items,
-                                      home,
                                       url);
     }
     else
@@ -1140,7 +1129,7 @@ complete_assign(Single_Feed.prototype, {
     //Use slice, as set_headline_viewed can alter _displayed_headlines
     for (const headline of this._displayed_headlines.slice(0))
     {
-      this.mediator.open_link(headline.getLink());
+      this.mediator.open_link(headline.link);
       mediator.set_headline_viewed(headline.title, headline.link);
     }
   },

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -833,7 +833,6 @@ complete_assign(Single_Feed.prototype, {
   process_headlines(headlines)
   {
     this.error = false;
-    const home = this.getLinkAddress();
     const url = this.getUrl();
     //FIXME Replace with a sequence of promises
     this._read_timeout = setTimeout(event_binder(this._read_feed_1, this),

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -591,6 +591,9 @@ complete_assign(Single_Feed.prototype, {
       {
         //FIXME This is questionable as it doesn't actually copy all the
         //attributes to the new headline and scrolling doesn't start
+/**/console.log("synchronise", headline)
+        //FIXME This is now totally shafted - we need to call something in
+        //headline class to construct this.
         const head = new Headline(
           new Date(headline.getAttribute("receivedDate")),
           new Date(headline.getAttribute("pubDate")),
@@ -1084,12 +1087,12 @@ complete_assign(Single_Feed.prototype, {
     //FIXME We shouldn't need the title. The URL should be enough
     //FIXME Why is it necessary to return a value. headline bar uses it to
     //speed up processing but why can't it find out itself in a better way?
-    //Even worse, setviewed and setbanned call operations on the feed...
     for (const headline of this._displayed_headlines)
     {
       if (headline.link == link && headline.title == title)
       {
-        headline.setViewed();
+        this.setAttribute(link, title, "viewed", "true");
+        this.setAttribute(link, title, "readDate", headline.set_viewed());
         //FIXME I am at a loss as to why this should be necessary.
         this.manager.signalReadEnd(this);
         return true;
@@ -1109,24 +1112,24 @@ complete_assign(Single_Feed.prototype, {
     }
   },
 
-  /** Set a headline as banned (can never be seen again)
+  /** Set a headline as banned (can never be seen again).
    *
-   * @param {string} title - headline title
-   * @param {string} link - url of headline
+   * @param {string} title - Headline title.
+   * @param {string} link - URL of headline.
    *
-   * @returns {boolean} true if the headline was found
+   * @returns {boolean} True if the headline was found.
    */
   setBanned(title, link)
   {
     //FIXME We shouldn't need the title. The URL should be enough
     //FIXME Why is it necessary to return a value. headline bar uses it to
     //speed up processing but why can't it find out itself in a better way?
-    //Even worse, setviewed and setbanned call operations on the feed...
     for (const headline of this._displayed_headlines)
     {
       if (headline.link == link && headline.title == title)
       {
-        headline.setBanned();
+        headline.set_banned();
+        this.setAttribute(link, title, "banned", "true");
         //FIXME I am at a loss as to why this should be necessary.
         this.manager.signalReadEnd(this);
         return true;
@@ -1136,7 +1139,7 @@ complete_assign(Single_Feed.prototype, {
   },
 
   //----------------------------------------------------------------------------
-  //AFAICS This doesn't actually mark them banned. It marks them *read*.
+  //FIXME This doesn't actually mark them banned. It marks them *read*.
   //Or 'mark all as read' doesn't do what it claims to.
   setBannedAll()
   {

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -600,26 +600,29 @@ complete_assign(Single_Feed.prototype, {
       this._clear_sync_timer();
       for (const headline of objDoc.getElementsByTagName("headline"))
       {
-        //FIXME This is questionable as it doesn't actually copy all the
-        //attributes to the new headline and scrolling doesn't start
-/**/console.log("synchronise", headline)
-        //FIXME This is now totally shafted - we need to call something in
-        //headline class to construct this.
+        //FIXME This is questionable as scrolling doesn't start. Also, this
+        //relies on knowing the internals of headlines, so it should probably
+        //belong to the Headline class.
+        let viewed_date = headline.getAttribute("_viewed_date");
+        if (viewed_date !== null)
+        {
+          viewed_date = new Date(viewed_date);
+        }
         const head = new Headline(
           new Date(headline.getAttribute("receivedDate")),
           new Date(headline.getAttribute("pubDate")),
-          headline.getAttribute("title"),
-          headline.getAttribute("guid"),
-          headline.getAttribute("link"),
+          headline.getAttribute("_title"),
+          headline.getAttribute("_guid"),
+          headline.getAttribute("_link"),
           headline.getAttribute("description"),
           headline.getAttribute("category"),
           headline.getAttribute("enclosureUrl"),
           headline.getAttribute("enclosureType"),
           headline.getAttribute("enclosureSize"),
+          viewed_date,
+          headline.getAttribute("_banned"),
           this,
           this.config);
-        head.viewed = headline.getAttribute("viewed") == "true";
-        head.banned = headline.getAttribute("banned") == "true";
         this.headlines.push(head);
       }
       this._publish_feed();
@@ -872,7 +875,6 @@ complete_assign(Single_Feed.prototype, {
 
     let banned = false;
     let viewed_date = null;
-
     if (remember_headlines)
     {
       if (this.exists(link, title, this.getBrowserHistory()))

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -336,6 +336,28 @@ complete_assign(Single_Feed.prototype, {
     return headline.pubdate;
   },
 
+  /** Get the description of the headline.
+   *
+   * This will remove any script tags so that the description can be safely
+   * displayed in a tooltip.
+   *
+   * @warning Do NOT overide this method. Override the impl method.
+   *
+   * @param {Headline} headline - Headline in which we are interested.
+   *
+   * @returns {string} Sanitised description.
+   */
+  get_description(headline)
+  {
+    let description = this.get_description_impl(headline);
+    if (description != null)
+    {
+      description = htmlFormatConvert(description).replace(NL_MATCHER, " ");
+      description = this._remove_script(description);
+    }
+    return description;
+  },
+
   /** Get the enclosure details of the headline.
    *
    * @warning Do NOT overide this method. Override the impl method below.

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -106,9 +106,9 @@ const INFORSS_FETCH_TIMEOUT = 10 * 1000;
 
 const NL_MATCHER = new RegExp("\n", "g");
 
-/** Parses the response from an XmlHttpRequest, returning a document
+/** Parses the response from an XMLHttpRequest, returning a document
  *
- * @param {XmlHttpRequest} request - fulfilled request
+ * @param {XMLHttpRequest} request - fulfilled request
  * @param {string} string - why do we pass this?
  * @param {string} url - request source
  *
@@ -169,7 +169,7 @@ function parse_xml_data(request, string, url)
 
 /** Decode response from an xmlHttpRequest
  *
- * @param {XmlHttpRequest} request - completed request
+ * @param {XMLHttpRequest} request - completed request
  * @param {string} encoding - (optional) encoding to use, or null
  *
  * @returns {string} translated string

--- a/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_Single_Feed.jsm
@@ -849,8 +849,8 @@ complete_assign(Single_Feed.prototype, {
    * @param {object} item - A headline extracted from feed xml.
    * @param {Date} received_date - When the headline was received.
    * @param {boolean} remember_headlines - If true, then check against our
-   *                  headline database to see if we've already received it
-   * @param {string} save_podcast_location - if not blank, podcasts will be
+   *                  headline database to see if we've already received it.
+   * @param {string} save_podcast_location - If not blank, podcasts will be
    *                 saved to the specified location.
    *
    * @returns {Headline} A beautiful headline object...
@@ -859,9 +859,12 @@ complete_assign(Single_Feed.prototype, {
     item, received_date, remember_headlines = false, save_podcast_location = ""
   )
   {
-    //FIXME does the htmlFormatConvert call do anything useful?
-    const title = htmlFormatConvert(this.get_title(item)).replace(
+    let title = htmlFormatConvert(this.get_title(item)).replace(
       NL_MATCHER, " ");
+    if (title == "")
+    {
+      title = "(no title)";
+    }
 
     const link = this.get_link(item);
 
@@ -1017,7 +1020,7 @@ complete_assign(Single_Feed.prototype, {
   //----------------------------------------------------------------------------
   _remove_headline(i)
   {
-    this.headlines[i].resetHbox();
+    this.headlines[i].reset_hbox();
     this.headlines.splice(i, 1);
   },
 
@@ -1081,7 +1084,7 @@ complete_assign(Single_Feed.prototype, {
         const found = match !== undefined;
         if (! found)
         {
-          old_headline.resetHbox();
+          old_headline.reset_hbox();
         }
         return found;
       });

--- a/source/content/inforss/feed_handlers/inforss_factory.jsm
+++ b/source/content/inforss/feed_handlers/inforss_factory.jsm
@@ -59,13 +59,6 @@ const factory = {};
 factory.feeds = {};
 
 //Register a function which creates a new instance of what is being registered.
-//The function is passed 5 or 6 parameters and is expected to return a new
-//feed handler constructed with the appropriate parameters
-//p1 = feed xml object
-//p2 = manager instance
-//p3 = menu instance
-//p4 = mediator
-//p5 = config
 factory.register = function register(name, func)
 {
   factory.feeds[name] = func;

--- a/source/content/inforss/inforssOverlay.xul
+++ b/source/content/inforss/inforssOverlay.xul
@@ -15,13 +15,13 @@
 
   <toolbox>
     <toolbar id="inforss-addon-bar" collapsed="true">
-      <toolbaritem id="inforss.headlines"
-                   context="">
-        <popupset id="inforss.popupset"
-                  style="overflow:auto">
-          <tooltip id="inforss.popup.mainicon"
-                   style="overflow:auto"
-                   >
+      <toolbaritem id="inforss.headlines" context="">
+        <!-- You need to place dynamic tooltips inside a popupset or they
+             don't work.
+        -->
+        <popupset id="inforss.tooltips" style="overflow:auto">
+          <!-- tooltip for main icon (summary of current feed state -->
+          <tooltip id="inforss.mainicon.tooltip" style="overflow:auto">
             <grid>
               <columns>
                 <column/>
@@ -30,9 +30,7 @@
               <rows/>
             </grid>
           </tooltip>
-          <tooltip id="inforss.tooltip.default"
-                   type="default"
-                   position="before_end"/>
+          <!-- tooltip for 'hide old' button -->
           <tooltip id="inforss.hideold.tooltip">
             <label value="&inforss.hide.old; ()"/>
           </tooltip>
@@ -41,7 +39,7 @@
                         type="menu"
                         class="statusbarpanel-menu-iconic"
                         style="border-style: none"
-                        tooltip="inforss.popup.mainicon"
+                        tooltip="inforss.mainicon.tooltip"
                         src="chrome://inforss/skin/inforss.png">
           <menupopup id="inforss.menupopup"
                      ignorekeys="false">

--- a/source/content/inforss/modules/inforss_Constants.jsm
+++ b/source/content/inforss/modules/inforss_Constants.jsm
@@ -47,7 +47,6 @@
 /* exported EXPORTED_SYMBOLS */
 const EXPORTED_SYMBOLS = [
   "INFORSS_DEFAULT_FETCH_TIMEOUT", /* exported INFORSS_DEFAULT_FETCH_TIMEOUT */
-  "INFORSS_MAX_SUBMENU", /* exported INFORSS_MAX_SUBMENU */
   "MIME_feed_type", /* exported MIME_feed_type */
   "MIME_feed_url", /* exported MIME_feed_url */
 ];
@@ -60,9 +59,6 @@ const EXPORTED_SYMBOLS = [
 
 /* Timeout for feed fetches */
 var INFORSS_DEFAULT_FETCH_TIMEOUT = 5000;
-
-//Maximum number of headlines in headline submenu.
-var INFORSS_MAX_SUBMENU = 25;
 
 var MIME_feed_type = "application/x-inforss-feed-type";
 var MIME_feed_url = "application/x-inforss-feed-url";

--- a/source/content/inforss/modules/inforss_Feed_Page.jsm
+++ b/source/content/inforss/modules/inforss_Feed_Page.jsm
@@ -90,6 +90,7 @@ Components.utils.import(
  *
  * @param {string} url - URL to fetch.
  * @param {object} options - Optional params.
+ * @param {Config} options.config - Extension configuration.
  * @param {string} options.feed - Set to a feed xml config to use that config,
  *                                rather than work it out from the fetched page.
  * @param {string} options.fetch_icon - Set to true to fetch icon.
@@ -106,6 +107,7 @@ function Feed_Page(url, options = {})
   this._url = url;
   this._user = options.user;
   this._password = options.password;
+  this._config = options.config;
   this._fetch_icon = options.fetch_icon;
   this._feed_config = options.feed_config;
   this._refresh_feed = options.refresh_feed;
@@ -171,13 +173,13 @@ Feed_Page.prototype =
         feedXML.setAttribute("type", this._type);
 
         this._feed = feed_handlers.factory.create(
-          feedXML, { doc: objDoc, url: this._url });
+          feedXML, { config: this._config, doc: objDoc, url: this._url });
       }
       else
       {
         this._type = this._feed_config.getAttribute("type");
         this._feed = feed_handlers.factory.create(
-          this._feed_config, { url: this._url }
+          this._feed_config, { config: this._config, url: this._url }
         );
       }
 

--- a/source/content/inforss/modules/inforss_Feed_Page.jsm
+++ b/source/content/inforss/modules/inforss_Feed_Page.jsm
@@ -84,16 +84,18 @@ Components.utils.import(
 //const { console } =
 //  Components.utils.import("resource://gre/modules/Console.jsm", {});
 
-/** Use this to get feed page information
+/** Use this to get feed page information.
  *
- * @param {string} url - url to fetch
- * @param {Object} options - optional params
- * @param {string} options.user - user id.
- * @param {string} options.password - if unset, will fetch from password store
- * @param {string} options.feed - set to a feed xml config to use that config,
- *                                rather than work it out from the fetched page
- * @param {string} options.fetch_icon - set to true to fetch icon
- * @param {string} options.refresh_feed - set to true if refreshing feed config.
+ * @class
+ *
+ * @param {string} url - URL to fetch.
+ * @param {object} options - Optional params.
+ * @param {string} options.feed - Set to a feed xml config to use that config,
+ *                                rather than work it out from the fetched page.
+ * @param {string} options.fetch_icon - Set to true to fetch icon.
+ * @param {string} options.user - User id.
+ * @param {string} options.password - If unset, will fetch from password store.
+ * @param {string} options.refresh_feed - Set to true if refreshing feed config.
  *
  * If the url is an https url and the user id isn't, given a prompt box is
  * generated to get the user name and password. If you escape from this, an
@@ -168,12 +170,15 @@ Feed_Page.prototype =
         const feedXML = objDoc.createElement("rss");
         feedXML.setAttribute("type", this._type);
 
-        this._feed = feed_handlers.factory.create(feedXML, this._url, objDoc);
+        this._feed = feed_handlers.factory.create(
+          feedXML, { doc: objDoc, url: this._url });
       }
       else
       {
         this._type = this._feed_config.getAttribute("type");
-        this._feed = feed_handlers.factory.create(this._feed_config, this._url);
+        this._feed = feed_handlers.factory.create(
+          this._feed_config, { url: this._url }
+        );
       }
 
       const feed = this._feed;

--- a/source/content/inforss/modules/inforss_Feed_Page.jsm
+++ b/source/content/inforss/modules/inforss_Feed_Page.jsm
@@ -105,7 +105,7 @@ function Feed_Page(url, options = {})
   this._user = options.user;
   this._password = options.password;
   this._fetch_icon = options.fetch_icon;
-  this._feed_config = options.feed;
+  this._feed_config = options.feed_config;
   this._refresh_feed = options.refresh_feed;
   this._icon = undefined;
   this._request = null;
@@ -183,6 +183,9 @@ Feed_Page.prototype =
       {
         this._headlines.push(
           {
+            //FIXME maybe we should just return the headline? not the rest of
+            //the stuff
+            headline,
             title: feed.get_title(headline),
             description: feed.get_description(headline),
             link: feed.get_link(headline),

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -74,8 +74,8 @@ Components.utils.import(
   "chrome://inforss/content/mediator/inforss_Mediator_API.jsm",
   mediator);
 
-/**/const { console } =
-/**/  Components.utils.import("resource://gre/modules/Console.jsm", {});
+const { console } =
+  Components.utils.import("resource://gre/modules/Console.jsm", {});
 
 const INFORSS_TOOLTIP_BROWSER_WIDTH = 600;
 const INFORSS_TOOLTIP_BROWSER_HEIGHT = 400;

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -1,0 +1,533 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is infoRSS.
+ *
+ * The Initial Developer of the Original Code is
+ *   Didier Ernotte <didier@ernotte.com>.
+ * Portions created by the Initial Developer are Copyright (C) 2004
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *   Didier Ernotte <didier@ernotte.com>.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+//------------------------------------------------------------------------------
+// inforss_Tooltip
+// Author : Tom Tanner, 2023
+// Inforss extension
+//------------------------------------------------------------------------------
+/* jshint globalstrict: true */
+/* eslint-disable strict */
+"use strict";
+
+/* eslint-disable array-bracket-newline */
+/* exported EXPORTED_SYMBOLS */
+const EXPORTED_SYMBOLS = [
+  "Headline_Tooltip", /* exported Headline_Tooltip */
+];
+/* eslint-enable array-bracket-newline */
+
+const { MIME_feed_type, MIME_feed_url } = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Constants.jsm",
+  {}
+);
+
+const { debug } = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Debug.jsm",
+  {}
+);
+
+const { Notifier } = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Notifier.jsm",
+  {}
+);
+
+const { alert, prompt } = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Prompt.jsm",
+  {}
+);
+
+const {
+  add_event_listeners,
+  event_binder,
+  htmlFormatConvert,
+  option_window_displayed,
+  remove_all_children,
+  remove_event_listeners,
+  reverse
+} = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Utils.jsm",
+  {}
+);
+
+const { get_string } = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Version.jsm",
+  {}
+);
+
+const { Resize_Button } = Components.utils.import(
+  "chrome://inforss/content/toolbar/inforss_Resize_Button.jsm",
+  {}
+);
+
+const mediator = {};
+Components.utils.import(
+  "chrome://inforss/content/mediator/inforss_Mediator_API.jsm",
+  mediator);
+
+/**/const { console } =
+/**/  Components.utils.import("resource://gre/modules/Console.jsm", {});
+
+const { clearTimeout, setTimeout } = Components.utils.import(
+  "resource://gre/modules/Timer.jsm",
+  {}
+);
+
+const INFORSS_TOOLTIP_BROWSER_WIDTH = 600;
+const INFORSS_TOOLTIP_BROWSER_HEIGHT = 400;
+
+const ParserUtils = Components.classes[
+  "@mozilla.org/parserutils;1"].getService(
+  Components.interfaces.nsIParserUtils);
+
+const ClipboardHelper = Components.classes[
+  "@mozilla.org/widget/clipboardhelper;1"].getService(
+  Components.interfaces.nsIClipboardHelper);
+
+const Sound = Components.classes["@mozilla.org/sound;1"].getService(
+  Components.interfaces.nsISound);
+
+const Icon_Size = 16;
+const Spacer_Width = 5;
+
+/** Creates a tooltip and controls the up-poppingness.
+ *
+ * @class
+ * @param {Config} config - Configuration.
+ * @param {Document} document - Top level browser document.
+ */
+function Tooltip_Controller(config, document)
+{
+
+  //this._mediator = mediator_;
+  this._config = config;
+
+  this._document = document;
+  /*
+  this._feed_manager = feed_manager;
+
+  //Scrolling is complicated by the fact we have three things to control it:
+  //1) The global config control (disabled, fade, scroll)
+  //2) the 'pause scrolling button'
+  //3) the 'pause on mouse over' config.
+  this._scrolling = {
+    _paused_toggle: false,
+    _paused_mouse: false
+  };
+  this._scroll_needed = true;
+  this._scroll_timeout = null;
+  this._resize_timeout = null;
+  this._notifier = new Notifier();
+  this._active_tooltip = false;
+  this._mouse_down_handler = event_binder(this.__mouse_down_handler, this);
+  */
+  this._tooltip_open = event_binder(this.__tooltip_open, this);
+  this._tooltip_close = event_binder(this.__tooltip_close, this);
+  this._tooltip_mouse_move = event_binder(this.__tooltip_mouse_move, this);
+  this._tooltip_X = -1;
+  this._tooltip_Y = -1;
+  this._tooltip_browser = null;
+/*
+  const box = document.getElementById("inforss.newsbox1");
+  this._headline_box = box;
+
+  this._resize_button = new Resize_Button(config,
+                                          this,
+                                          document,
+                                          box,
+                                          addon_bar);
+
+  this._had_addon_bar = addon_bar.id != "inforss-addon-bar";
+*/
+  /* eslint-disable array-bracket-newline */
+  /*
+  this._listeners = add_event_listeners(
+    this,
+    document,
+    [ box, "DOMMouseScroll", this._mouse_scroll ], //FIXME use the wheel event?
+    [ box, "mouseover", this._pause_scrolling ],
+    [ box, "mouseout", this._resume_scrolling ],
+    [ box, "dragover", this._on_drag_over ],
+    [ box, "drop", this._on_drop ],
+    [ "icon.pause", "click", this._toggle_pause ],
+    [ "icon.shuffle", "click", this._switch_shuffle_style ],
+    [ "icon.direction", "click", this._switch_scroll_direction ],
+    [ "icon.scrolling", "click", this._toggle_scrolling ],
+    [ "icon.filter", "click", this._quick_filter ],
+    [ document.defaultView, "resize", this._resize_window ]
+  );
+  */
+  /* eslint-enable array-bracket-newline */
+}
+
+Tooltip_Controller.prototype = {
+
+//-------------------------------------------------------------------------------------------------------------
+  //FIXME called from Feed_Manager during cycle_feed. is this meaningful?
+  //This is needed in the main headline handler to stop cycling feed during
+  //a mouseover so we need to die this in somehow
+  isActiveTooltip()
+  {
+    return this._active_tooltip;
+  },
+
+  /** Create a tooltip for the supplied headline.
+   *
+   * @param {Headline} headline - Headline to which to add tooltip.
+   *
+   * @returns {string} The new tooltip id.
+   */
+  create_tooltip(headline)
+  {
+    let tooltip_contents = "";
+    let tooltip_type = "text";
+
+    switch (this._config.headline_tooltip_style)
+    {
+      default:
+        debug("Unknown tooltip style: " + this._config.headline_tooltip_style);
+        /* eslint-disable-next-line lines-around-comment */
+        /* fall through */
+
+      case "article":
+        tooltip_contents = headline.link;
+        tooltip_type = "url";
+        break;
+
+      case "description":
+        {
+          const container = this._document.createElement("hbox");
+          const fragment = ParserUtils.parseFragment(headline.description,
+                                                     0,
+                                                     false,
+                                                     null,
+                                                     container);
+          tooltip_contents = fragment.textContent;
+        }
+        break;
+
+      case "title":
+        {
+          const container = this._document.createElement("hbox");
+          const fragment = ParserUtils.parseFragment(headline.title,
+                                                     0,
+                                                     false,
+                                                     null,
+                                                     container);
+          tooltip_contents = fragment.textContent;
+        }
+        break;
+
+      case "allInfo":
+        {
+          const container = this._document.createElement("hbox");
+          const fragment = ParserUtils.parseFragment(headline.description,
+                                                     0,
+                                                     false,
+                                                     null,
+                                                     container);
+
+          const feed = headline.feed;
+
+          tooltip_contents = "<TABLE width='100%' \
+style='background-color:#2B60DE; color:white; -moz-border-radius: 10px; \
+padding: 6px'><TR><TD colspan=2 align=center \
+style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
+            feed.getIcon() +
+            "' width=16px height=16px> " + feed.getTitle() +
+            "</B></TD></TR><TR><TD align='right'><B>" + get_string("title") +
+            ": </B></TD><TD>" + headline.title +
+            "</TD></TR><TR><TD align='right'><B>" + get_string("date") +
+            ": </B></TD><TD>" + headline.publishedDate +
+            "</TD></TR><TR><TD align='right'><B>" + get_string("rss") +
+            ": </B></TD><TD>" + headline.url +
+            "</TD></TR><TR><TD align='right'><B>" + get_string("link") +
+            ": </B></TD><TD>" + headline.link +
+            "</TD></TR></TABLE><br>" + fragment.textContent;
+        }
+        break;
+    }
+
+    const id = "inforss.headline.tooltip." + /*headline.guid*/headline.link;
+
+    {
+      const oldtip = this._document.getElementById(id);
+      if (oldtip !== null)
+      {
+        oldtip.remove();
+      }
+    }
+
+    const tooltip = this._document.createElement("tooltip");
+    tooltip.setAttribute("id", id);
+    tooltip.setAttribute("position", "before_end");
+    tooltip.setAttribute("noautohide", true);
+    tooltip.append(
+      this._fill_tooltip(headline, tooltip_contents, tooltip_type)
+    );
+
+    //FIXME need to remove these somehow?
+    tooltip.addEventListener("popupshown", this._tooltip_open);
+    tooltip.addEventListener("popuphiding", this._tooltip_close);
+
+    this._document.getElementById("inforss.tooltips").append(tooltip);
+    return id;
+  },
+
+  //----------------------------------------------------------------------------
+  //FIXME this is unnecessarily complex
+  _fill_tooltip(headline, str, type)
+  {
+    const toolHbox = this._document.createElement("hbox");
+    toolHbox.setAttribute("flex", "1");
+    if (headline.enclosureUrl != null &&
+        this._config.headline_tooltip_style != "article")
+    {
+      const vbox = this._document.createElement("vbox");
+      vbox.setAttribute("flex", "0");
+      vbox.style.backgroundColor = "inherit";
+      if (headline.enclosureType.startsWith("audio/") ||
+          headline.enclosureType.startsWith("video/"))
+      {
+        vbox.setAttribute("enclosureUrl", headline.enclosureUrl);
+        vbox.setAttribute("enclosureType", headline.enclosureType);
+        vbox.headline = headline;
+      }
+      else
+      {
+        const img = this._document.createElement("image");
+        img.setAttribute("src", headline.enclosureUrl);
+        vbox.appendChild(img);
+      }
+
+      const spacer = this._document.createElement("spacer");
+      spacer.setAttribute("width", "10");
+      vbox.appendChild(spacer);
+
+      toolHbox.appendChild(vbox);
+    }
+
+    {
+      const vbox = this._document.createElement("vbox");
+      vbox.setAttribute("flex", "1");
+      if (type == "text")
+      {
+        str = htmlFormatConvert(str);
+        if (str != null && str.indexOf("<") != -1 && str.indexOf(">") != -1)
+        {
+          let br = this._document.createElement("iframe");
+          vbox.appendChild(br);
+          br.setAttribute("type", "content-targetable");
+          br.setAttribute(
+            "src",
+            "data:text/html;charset=utf-8,<html><body>" +
+              encodeURIComponent(str) + "</body></html>"
+          );
+          br.setAttribute("flex", "1");
+          br.style.overflow = "auto";
+          br.style.width = INFORSS_TOOLTIP_BROWSER_WIDTH + "px";
+          br.style.height = INFORSS_TOOLTIP_BROWSER_HEIGHT + "px";
+        }
+        else if (str != null && str != "")
+        {
+          //Break this up into lines of 60 characters.
+          //FIXME I'm pretty sure this sort of thing occurs elsewhere
+          do
+          {
+            let j = str.length > 60 ? str.lastIndexOf(' ', 60) : -1;
+            if (j == -1)
+            {
+              j = 60;
+            }
+            const description = this._document.createElement("label");
+            description.setAttribute("value", str.substring(0, j).trim());
+            vbox.appendChild(description);
+            str = str.substring(j + 1).trim();
+          } while (str != "");
+        }
+        else if (headline.enclosureUrl != null)
+        {
+          const image = this._document.createElement("image");
+          //FIXME What if it's not one of those?
+          if (headline.enclosureType.startsWith("image"))
+          {
+            image.setAttribute("src", "chrome://inforss/skin/image.png");
+          }
+          else if (headline.enclosureType.startsWith("video"))
+          {
+            image.setAttribute("src", "chrome://inforss/skin/movie.png");
+          }
+          else if (headline.enclosureType.startsWith("audio"))
+          {
+            image.setAttribute("src", "chrome://inforss/skin/speaker.png");
+          }
+          vbox.appendChild(image);
+        }
+      }
+      else
+      {
+        //Apparently not text. Do we assume its html?
+        let br = this._document.createElement("browser");
+        vbox.appendChild(br);
+        br.setAttribute("flex", "1");
+        br.srcUrl = str;
+      }
+
+      toolHbox.appendChild(vbox);
+    }
+
+    return toolHbox;
+  },
+
+  /** Deal with showing tooltip.
+   *
+   * @param {PopupEvent} event - Tooltip showing event.
+   */
+  __tooltip_open(event)
+  {
+/**/console.log(event)
+    this._active_tooltip = true;
+
+    const tooltip = event.target;
+    for (const vbox of tooltip.getElementsByTagName("vbox"))
+    {
+/**/console.log(vbox);
+      if (vbox.hasAttribute("enclosureUrl") &&
+          vbox.headline.feed.feedXML.getAttribute("playPodcast") == "true")
+      {
+/**/console.log(vbox);
+        if (vbox.childNodes.length == 1)
+        {
+          const br = this._document.createElement("browser");
+          br.setAttribute("enclosureUrl", vbox.getAttribute("enclosureUrl"));
+          const size =
+            vbox.getAttribute("enclosureType").startsWith("video") ? 200 : 1;
+          br.setAttribute("width", size);
+          br.setAttribute("height", size);
+          br.setAttribute(
+            "src",
+            "data:text/html;charset=utf-8,<HTML><BODY><EMBED src='" +
+              vbox.getAttribute("enclosureUrl") +
+              "' autostart='true' ></EMBED></BODY></HTML>"
+          );
+          vbox.appendChild(br);
+        }
+        break;
+      }
+    }
+    this._tooltip_browser = null;
+    for (const browser of tooltip.getElementsByTagName("browser"))
+    {
+      if (browser.srcUrl != null && ! browser.hasAttribute("src"))
+      {
+        browser.style.width = INFORSS_TOOLTIP_BROWSER_WIDTH + "px";
+        browser.style.height = INFORSS_TOOLTIP_BROWSER_HEIGHT + "px";
+        browser.setAttribute("flex", "1");
+        browser.setAttribute("src", browser.srcUrl);
+        browser.focus();
+      }
+      if (this._tooltip_browser == null &&
+          ! browser.hasAttribute("enclosureUrl"))
+      {
+        this._tooltip_browser = browser;
+      }
+      browser.contentWindow.scrollTo(0, 0);
+    }
+    tooltip.setAttribute("noautohide", "true");
+
+    if (this._document.tooltipNode != null)
+    {
+      this._document.tooltipNode.addEventListener("mousemove",
+                                                  this._tooltip_mouse_move);
+    }
+/**/console.log("done")
+  },
+
+  /** Deal with tooltip hiding.
+   *
+   * @param {PopupEvent} event - Event details.
+   */
+  __tooltip_close(event)
+  {
+/**/console.log(event)
+    this._active_tooltip = false;
+
+    if (this._document.tooltipNode != null)
+    {
+      this._document.tooltipNode.removeEventListener(
+        "mousemove",
+        this._tooltip_mouse_move
+      );
+    }
+
+    //Need to set tooltip to beginning of article and enable podcast playing
+    //to see one of these...
+    const item = event.target.querySelector("browser[enclosureUrl]");
+    if (item != null)
+    {
+      item.remove();
+    }
+    this._tooltip_browser = null;
+  },
+
+  /** Deal with tooltip mouse movement.
+   *
+   * @param {MouseEvent} event - Event details.
+   */
+  __tooltip_mouse_move(event)
+  {
+    //It is not clear to me why these are only initialised once and not
+    //(say) when the browser window is created.
+    if (this._tooltip_X == -1)
+    {
+      this._tooltip_X = event.screenX;
+    }
+    if (this._tooltip_Y == -1)
+    {
+      this._tooltip_Y = event.screenY;
+    }
+    if (this._tooltip_browser != null)
+    {
+      this._tooltip_browser.contentWindow.scrollBy(
+        (event.screenX - this._tooltip_X) * 50,
+        (event.screenY - this._tooltip_Y) * 50
+      );
+    }
+    this._tooltip_X = event.screenX;
+    this._tooltip_Y = event.screenY;
+  },
+
+};

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -273,11 +273,13 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
       vbox.setAttribute("flex", "1");
       let tooltip_contents = htmlFormatConvert(
         this._get_tooltip_text(headline)
-      );
-      if (tooltip_contents.includes("<") && tooltip_contents.includes(">"))
+      ).trim();
+      //What we should really be doing is for get_tooltip_text to determine
+      //whether or not to produce html or text. Currently however, it strips
+      //all the html and returns the textContent part of the parsed HTML.
+      //See issue #325
+      if (this._config.headline_tooltip_style == "allInfo")
       {
-        //FIXME Is this actually possible?
-/**/console.log("found html")
         const br = this._document.createElement("iframe");
         vbox.appendChild(br);
         br.setAttribute("tooltip_type", "content-targetable");
@@ -293,25 +295,25 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
       }
       else if (tooltip_contents != "")
       {
-        //Break this up into lines of 60 characters.
-        //FIXME I'm pretty sure this sort of thing occurs elsewhere
+        //Break this up into lines of 60 characters and attach as labels.
         do
         {
-          let j = tooltip_contents.length > 60 ? tooltip_contents.lastIndexOf(' ', 60) : -1;
-          if (j == -1)
+          let pos = tooltip_contents.length > 60 ?
+            tooltip_contents.lastIndexOf(" ", 60) :
+            -1;
+          if (pos == -1)
           {
-            j = 60;
+            pos = 60;
           }
           const description = this._document.createElement("label");
-          description.setAttribute("value", tooltip_contents.substring(0, j).trim());
+          description.setAttribute("value", tooltip_contents.substring(0, pos));
           vbox.appendChild(description);
-          tooltip_contents = tooltip_contents.substring(j + 1).trim();
+          tooltip_contents = tooltip_contents.substring(pos + 1).trim();
         } while (tooltip_contents != "");
       }
       else if (headline.enclosureUrl != null)
       {
         const image = this._document.createElement("image");
-        //FIXME What if it's not one of those?
         if (headline.enclosureType.startsWith("image"))
         {
           image.setAttribute("src", "chrome://inforss/skin/image.png");
@@ -324,6 +326,7 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
         {
           image.setAttribute("src", "chrome://inforss/skin/speaker.png");
         }
+        //Otherwise we have a blank image which is fine.
         vbox.appendChild(image);
       }
 

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -198,7 +198,7 @@ Tooltip_Controller.prototype = {
 //-------------------------------------------------------------------------------------------------------------
   //FIXME called from Feed_Manager during cycle_feed. is this meaningful?
   //This is needed in the main headline handler to stop cycling feed during
-  //a mouseover so we need to die this in somehow
+  //a mouseover so we need to tie this in somehow
   isActiveTooltip()
   {
     return this._active_tooltip;
@@ -264,7 +264,7 @@ Tooltip_Controller.prototype = {
             null,
             container);
 
-        //  const feed = headline.feed;
+          //const feed = headline.feed;
 
           tooltip_contents = "<TABLE width='100%' \
 style='background-color:#2B60DE; color:white; -moz-border-radius: 10px; \

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -206,12 +206,11 @@ Tooltip_Controller.prototype = {
 
   /** Create a tooltip for the supplied headline.
    *
-   * @param {Feed} feed - Feed from which headline came.
    * @param {Headline} headline - Headline to which to add tooltip.
    *
    * @returns {string} The new tooltip id.
    */
-  create_tooltip(feed, headline)
+  create_tooltip(headline)
   {
     let tooltip_contents = "";
     let tooltip_type = "text";
@@ -224,7 +223,7 @@ Tooltip_Controller.prototype = {
         /* fall through */
 
       case "article":
-        tooltip_contents = feed.get_link(headline); //headline.link
+        tooltip_contents = headline.link;
         tooltip_type = "url";
         break;
 
@@ -232,7 +231,7 @@ Tooltip_Controller.prototype = {
         {
           const container = this._document.createElement("hbox");
           const fragment = ParserUtils.parseFragment(
-            feed.get_description(headline), //headline.description
+            headline.description,
             0,
             false,
             null,
@@ -245,7 +244,7 @@ Tooltip_Controller.prototype = {
         {
           const container = this._document.createElement("hbox");
           const fragment = ParserUtils.parseFragment(
-            feed.get_title(headline), //headline.title
+            headline.title,
             0,
             false,
             null,
@@ -258,13 +257,13 @@ Tooltip_Controller.prototype = {
         {
           const container = this._document.createElement("hbox");
           const fragment = ParserUtils.parseFragment(
-            feed.get_description(headline), //headline.description
+            headline.description,
             0,
             false,
             null,
             container);
 
-          //const feed = headline.feed;
+          const feed = headline.feed;
 
           tooltip_contents = "<TABLE width='100%' \
 style='background-color:#2B60DE; color:white; -moz-border-radius: 10px; \
@@ -285,7 +284,7 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
         break;
     }
 
-    const id = "inforss.headline.tooltip." + "magic." + feed.get_guid(headline); //headline.guid;
+    const id = "inforss.headline.tooltip." + "magic." + headline.guid;
 
     {
       const oldtip = this._document.getElementById(id);

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -143,6 +143,8 @@ Tooltip_Controller.prototype = {
 
     this._tooltips.append(tooltip);
 /**/console.log(this._tooltips, this._tooltips.childElementCount)
+//FIXME Add method to remove tooltips - when should it be called. also I need a
+//way of distinguishing between menu tooltips and headline bar tooltips.
     return id;
   },
 
@@ -172,7 +174,6 @@ Tooltip_Controller.prototype = {
           container);
 
         const feed = headline.feed;
-
         return "<TABLE width='100%' \
 style='background-color:#2B60DE; color:white; -moz-border-radius: 10px; \
 padding: 6px'><TR><TD colspan=2 align=center \
@@ -184,7 +185,7 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
           "</TD></TR><TR><TD align='right'><B>" + get_string("date") +
           ": </B></TD><TD>" + headline.publishedDate +
           "</TD></TR><TR><TD align='right'><B>" + get_string("rss") +
-          ": </B></TD><TD>" + headline.url +
+          ": </B></TD><TD>" + feed.getUrl() +
           "</TD></TR><TR><TD align='right'><B>" + get_string("link") +
           ": </B></TD><TD>" + headline.link +
           "</TD></TR></TABLE><br>" + fragment.textContent;

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -86,8 +86,9 @@ const ParserUtils = Components.classes[
  *
  * @param {Config} config - Configuration.
  * @param {Document} document - Top level browser document.
+ * @param {string} id - To differentiate between different tooltip clients
  */
-function Tooltip_Controller(config, document)
+function Tooltip_Controller(config, document, id)
 {
   this._config = config;
   this._document = document;
@@ -100,6 +101,7 @@ function Tooltip_Controller(config, document)
   this._tooltip_browser = null;
   this._has_active_tooltip = true;
   this._tooltips = this._document.getElementById("inforss.tooltips");
+  this._tooltip_id_base = "inforss.tooltip." + id + ".";
 }
 
 Tooltip_Controller.prototype = {
@@ -121,7 +123,7 @@ Tooltip_Controller.prototype = {
    */
   create_tooltip(headline)
   {
-    const id = "inforss.headline.tooltip." + headline.guid;
+    const id = this._tooltip_id_base + headline.guid;
 
     {
       const oldtip = this._document.getElementById(id);
@@ -142,9 +144,8 @@ Tooltip_Controller.prototype = {
     tooltip.addEventListener("popuphiding", this._tooltip_close);
 
     this._tooltips.append(tooltip);
-/**/console.log(this._tooltips, this._tooltips.childElementCount)
-//FIXME Add method to remove tooltips - when should it be called. also I need a
-//way of distinguishing between menu tooltips and headline bar tooltips.
+    headline.tooltip = tooltip;
+
     return id;
   },
 

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -139,7 +139,6 @@ Tooltip_Controller.prototype = {
     tooltip.setAttribute("noautohide", true);
     tooltip.append(this._fill_tooltip(headline));
 
-    //FIXME need to remove these somehow?
     tooltip.addEventListener("popupshown", this._tooltip_open);
     tooltip.addEventListener("popuphiding", this._tooltip_close);
 
@@ -275,10 +274,10 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
       let tooltip_contents = htmlFormatConvert(
         this._get_tooltip_text(headline)
       );
-      if (tooltip_contents != null &&
-          tooltip_contents.includes("<") &&
-          tooltip_contents.includes(">"))
+      if (tooltip_contents.includes("<") && tooltip_contents.includes(">"))
       {
+        //FIXME Is this actually possible?
+/**/console.log("found html")
         const br = this._document.createElement("iframe");
         vbox.appendChild(br);
         br.setAttribute("tooltip_type", "content-targetable");
@@ -292,7 +291,7 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
         br.style.width = INFORSS_TOOLTIP_BROWSER_WIDTH + "px";
         br.style.height = INFORSS_TOOLTIP_BROWSER_HEIGHT + "px";
       }
-      else if (tooltip_contents != null && tooltip_contents != "")
+      else if (tooltip_contents != "")
       {
         //Break this up into lines of 60 characters.
         //FIXME I'm pretty sure this sort of thing occurs elsewhere

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -206,11 +206,12 @@ Tooltip_Controller.prototype = {
 
   /** Create a tooltip for the supplied headline.
    *
+   * @param {Feed} feed - Feed from which headline came.
    * @param {Headline} headline - Headline to which to add tooltip.
    *
    * @returns {string} The new tooltip id.
    */
-  create_tooltip(headline)
+  create_tooltip(feed, headline)
   {
     let tooltip_contents = "";
     let tooltip_type = "text";
@@ -223,18 +224,19 @@ Tooltip_Controller.prototype = {
         /* fall through */
 
       case "article":
-        tooltip_contents = headline.link;
+        tooltip_contents = feed.get_link(headline); //headline.link
         tooltip_type = "url";
         break;
 
       case "description":
         {
           const container = this._document.createElement("hbox");
-          const fragment = ParserUtils.parseFragment(headline.description,
-                                                     0,
-                                                     false,
-                                                     null,
-                                                     container);
+          const fragment = ParserUtils.parseFragment(
+            feed.get_description(headline), //headline.description
+            0,
+            false,
+            null,
+            container);
           tooltip_contents = fragment.textContent;
         }
         break;
@@ -242,11 +244,12 @@ Tooltip_Controller.prototype = {
       case "title":
         {
           const container = this._document.createElement("hbox");
-          const fragment = ParserUtils.parseFragment(headline.title,
-                                                     0,
-                                                     false,
-                                                     null,
-                                                     container);
+          const fragment = ParserUtils.parseFragment(
+            feed.get_title(headline), //headline.title
+            0,
+            false,
+            null,
+            container);
           tooltip_contents = fragment.textContent;
         }
         break;
@@ -254,13 +257,14 @@ Tooltip_Controller.prototype = {
       case "allInfo":
         {
           const container = this._document.createElement("hbox");
-          const fragment = ParserUtils.parseFragment(headline.description,
-                                                     0,
-                                                     false,
-                                                     null,
-                                                     container);
+          const fragment = ParserUtils.parseFragment(
+            feed.get_description(headline), //headline.description
+            0,
+            false,
+            null,
+            container);
 
-          const feed = headline.feed;
+        //  const feed = headline.feed;
 
           tooltip_contents = "<TABLE width='100%' \
 style='background-color:#2B60DE; color:white; -moz-border-radius: 10px; \
@@ -281,7 +285,7 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
         break;
     }
 
-    const id = "inforss.headline.tooltip." + /*headline.guid*/headline.link;
+    const id = "inforss.headline.tooltip." + "magic." + feed.get_guid(headline); //headline.guid;
 
     {
       const oldtip = this._document.getElementById(id);

--- a/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
+++ b/source/content/inforss/modules/inforss_Tooltip_Controller.jsm
@@ -99,6 +99,7 @@ function Tooltip_Controller(config, document)
   this._tooltip_Y = -1;
   this._tooltip_browser = null;
   this._has_active_tooltip = true;
+  this._tooltips = this._document.getElementById("inforss.tooltips");
 }
 
 Tooltip_Controller.prototype = {
@@ -140,16 +141,16 @@ Tooltip_Controller.prototype = {
     tooltip.addEventListener("popupshown", this._tooltip_open);
     tooltip.addEventListener("popuphiding", this._tooltip_close);
 
-    this._document.getElementById("inforss.tooltips").append(tooltip);
-/**/console.log(this._document.getElementById("inforss.tooltips"))
+    this._tooltips.append(tooltip);
+/**/console.log(this._tooltips, this._tooltips.childElementCount)
     return id;
   },
 
   /** Get the text for the tooltip.
    *
-   * @param {Headline} headline - Headline for which we want a tooltip
+   * @param {Headline} headline - Headline for which we want a tooltip.
    *
-   * @returns {string} Appropriate text
+   * @returns {string} Appropriate text.
    */
   _get_tooltip_text(headline)
   {
@@ -425,8 +426,6 @@ style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
    */
   __tooltip_mouse_move(event)
   {
-    //It is not clear to me why these are only initialised once and not
-    //(say) when the browser window is created.
     if (this._tooltip_X == -1)
     {
       this._tooltip_X = event.screenX;

--- a/source/content/inforss/modules/inforss_Utils.jsm
+++ b/source/content/inforss/modules/inforss_Utils.jsm
@@ -71,10 +71,10 @@ const { debug } = Components.utils.import(
   {}
 );
 
-//const { console } = Components.utils.import(
-//  "resource://gre/modules/Console.jsm",
-//  {}
-//);
+const { console } = Components.utils.import(
+  "resource://gre/modules/Console.jsm",
+  {}
+);
 
 const IoService = Components.classes[
   "@mozilla.org/network/io-service;1"].getService(
@@ -170,54 +170,53 @@ function format_as_hh_mm_ss(date)
 //perhaps we should drop all the parameters and give that its own function.
 /** HTML string conversion
  *
- * @param {string} str - string to convert
- * @param {boolean} keep - keep < and > if set
- * @param {string} mimeTypeFrom - mime type of string (defaults to text/html)
- * @param {string} mimeTypeTo - mime type to convert to (defaults to
- *                 text/unicode
+ * @param {string} instr - String to convert.
+ * @param {boolean} keep - Keep < and > if set.
+ * @param {string} mimeTypeFrom - Mime type of string (defaults to text/html).
+ * @param {string} mimeTypeTo - Mime type to convert to (defaults to
+ *                 text/unicode.
  *
  * @returns {string} converted string
  *
  */
-function htmlFormatConvert(str, keep, mimeTypeFrom, mimeTypeTo)
+function htmlFormatConvert(instr, keep, mimeTypeFrom, mimeTypeTo)
 {
-  if (str == null)
+  if (instr == null)
   {
     return ""; //Seriously - this happens
   }
 
-  let convertedString = null;
-
   //This is called from inforssNntp with keep false, converting from plain to
   //html. Arguably it should have its own method.
-  if (keep == null)
+  if (keep === undefined)
   {
     keep = true;
   }
 
-  if (mimeTypeFrom == null)
+  if (mimeTypeFrom === undefined)
   {
     mimeTypeFrom = "text/html";
   }
 
-  if (mimeTypeTo == null)
+  if (mimeTypeTo === undefined)
   {
     mimeTypeTo = "text/unicode";
   }
 
+  let str = instr;
   if (keep)
   {
     str = str.replace(/</gi, "__LT__");
     str = str.replace(/>/gi, "__GT__");
   }
 
-  const fromString = new SupportsString();
-  fromString.data = str;
-  let toString = { value: null };
-
   //FIXME do I really need try/catch here?
   try
   {
+    const fromString = new SupportsString();
+    fromString.data = str;
+    let toString = { value: null };
+
     //This API is almost completely undocumented, so I've no idea how to rework
     //it it into something useful.
     const converter = new FormatConverter();
@@ -231,40 +230,37 @@ function htmlFormatConvert(str, keep, mimeTypeFrom, mimeTypeTo)
     {
       toString = toString.value.QueryInterface(
         Components.interfaces.nsISupportsString);
-      convertedString = toString.toString();
+      let convertedString = toString.toString();
       if (keep)
       {
         convertedString = convertedString.replace(/__LT__/gi, "<");
         convertedString = convertedString.replace(/__GT__/gi, ">");
       }
-    }
-    else
-    {
-      convertedString = str;
+      return convertedString;
     }
   }
   catch (err)
   {
-    convertedString = str;
+    console.log("Unexpected error converting string", err);
   }
 
-  return convertedString;
+  return instr;
 }
 
-/** Make a URI from a string
+/** Make a URI from a string.
  *
- * @param {string} url - url to turn into a URI
+ * @param {string} url - URL to turn into a URI.
  *
- * @returns {URI} URI object
+ * @returns {URI} URI object.
  */
 function make_URI(url)
 {
   return IoService.newURI(url);
 }
 
-/** Open or focus the option window
+/** Open or focus the option window.
  *
- * @param {Window} window - parent window
+ * @param {Window} window - Parent window.
  */
 function open_option_window(window)
 {
@@ -281,9 +277,9 @@ function open_option_window(window)
   }
 }
 
-/** Check if the option window is currently displayed
+/** Check if the option window is currently displayed.
  *
- * @returns {boolean} true if the option window is currently displayed
+ * @returns {boolean} True if the option window is currently displayed.
  */
 function option_window_displayed()
 {

--- a/source/content/inforss/ticker/inforss_Headline.jsm
+++ b/source/content/inforss/ticker/inforss_Headline.jsm
@@ -64,6 +64,7 @@ const { console } = Components.utils.import(
 /** This object contains the contents of a displayed headline.
  *
  * @class
+ *
  * It sadly has a lot of content, and needs refactoring to hide/expose the
  * correct stuff.
  */
@@ -104,8 +105,8 @@ function Headline(
   this.guid = guid;
   this.link = link;
   this.description = description;
-  this.url = url;
-  this.home = home;
+  this._url = url;
+  this._home = home;
   this.category = category;
   this.enclosureUrl = enclosureUrl;
   this.enclosureType = enclosureType;
@@ -116,10 +117,22 @@ function Headline(
   this._config = config;
 
   this._hbox = null;
-  this._tooltip = null;
+  /**/this._tooltip = null;
 }
 
 complete_assign(Headline.prototype, {
+
+  get url()
+  {
+    /**/console.log("Getting HL URL", new Error());
+    return this._url;
+  },
+
+  get home()
+  {
+    /**/console.log("Getting HL home", new Error());
+    return this._home;
+  },
 
   /** get current hbox for this headline
    *
@@ -150,6 +163,7 @@ complete_assign(Headline.prototype, {
    */
   get tooltip()
   {
+    /**/console.log("Getting hl tooltip", new Error())
     return this._tooltip;
   },
 
@@ -159,6 +173,7 @@ complete_assign(Headline.prototype, {
    */
   set tooltip(tooltip)
   {
+    /**/console.log("Setting hl tooltip", new Error())
     if (this._tooltip != null)
     {
       this._tooltip.remove();
@@ -241,12 +256,6 @@ complete_assign(Headline.prototype, {
     this._banned = true;
   },
 
-  //Is someone using this?? Leave around for a bit.
-  get config()
-  {
-    /**/console.log("Yer what", new Error())
-    return this._config;
-  },
   //-------------------------------------------------------------------------------------------------------------
   isNew()
   {

--- a/source/content/inforss/ticker/inforss_Headline.jsm
+++ b/source/content/inforss/ticker/inforss_Headline.jsm
@@ -66,7 +66,7 @@ const { console } = Components.utils.import(
  * @class
  *
  * It sadly has a lot of content, and needs refactoring to hide/expose the
- * correct stuff.
+ * correct stuff. Also, all the properties need to be protected by getters.
  */
 function Headline(
   receivedDate,
@@ -75,8 +75,6 @@ function Headline(
   guid,
   link,
   description,
-  url,
-  home,
   category,
   enclosureUrl,
   enclosureType,
@@ -86,27 +84,12 @@ function Headline(
   feed,
   config)
 {
-  //FIXME I don't think this is possible any more but need to check nntp code
-  //Should probably be done elsewhere anyway.
-  if (link == null || link == "")
-  {
-    console.log("null link, using home page " + home);
-    link = home;
-  }
-  //FIXME Move this to feed handler as it is possible
-  if (pubDate == null)
-  {
-    pubDate = receivedDate;
-  }
-
   this.receivedDate = receivedDate;
   this.publishedDate = pubDate;
-  this.title = title;
+  this._title = title;
   this.guid = guid;
-  this.link = link;
+  this._link = link;
   this.description = description;
-  this._url = url;
-  this._home = home;
   this.category = category;
   this.enclosureUrl = enclosureUrl;
   this.enclosureType = enclosureType;
@@ -117,35 +100,27 @@ function Headline(
   this._config = config;
 
   this._hbox = null;
+  //FIXME Is this unused? Should it be ? (as we don't want to repeatedly
+  //create tooltips and want to remove them when things go out of context
   /**/this._tooltip = null;
+
+  Object.seal(this);
 }
 
 complete_assign(Headline.prototype, {
 
-  get url()
-  {
-    /**/console.log("Getting HL URL", new Error());
-    return this._url;
-  },
-
-  get home()
-  {
-    /**/console.log("Getting HL home", new Error());
-    return this._home;
-  },
-
-  /** get current hbox for this headline
+  /** Get current hbox for this headline.
    *
-   * @returns {hbox} current hbox for this headline
+   * @returns {hbox} Current hbox for this headline.
    */
   get hbox()
   {
     return this._hbox;
   },
 
-  /** set hbox and removes old hbox from dom
+  /** Set hbox and removes old hbox from dom.
    *
-   * @param {hbox} hbox - new hbox for headline
+   * @param {hbox} hbox - New hbox for headline.
    */
   set hbox(hbox)
   {
@@ -156,10 +131,18 @@ complete_assign(Headline.prototype, {
     this._hbox = hbox;
   },
 
-  //FIXME Knock these 2 on the head when refactored.
-  /** get current tooltip for this headline
+  /** Headline is no longer being displayed, so remove associated data. */
+  resetHbox()
+  {
+    //FIXME Should this discard the tooltip as well?
+    /**/console.log("resetting hbox", this._hbox, this._tooltip, new Error())
+    this.hbox = null;
+    //this.tooltip = null;
+  },
+
+  /** Get current tooltip for this headline.
    *
-   * @returns {tooltip} current tooltip for this headline
+   * @returns {tooltip} Current tooltip for this headline.
    */
   get tooltip()
   {
@@ -167,13 +150,13 @@ complete_assign(Headline.prototype, {
     return this._tooltip;
   },
 
-  /** set tooltip and removes old tooltip from dom
+  /** Set tooltip and removes old tooltip from dom.
    *
-   * @param {tooltip} tooltip - new tooltip for headline
+   * @param {tooltip} tooltip - New tooltip for headline.
    */
   set tooltip(tooltip)
   {
-    /**/console.log("Setting hl tooltip", new Error())
+    /**/console.log("Setting hl tooltip", tooltip, new Error())
     if (this._tooltip != null)
     {
       this._tooltip.remove();
@@ -181,7 +164,7 @@ complete_assign(Headline.prototype, {
     this._tooltip = tooltip;
   },
 
-  /** get current feed for this headline
+  /** Get current feed for this headline.
    *
    * @returns {Feed} The feed from which this headline came.
    */
@@ -190,26 +173,22 @@ complete_assign(Headline.prototype, {
     return this._feed;
   },
 
-  //----------------------------------------------------------------------------
-  getLink()
+  /** Get the link to the news item.
+   *
+   * @returns {string} URL of news item.
+   */
+  get link()
   {
-    return this.link;
+    return this._link;
   },
 
-  //----------------------------------------------------------------------------
-  getTitle()
+  /** Gets the title of the news item.
+   *
+   * @returns {string} News item title.
+   */
+  get title()
   {
-    return this.title;
-  },
-
-  //----------------------------------------------------------------------------
-  resetHbox()
-  {
-    //FIXME does this actually do anything useful as afaics when this is called,
-    //it's because we've just sliced something out of the array.
-    //in any case neither of those members exist.
-    this.hbox = null;
-    this.tooltip = null;
+    return this._title;
   },
 
   /** Find out if article has been viewed.

--- a/source/content/inforss/ticker/inforss_Headline.jsm
+++ b/source/content/inforss/ticker/inforss_Headline.jsm
@@ -78,7 +78,7 @@ function Headline(
   enclosureType,
   enclosureSize,
   banned,
-  readDate,
+  viewed_date,
   feed,
   config)
 {
@@ -93,7 +93,7 @@ function Headline(
   this.enclosureType = enclosureType;
   this.enclosureSize = enclosureSize;
   this._banned = banned;
-  this._viewed_date = readDate;
+  this._viewed_date = viewed_date;
   this._feed = feed;
   this._config = config;
 
@@ -250,12 +250,10 @@ complete_assign(Headline.prototype, {
   as_node(doc)
   {
     const headline = doc.createElement("headline");
-    for (const attrib of Object.keys(this))
+    for (const [ attrib, value ] of Object.entries(this))
     {
-      const value = this[attrib];
-      if (typeof value != "function" &&
-          typeof value != "object" &&
-          value !== null)
+      if (attrib != "_feed" && attrib != "_config" &&
+          typeof value != "function" && value !== null)
       {
         headline.setAttribute(attrib, value);
       }

--- a/source/content/inforss/ticker/inforss_Headline.jsm
+++ b/source/content/inforss/ticker/inforss_Headline.jsm
@@ -86,12 +86,13 @@ function Headline(
   config)
 {
   //FIXME I don't think this is possible any more but need to check nntp code
+  //Should probably be done elsewhere anyway.
   if (link == null || link == "")
   {
     console.log("null link, using home page " + home);
     link = home;
   }
-  //Move this to feed handler as it is possible
+  //FIXME Move this to feed handler as it is possible
   if (pubDate == null)
   {
     pubDate = receivedDate;

--- a/source/content/inforss/ticker/inforss_Headline.jsm
+++ b/source/content/inforss/ticker/inforss_Headline.jsm
@@ -108,15 +108,14 @@ function Headline(
   this.enclosureType = enclosureType;
   this.enclosureSize = enclosureSize;
   this._feed = feed;
-  this.config = config;
+  this._config = config;
 
-  this.readDate = null;
+  this._viewed_date = null;
   this._hbox = null;
   this._tooltip = null;
-  this.viewed = false;
-  this.banned = false;
+  this._banned = false;
 
-  if (this.config.remember_headlines)
+  if (this._config.remember_headlines)
   {
     if (feed.exists(link, title, feed.getBrowserHistory()))
     {
@@ -131,19 +130,13 @@ function Headline(
       //FIXME Why check against ""?
       if (oldReadDate != null && oldReadDate != "")
       {
-        this.readDate = new Date(oldReadDate);
-      }
-
-      const oldViewed = feed.getAttribute(link, title, "viewed");
-      if (oldViewed != null)
-      {
-        this.viewed = oldViewed == "true";
+        this._viewed_date = new Date(oldReadDate);
       }
 
       const oldBanned = feed.getAttribute(link, title, "banned");
       if (oldBanned != null)
       {
-        this.banned = oldBanned == "true";
+        this._banned = oldBanned == "true";
       }
     }
     else
@@ -224,33 +217,68 @@ complete_assign(Headline.prototype, {
   //----------------------------------------------------------------------------
   resetHbox()
   {
+    //FIXME does this actually do anything useful as afaics when this is called,
+    //it's because we've just sliced something out of the array.
+    //in any case neither of those members exist.
     this.hbox = null;
     this.tooltip = null;
   },
 
-  //-------------------------------------------------------------------------------------------------------------
-  //FIXME Make this getter/setter
-  setViewed()
+  /** Find out if article has been viewed.
+   *
+   * @returns {boolean} True if article was viewed.
+   */
+  get viewed()
   {
-    this.viewed = true;
-    this.readDate = new Date();
-    this._feed.setAttribute(this.link, this.title, "viewed", "true");
-    this._feed.setAttribute(this.link, this.title, "readDate", this.readDate);
+    return this._viewed_date != null;
   },
 
-  //-------------------------------------------------------------------------------------------------------------
-  //FIXME Make ghis getter/setter
-  setBanned()
+  /** Get the date on which the article was viewed
+   *
+   * @returns {Date} Date on which article was viewed.
+   */
+  get readDate()
   {
-    this.banned = true;
-    this._feed.setAttribute(this.link, this.title, "banned", "true");
+    return this._viewed_date;
   },
 
+  /** Mark headline as viewed and remember when it was viewed.
+   *
+   * @returns {Date} Current date (date when viewed).
+   */
+  set_viewed()
+  {
+    this._viewed_date = new Date();
+    return this._viewed_date;
+  },
+
+  /** See if headline is banned forever.
+   *
+   * @returns {boolean} True if headline is never to be seen again.
+   *
+   */
+  get banned()
+  {
+    return this._banned;
+  },
+
+  /** Ban the headline for ever if not longer. */
+  set_banned()
+  {
+    this._banned = true;
+  },
+
+  //Who the blank is using this?? Leave around for a bit.
+  get config()
+  {
+    /**/console.log("Yer what", new Error())
+    return this._config;
+  },
   //-------------------------------------------------------------------------------------------------------------
   isNew()
   {
     return new Date() - this.receivedDate <
-            this.config.recent_headline_max_age * 60000;
+            this._config.recent_headline_max_age * 60000;
   },
 
   //-------------------------------------------------------------------------------------------------------------

--- a/source/content/inforss/ticker/inforss_Headline.jsm
+++ b/source/content/inforss/ticker/inforss_Headline.jsm
@@ -52,14 +52,12 @@ const EXPORTED_SYMBOLS = [
 /* eslint-enable array-bracket-newline */
 
 const { complete_assign } = Components.utils.import(
-  "chrome://inforss/content/modules/inforss_Utils.jsm",
-  {}
+  "chrome://inforss/content/modules/inforss_Utils.jsm", {}
 );
 
-const { console } = Components.utils.import(
-  "resource://gre/modules/Console.jsm",
-  {}
-);
+//const { console } = Components.utils.import(
+//  "resource://gre/modules/Console.jsm",  {}
+//);
 
 /** This object contains the contents of a displayed headline.
  *
@@ -100,9 +98,7 @@ function Headline(
   this._config = config;
 
   this._hbox = null;
-  //FIXME Is this unused? Should it be ? (as we don't want to repeatedly
-  //create tooltips and want to remove them when things go out of context
-  /**/this._tooltip = null;
+  this._tooltip = null;
 
   Object.seal(this);
 }
@@ -132,12 +128,10 @@ complete_assign(Headline.prototype, {
   },
 
   /** Headline is no longer being displayed, so remove associated data. */
-  resetHbox()
+  reset_hbox()
   {
-    //FIXME Should this discard the tooltip as well?
-    /**/console.log("resetting hbox", this._hbox, this._tooltip, new Error())
     this.hbox = null;
-    //this.tooltip = null;
+    this.tooltip = null;
   },
 
   /** Get current tooltip for this headline.
@@ -146,7 +140,6 @@ complete_assign(Headline.prototype, {
    */
   get tooltip()
   {
-    /**/console.log("Getting hl tooltip", new Error())
     return this._tooltip;
   },
 
@@ -156,7 +149,6 @@ complete_assign(Headline.prototype, {
    */
   set tooltip(tooltip)
   {
-    /**/console.log("Setting hl tooltip", tooltip, new Error())
     if (this._tooltip != null)
     {
       this._tooltip.remove();

--- a/source/content/inforss/toolbar/inforss_Headline_Display.jsm
+++ b/source/content/inforss/toolbar/inforss_Headline_Display.jsm
@@ -70,10 +70,14 @@ const { alert, prompt } = Components.utils.import(
   {}
 );
 
+const { Tooltip_Controller } = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Tooltip_Controller.jsm",
+  {}
+);
+
 const {
   add_event_listeners,
   event_binder,
-  htmlFormatConvert,
   option_window_displayed,
   remove_all_children,
   remove_event_listeners,
@@ -105,13 +109,6 @@ const { clearTimeout, setTimeout } = Components.utils.import(
   "resource://gre/modules/Timer.jsm",
   {}
 );
-
-const INFORSS_TOOLTIP_BROWSER_WIDTH = 600;
-const INFORSS_TOOLTIP_BROWSER_HEIGHT = 400;
-
-const ParserUtils = Components.classes[
-  "@mozilla.org/parserutils;1"].getService(
-  Components.interfaces.nsIParserUtils);
 
 const ClipboardHelper = Components.classes[
   "@mozilla.org/widget/clipboardhelper;1"].getService(
@@ -176,6 +173,7 @@ function Headline_Display(mediator_, config, document, addon_bar, feed_manager)
   this._config = config;
   this._document = document;
   this._feed_manager = feed_manager;
+  this._tooltip_controller = new Tooltip_Controller(config, document);
 
   //Scrolling is complicated by the fact we have three things to control it:
   //1) The global config control (disabled, fade, scroll)
@@ -189,14 +187,7 @@ function Headline_Display(mediator_, config, document, addon_bar, feed_manager)
   this._scroll_timeout = null;
   this._resize_timeout = null;
   this._notifier = new Notifier();
-  this._active_tooltip = false;
   this._mouse_down_handler = event_binder(this.__mouse_down_handler, this);
-  this._tooltip_open = event_binder(this.__tooltip_open, this);
-  this._tooltip_close = event_binder(this.__tooltip_close, this);
-  this._tooltip_mouse_move = event_binder(this.__tooltip_mouse_move, this);
-  this._tooltip_X = -1;
-  this._tooltip_Y = -1;
-  this._tooltip_browser = null;
 
   const box = document.getElementById("inforss.newsbox1");
   this._headline_box = box;
@@ -347,10 +338,9 @@ Headline_Display.prototype = {
   },
 
   //-------------------------------------------------------------------------------------------------------------
-  //FIXME called from Feed_Manager during cycle_feed. is this meaningful?
   isActiveTooltip()
   {
-    return this._active_tooltip;
+    return this._tooltip_controller.has_active_tooltip;
   },
 
   /** Stop any scrolling. */
@@ -544,322 +534,10 @@ Headline_Display.prototype = {
 
     container.addEventListener("mousedown", this._mouse_down_handler);
 
-    const tooltip = this._create_tooltip(container, headline);
-    headline.tooltip = tooltip; //Side effect - removes old from from dom
-    label.setAttribute("tooltip", tooltip.getAttribute("id"));
-    this._document.getElementById("inforss.tooltips").appendChild(tooltip);
+    const tooltip = this._tooltip_controller.create_tooltip(headline);
+    label.setAttribute("tooltip", tooltip);
 
     return container;
-  },
-
-  //----------------------------------------------------------------------------
-  //FIXME this is unnecessarily complex
-  _fill_tooltip(headline, str, type)
-  {
-    const toolHbox = this._document.createElement("hbox");
-    toolHbox.setAttribute("flex", "1");
-    if (headline.enclosureUrl != null &&
-        this._config.headline_tooltip_style != "article")
-    {
-      const vbox = this._document.createElement("vbox");
-      vbox.setAttribute("flex", "0");
-      vbox.style.backgroundColor = "inherit";
-      if (headline.enclosureType.startsWith("audio/") ||
-          headline.enclosureType.startsWith("video/"))
-      {
-        vbox.setAttribute("enclosureUrl", headline.enclosureUrl);
-        vbox.setAttribute("enclosureType", headline.enclosureType);
-        vbox.headline = headline;
-      }
-      else
-      {
-        const img = this._document.createElement("image");
-        img.setAttribute("src", headline.enclosureUrl);
-        vbox.appendChild(img);
-      }
-
-      const spacer = this._document.createElement("spacer");
-      spacer.setAttribute("width", "10");
-      vbox.appendChild(spacer);
-
-      toolHbox.appendChild(vbox);
-    }
-
-    {
-      const vbox = this._document.createElement("vbox");
-      vbox.setAttribute("flex", "1");
-      if (type == "text")
-      {
-        str = htmlFormatConvert(str);
-        if (str != null && str.indexOf("<") != -1 && str.indexOf(">") != -1)
-        {
-          let br = this._document.createElement("iframe");
-          vbox.appendChild(br);
-          br.setAttribute("type", "content-targetable");
-          br.setAttribute("src", "data:text/html;charset=utf-8,<html><body>" + encodeURIComponent(str) + "</body></html>");
-          br.setAttribute("flex", "1");
-          br.style.overflow = "auto";
-          br.style.width = INFORSS_TOOLTIP_BROWSER_WIDTH + "px";
-          br.style.height = INFORSS_TOOLTIP_BROWSER_HEIGHT + "px";
-        }
-        else if (str != null && str != "")
-        {
-          //Break this up into lines of 60 characters.
-          //FIXME I'm pretty sure this sort of thing occurs elsewhere
-          do
-          {
-            let j = str.length > 60 ? str.lastIndexOf(' ', 60) : -1;
-            if (j == -1)
-            {
-              j = 60;
-            }
-            const description = this._document.createElement("label");
-            description.setAttribute("value", str.substring(0, j).trim());
-            vbox.appendChild(description);
-            str = str.substring(j + 1).trim();
-          } while (str != "");
-        }
-        else if (headline.enclosureUrl != null)
-        {
-          const image = this._document.createElement("image");
-          //FIXME What if it's not one of those?
-          if (headline.enclosureType.startsWith("image"))
-          {
-            image.setAttribute("src", "chrome://inforss/skin/image.png");
-          }
-          else if (headline.enclosureType.startsWith("video"))
-          {
-            image.setAttribute("src", "chrome://inforss/skin/movie.png");
-          }
-          else if (headline.enclosureType.startsWith("audio"))
-          {
-            image.setAttribute("src", "chrome://inforss/skin/speaker.png");
-          }
-          vbox.appendChild(image);
-        }
-      }
-      else
-      {
-        //Apparently not text. Do we assume its html?
-        let br = this._document.createElement("browser");
-        vbox.appendChild(br);
-        br.setAttribute("flex", "1");
-        br.srcUrl = str;
-      }
-
-      toolHbox.appendChild(vbox);
-    }
-
-    return toolHbox;
-  },
-
-  /** Create a tooltip for the supplied headline.
-   *
-   * @param {hbox} container - Hbox to which tooltip should be attached.
-   * @param {Headline} headline - Headline to which to add tooltip.
-   *
-   * @returns {tooltip} The new tooltip.
-   */
-  _create_tooltip(container, headline)
-  {
-    let tooltip_contents = "";
-    let tooltip_type = "text";
-
-    switch (this._config.headline_tooltip_style)
-    {
-      default:
-        debug("Unknown tooltip style: " + this._config.headline_tooltip_style);
-        /* eslint-disable-next-line lines-around-comment */
-        /* fall through */
-
-      case "article":
-        tooltip_contents = headline.link;
-        tooltip_type = "url";
-        break;
-
-      case "description":
-        {
-          const fragment = ParserUtils.parseFragment(headline.description,
-                                                     0,
-                                                     false,
-                                                     null,
-                                                     container);
-          tooltip_contents = fragment.textContent;
-        }
-        break;
-
-      case "title":
-        {
-          const fragment = ParserUtils.parseFragment(headline.title,
-                                                     0,
-                                                     false,
-                                                     null,
-                                                     container);
-          tooltip_contents = fragment.textContent;
-        }
-        break;
-
-      case "allInfo":
-        {
-          const fragment = ParserUtils.parseFragment(headline.description,
-                                                     0,
-                                                     false,
-                                                     null,
-                                                     container);
-
-          const feed = headline.feed;
-
-          tooltip_contents = "<TABLE width='100%' style='background-color:#2B60DE; color:white; -moz-border-radius: 10px; padding: 6px'><TR><TD colspan=2 align=center style='border-bottom-style:solid; border-bottom-width:1px '><B><img src='" +
-            feed.getIcon() +
-            "' width=16px height=16px> " +
-            feed.getTitle() +
-            "</B></TD></TR><TR><TD align='right'><B>" +
-            get_string("title") +
-            ": </B></TD><TD>" +
-            headline.title +
-            "</TD></TR><TR><TD align='right'><B>" +
-            get_string("date") +
-            ": </B></TD><TD>" +
-            headline.publishedDate +
-            "</TD></TR><TR><TD align='right'><B>" +
-            get_string("rss") +
-            ": </B></TD><TD>" +
-            headline.url +
-            "</TD></TR><TR><TD align='right'><B>" +
-            get_string("link") +
-            ": </B></TD><TD>" +
-            headline.link +
-            "</TD></TR></TABLE><br>" +
-            fragment.textContent;
-        }
-        break;
-    }
-
-    const tooltip = this._document.createElement("tooltip");
-    tooltip.setAttribute("id", "inforss.headline.tooltip." + headline.guid);
-    tooltip.setAttribute("position", "before_end");
-    tooltip.setAttribute("noautohide", true);
-    tooltip.appendChild(
-      this._fill_tooltip(headline, tooltip_contents, tooltip_type));
-
-    //FIXME need to remove these somehow?
-    tooltip.addEventListener("popupshown", this._tooltip_open);
-    tooltip.addEventListener("popuphiding", this._tooltip_close);
-
-    return tooltip;
-  },
-
-  /** Deal with showing tooltip.
-   *
-   * @param {PopupEvent} event - Tooltip showing event.
-   */
-  __tooltip_open(event)
-  {
-    this._active_tooltip = true;
-
-    const tooltip = event.target;
-    for (const vbox of tooltip.getElementsByTagName("vbox"))
-    {
-      if (vbox.hasAttribute("enclosureUrl") &&
-          vbox.headline.feed.feedXML.getAttribute("playPodcast") == "true")
-      {
-        if (vbox.childNodes.length == 1)
-        {
-          const br = this._document.createElement("browser");
-          br.setAttribute("enclosureUrl", vbox.getAttribute("enclosureUrl"));
-          const size =
-            vbox.getAttribute("enclosureType").startsWith("video") ? 200 : 1;
-          br.setAttribute("width", size);
-          br.setAttribute("height", size);
-          br.setAttribute(
-            "src",
-            "data:text/html;charset=utf-8,<HTML><BODY><EMBED src='" +
-              vbox.getAttribute("enclosureUrl") +
-              "' autostart='true' ></EMBED></BODY></HTML>"
-          );
-          vbox.appendChild(br);
-        }
-        break;
-      }
-    }
-    this._tooltip_browser = null;
-    for (const browser of tooltip.getElementsByTagName("browser"))
-    {
-      if (browser.srcUrl != null && ! browser.hasAttribute("src"))
-      {
-        browser.style.width = INFORSS_TOOLTIP_BROWSER_WIDTH + "px";
-        browser.style.height = INFORSS_TOOLTIP_BROWSER_HEIGHT + "px";
-        browser.setAttribute("flex", "1");
-        browser.setAttribute("src", browser.srcUrl);
-        browser.focus();
-      }
-      if (this._tooltip_browser == null &&
-          ! browser.hasAttribute("enclosureUrl"))
-      {
-        this._tooltip_browser = browser;
-      }
-      browser.contentWindow.scrollTo(0, 0);
-    }
-    tooltip.setAttribute("noautohide", "true");
-
-    if (this._document.tooltipNode != null)
-    {
-      this._document.tooltipNode.addEventListener("mousemove",
-                                                  this._tooltip_mouse_move);
-    }
-  },
-
-  /** Deal with tooltip hiding.
-   *
-   * @param {PopupEvent} event - Event details.
-   */
-  __tooltip_close(event)
-  {
-    this._active_tooltip = false;
-
-    if (this._document.tooltipNode != null)
-    {
-      this._document.tooltipNode.removeEventListener(
-        "mousemove",
-        this._tooltip_mouse_move
-      );
-    }
-
-    //Need to set tooltip to beginning of article and enable podcast playing
-    //to see one of these...
-    const item = event.target.querySelector("browser[enclosureUrl]");
-    if (item != null)
-    {
-      item.remove();
-    }
-    this._tooltip_browser = null;
-  },
-
-  /** Deal with tooltip mouse movement.
-   *
-   * @param {MouseEvent} event - Event details.
-   */
-  __tooltip_mouse_move(event)
-  {
-    //It is not clear to me why these are only initialised once and not
-    //(say) when the browser window is created.
-    if (this._tooltip_X == -1)
-    {
-      this._tooltip_X = event.screenX;
-    }
-    if (this._tooltip_Y == -1)
-    {
-      this._tooltip_Y = event.screenY;
-    }
-    if (this._tooltip_browser != null)
-    {
-      this._tooltip_browser.contentWindow.scrollBy(
-        (event.screenX - this._tooltip_X) * 50,
-        (event.screenY - this._tooltip_Y) * 50
-      );
-    }
-    this._tooltip_X = event.screenX;
-    this._tooltip_Y = event.screenY;
   },
 
   /** Show test or beep according to config when feed gets new headline.

--- a/source/content/inforss/toolbar/inforss_Headline_Display.jsm
+++ b/source/content/inforss/toolbar/inforss_Headline_Display.jsm
@@ -173,7 +173,8 @@ function Headline_Display(mediator_, config, document, addon_bar, feed_manager)
   this._config = config;
   this._document = document;
   this._feed_manager = feed_manager;
-  this._tooltip_controller = new Tooltip_Controller(config, document);
+  this._tooltip_controller =
+    new Tooltip_Controller(config, document, "headline");
 
   //Scrolling is complicated by the fact we have three things to control it:
   //1) The global config control (disabled, fade, scroll)
@@ -328,7 +329,7 @@ Headline_Display.prototype = {
   {
     for (const headline of feed.getDisplayedHeadlines())
     {
-      headline.resetHbox();
+      headline.reset_hbox();
     }
     if (this._headline_box.childNodes.length <= 1)
     {
@@ -476,11 +477,6 @@ Headline_Display.prototype = {
     {
       let title = headline.title;
 
-      if (title == "")
-      {
-        title = "(no title)";
-      }
-
       //truncate to max permitted
       title = title.substring(0, feed.getLengthItem());
 
@@ -535,8 +531,8 @@ Headline_Display.prototype = {
 
     container.addEventListener("mousedown", this._mouse_down_handler);
 
-    const tooltip = this._tooltip_controller.create_tooltip(headline);
-    label.setAttribute("tooltip", tooltip);
+    label.setAttribute("tooltip",
+                       this._tooltip_controller.create_tooltip(headline));
 
     return container;
   },

--- a/source/content/inforss/toolbar/inforss_Headline_Display.jsm
+++ b/source/content/inforss/toolbar/inforss_Headline_Display.jsm
@@ -576,7 +576,7 @@ Headline_Display.prototype = {
     const tooltip = this._create_tooltip(container, headline);
     headline.tooltip = tooltip; //Side effect - removes old from from dom
     label.setAttribute("tooltip", tooltip.getAttribute("id"));
-    this._document.getElementById("inforss.popupset").appendChild(tooltip);
+    this._document.getElementById("inforss.tooltips").appendChild(tooltip);
 
     return container;
   },

--- a/source/content/inforss/toolbar/inforss_Headline_Display.jsm
+++ b/source/content/inforss/toolbar/inforss_Headline_Display.jsm
@@ -102,8 +102,8 @@ Components.utils.import(
   "chrome://inforss/content/mediator/inforss_Mediator_API.jsm",
   mediator);
 
-/**/const { console } =
-/**/  Components.utils.import("resource://gre/modules/Console.jsm", {});
+//const { console } =
+//  Components.utils.import("resource://gre/modules/Console.jsm", {});
 
 const { clearTimeout, setTimeout } = Components.utils.import(
   "resource://gre/modules/Timer.jsm",
@@ -337,7 +337,10 @@ Headline_Display.prototype = {
     feed.clearDisplayedHeadlines();
   },
 
-  //-------------------------------------------------------------------------------------------------------------
+  /** Check if there's a tooltip currently displayed.
+   *
+   * @returns {boolean} True if there's a tooltip currently active.
+   */
   isActiveTooltip()
   {
     return this._tooltip_controller.has_active_tooltip;
@@ -455,8 +458,6 @@ Headline_Display.prototype = {
   _create_display_headline(headline)
   {
     const container = this._document.createElement("hbox");
-/**/console.log(headline)
-
     container.setAttribute("link", headline.link);
     container.setAttribute("flex", "0");
     container.setAttribute("pack", "end");

--- a/source/content/inforss/toolbar/inforss_Headline_Display.jsm
+++ b/source/content/inforss/toolbar/inforss_Headline_Display.jsm
@@ -525,36 +525,6 @@ Headline_Display.prototype = {
         vbox = this._create_icon("chrome://inforss/skin/image.png");
       }
       container.appendChild(vbox);
-
-      vbox.setAttribute("tooltip", "_child");
-
-      const tooltip1 = this._document.createElement("tooltip");
-      vbox.appendChild(tooltip1);
-
-      const vbox1 = this._document.createElement("vbox");
-      tooltip1.appendChild(vbox1);
-
-      let description1 = this._document.createElement("label");
-      description1.setAttribute(
-        "value",
-        get_string("url") + ": " + headline.enclosureUrl
-      );
-      vbox1.appendChild(description1);
-
-      description1 = this._document.createElement("label");
-      description1.setAttribute(
-        "value",
-        get_string("enclosure.type") + ": " + headline.enclosureType
-      );
-      vbox1.appendChild(description1);
-
-      description1 = this._document.createElement("label");
-      description1.setAttribute(
-        "value",
-        get_string("enclosure.size") + ": " + headline.enclosureSize + " " +
-          get_string("enclosure.sizeUnit")
-      );
-      vbox1.appendChild(description1);
     }
 
     if (this._config.headline_shows_ban_icon)

--- a/source/content/inforss/toolbar/inforss_Headline_Display.jsm
+++ b/source/content/inforss/toolbar/inforss_Headline_Display.jsm
@@ -98,8 +98,8 @@ Components.utils.import(
   "chrome://inforss/content/mediator/inforss_Mediator_API.jsm",
   mediator);
 
-//const { console } =
-//  Components.utils.import("resource://gre/modules/Console.jsm", {});
+/**/const { console } =
+/**/  Components.utils.import("resource://gre/modules/Console.jsm", {});
 
 const { clearTimeout, setTimeout } = Components.utils.import(
   "resource://gre/modules/Timer.jsm",
@@ -465,6 +465,7 @@ Headline_Display.prototype = {
   _create_display_headline(headline)
   {
     const container = this._document.createElement("hbox");
+/**/console.log(headline)
 
     container.setAttribute("link", headline.link);
     container.setAttribute("flex", "0");

--- a/source/content/inforss/toolbar/inforss_Main_Icon.jsm
+++ b/source/content/inforss/toolbar/inforss_Main_Icon.jsm
@@ -118,7 +118,7 @@ function Main_Icon(feed_manager, config, document)
 
   this._main_menu = new Main_Menu(feed_manager, config, document, this);
 
-  this._icon_tooltip = document.getElementById("inforss.popup.mainicon");
+  this._icon_tooltip = document.getElementById("inforss.mainicon.tooltip");
 
   this._tooltip_enabled = true;
 

--- a/source/content/inforss/toolbar/inforss_Main_Menu.jsm
+++ b/source/content/inforss/toolbar/inforss_Main_Menu.jsm
@@ -120,12 +120,6 @@ const Transferable = Components.Constructor(
   "@mozilla.org/widget/transferable;1",
   Components.interfaces.nsITransferable);
 
-//FIXME ripped off
-const ParserUtils = Components.classes[
-  "@mozilla.org/parserutils;1"].getService(
-  Components.interfaces.nsIParserUtils);
-
-
 const { console } =
   Components.utils.import("resource://gre/modules/Console.jsm", {});
 
@@ -136,8 +130,8 @@ const { console } =
  * @param {Feed_Manager} feed_manager - Fetches feed headlines.
  * @param {Config} config - Configuration.
  * @param {Document} document - The DOM.
- * @param {Main_Icon} main_icon - the main icon (so we can enable/disable
- *                                tooltips)
+ * @param {Main_Icon} main_icon - The main icon (so we can enable/disable
+ *                                tooltips).
  */
 function Main_Menu(feed_manager, config, document, main_icon)
 {
@@ -393,7 +387,7 @@ Main_Menu.prototype = {
 
   /** Handle drop of menu element into a menu element.
    *
-   * @param {Feed} feed - feed which is being dropped
+   * @param {Feed} feed - Feed which is being dropped.
    * @param {DragEvent} event - Drop event.
    */
   _on_drop(feed, event)
@@ -466,7 +460,7 @@ Main_Menu.prototype = {
     popup.appendChild(item);
   },
 
-  /** Add an item to the menu
+  /** Add an item to the menu.
    *
    * @param {string} url - URL of the feed.
    * @param {string} title - Title of the feed.
@@ -548,9 +542,9 @@ Main_Menu.prototype = {
 
   /** Add a feed to the main popup menu and returns the added item.
    *
-   * @param {Element} rss - the feed definition
+   * @param {Element} rss - The feed definition.
    *
-   * @returns {menuitem} New menu item
+   * @returns {menuitem} New menu item.
    */
   add_feed_to_menu(rss)
   {
@@ -648,10 +642,10 @@ Main_Menu.prototype = {
   },
 
   /** Handle the popup of a submenu. This starts a 3 second timer and
-   *  then displays the submenu
+   *  then displays the submenu.
    *
-   * @param {Element} rss - feed config for submenu
-   * @param {PopupEvent} event - popup showing event
+   * @param {Element} rss - Feed config for submenu.
+   * @param {PopupEvent} event - Popup showing event.
    */
   _submenu_popup_showing(rss, event)
   {
@@ -711,7 +705,7 @@ Main_Menu.prototype = {
         //cannot put the null in a finally block because alert closes the menu
         //which causes a certain amount of confusion.
         this._submenu_request = null;
-        if (! ('event' in err) || err.event.type != "abort")
+        if (! ("event" in err) || err.event.type != "abort")
         {
           console.log(err);
           alert(err.message);
@@ -722,6 +716,7 @@ Main_Menu.prototype = {
 
   /** Process XML response into a submenu.
    *
+   * @param {Feed} feed - Feed information.
    * @param {menupopup} popup - Original menu.
    */
   _submenu_process(feed, popup)

--- a/source/content/inforss/toolbar/inforss_Main_Menu.jsm
+++ b/source/content/inforss/toolbar/inforss_Main_Menu.jsm
@@ -69,7 +69,6 @@ const { alert } = Components.utils.import(
 const {
   add_event_listeners,
   event_binder,
-  htmlFormatConvert,
   option_window_displayed,
   remove_all_children,
   remove_event_listeners

--- a/source/content/inforss/toolbar/inforss_Main_Menu.jsm
+++ b/source/content/inforss/toolbar/inforss_Main_Menu.jsm
@@ -734,7 +734,7 @@ Main_Menu.prototype = {
       elem.setAttribute("label", title);
 
       //home, url, why???
-      const hl = feed.get_headline(headline.headline, new Date(), null, null);
+      const hl = feed.get_headline(headline.headline, new Date());
       const tooltip = this._tooltip_controller.create_tooltip(hl);
       elem.setAttribute("tooltip", tooltip);
 

--- a/source/content/inforss/toolbar/inforss_Main_Menu.jsm
+++ b/source/content/inforss/toolbar/inforss_Main_Menu.jsm
@@ -685,7 +685,11 @@ Main_Menu.prototype = {
     {
       this._submenu_request = new Feed_Page(
         url,
-        { feed_config: rss, user: rss.getAttribute("user") }
+        {
+          config: this._config,
+          feed_config: rss,
+          user: rss.getAttribute("user")
+        }
       );
     }
     catch (err)
@@ -723,7 +727,6 @@ Main_Menu.prototype = {
   _submenu_process(feed, popup)
   {
     const headlines = this._submenu_request.headlines;
-/**/console.log(feed, headlines)
     const max = Math.min(INFORSS_MAX_SUBMENU, headlines.length);
     for (const headline of headlines)
     {
@@ -735,12 +738,9 @@ Main_Menu.prototype = {
       }
       elem.setAttribute("label", title);
 
-/**/console.log("raw headline", headline.headline)
-/**/console.log("guid", feed.get_guid(headline.headline))
       //home, url, why???
       const hl = feed.get_headline(headline.headline, new Date(), null, null);
-/**/console.log("compose", hl)
-      const tooltip = this._tooltip_controller.create_tooltip(feed, hl);
+      const tooltip = this._tooltip_controller.create_tooltip(hl);
       elem.setAttribute("tooltip", tooltip);
 
       elem.addEventListener(

--- a/source/content/inforss/toolbar/inforss_Main_Menu.jsm
+++ b/source/content/inforss/toolbar/inforss_Main_Menu.jsm
@@ -736,7 +736,8 @@ Main_Menu.prototype = {
       elem.setAttribute("label", title);
 
 /**/console.log(headline.headline)
-      const tooltip = this._tooltip_controller.create_tooltip(headline);
+/**/console.log(feed.get_guid(headline.headline))
+      const tooltip = this._tooltip_controller.create_tooltip(feed, headline.headline);
       elem.setAttribute("tooltip", tooltip);
 
       elem.addEventListener(

--- a/source/content/inforss/toolbar/inforss_Main_Menu.jsm
+++ b/source/content/inforss/toolbar/inforss_Main_Menu.jsm
@@ -735,9 +735,12 @@ Main_Menu.prototype = {
       }
       elem.setAttribute("label", title);
 
-/**/console.log(headline.headline)
-/**/console.log(feed.get_guid(headline.headline))
-      const tooltip = this._tooltip_controller.create_tooltip(feed, headline.headline);
+/**/console.log("raw headline", headline.headline)
+/**/console.log("guid", feed.get_guid(headline.headline))
+      //home, url, why???
+      const hl = feed.get_headline(headline.headline, new Date(), null, null);
+/**/console.log("compose", hl)
+      const tooltip = this._tooltip_controller.create_tooltip(feed, hl);
       elem.setAttribute("tooltip", tooltip);
 
       elem.addEventListener(

--- a/source/content/inforss/windows/Options/Basic/Feed_Group/inforss_Options_Basic_Feed_Group_Filter.jsm
+++ b/source/content/inforss/windows/Options/Basic/Feed_Group/inforss_Options_Basic_Feed_Group_Filter.jsm
@@ -281,9 +281,9 @@ Object.assign(Filter.prototype, {
 
   /** Fetch categories for rss/atom feed
    *
-   * @param {RSS} feed - the feed
+   * @param {RSS} rss - the feed
    */
-  _fetch_rss_categories(feed)
+  _fetch_rss_categories(rss)
   {
     if (this._request != null)
     {
@@ -291,8 +291,8 @@ Object.assign(Filter.prototype, {
       this._request.abort();
     }
     const request = new Feed_Page(
-      feed.getAttribute("url"),
-      { feed, user: feed.getAttribute("user") }
+      rss.getAttribute("url"),
+      { feed_config: rss, user: rss.getAttribute("user") }
     );
     this._request = request;
     request.fetch().then(

--- a/source/content/inforss/windows/Options/Basic/Feed_Group/inforss_Options_Basic_Feed_Group_General.jsm
+++ b/source/content/inforss/windows/Options/Basic/Feed_Group/inforss_Options_Basic_Feed_Group_General.jsm
@@ -897,7 +897,7 @@ complete_assign(General.prototype, {
           this._current_feed.getAttribute("url"),
           {
             user: this._current_feed.getAttribute("user"),
-            feed: this._current_feed,
+            feed_config: this._current_feed,
             refresh_feed: true
           }
         );

--- a/source/locale/en-GB/inforss/inforss.dtd
+++ b/source/locale/en-GB/inforss/inforss.dtd
@@ -126,7 +126,7 @@
 <!ENTITY inforss.filter.category "Category">
 <!ENTITY inforss.tooltip "Tooltip on headlines">
 <!ENTITY inforss.tooltip.title "Full headline">
-<!ENTITY inforss.tooltip.description "Begin of article">
+<!ENTITY inforss.tooltip.description "Article description">
 <!ENTITY inforss.tooltip.article "Full article">
 <!ENTITY inforss.tooltip.allInfo "All Info">
 <!ENTITY inforss.click.headline "Display full article">

--- a/source/locale/en-US/inforss/inforss.dtd
+++ b/source/locale/en-US/inforss/inforss.dtd
@@ -126,7 +126,7 @@
 <!ENTITY inforss.filter.category "Category">
 <!ENTITY inforss.tooltip "Tooltip on headlines">
 <!ENTITY inforss.tooltip.title "Full headline">
-<!ENTITY inforss.tooltip.description "Begin of article">
+<!ENTITY inforss.tooltip.description "Article description">
 <!ENTITY inforss.tooltip.article "Full article">
 <!ENTITY inforss.tooltip.allInfo "All Info">
 <!ENTITY inforss.click.headline "Display full article">

--- a/source/locale/sq-AL/inforss/inforss.dtd
+++ b/source/locale/sq-AL/inforss/inforss.dtd
@@ -126,7 +126,7 @@
 <!ENTITY inforss.filter.category "Category">
 <!ENTITY inforss.tooltip "Tooltip on headlines">
 <!ENTITY inforss.tooltip.title "Full headline">
-<!ENTITY inforss.tooltip.description "Begin of article">
+<!ENTITY inforss.tooltip.description "Article description">
 <!ENTITY inforss.tooltip.article "Full article">
 <!ENTITY inforss.tooltip.allInfo "All Info">
 <!ENTITY inforss.click.headline "Display full article">


### PR DESCRIPTION
Among other things, this means that the tooltip popped up when you display headlines as a submenu from the inforss button are controlled by the tooltip style setting in the configuration (and will play podcasts if enabled)

Also changed the (English) description of the first tooltip style from 'beginning of article' to 'article description'

Fixes #74 