### PR TITLE
Nntp htmlformatcovert tidyup

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -139,7 +139,7 @@ rules:
   quotes:
     - error
     - double
-    - avoidescape: true
+    - avoidEscape: true
 
   # mozilla has some functions that start with a capital letter
   new-cap:

--- a/source/content/inforss/feed_handlers/inforss_NNTP_Feed.jsm
+++ b/source/content/inforss/feed_handlers/inforss_NNTP_Feed.jsm
@@ -224,7 +224,7 @@ Object.assign(NNTP_Feed.prototype, {
         {
           const headline = {};
           headline.link = feed_url + encodeURIComponent(article[4].slice(1, -1));
-          headline.guid = headline.link;
+          headline.guid = article[4];
           headline.pubdate = new Date(article[3]);
           article[1] = decodeQuotedPrintable(article[1]);
           headline.title = "(" + nntp.group + ") " + article[1];
@@ -232,7 +232,7 @@ Object.assign(NNTP_Feed.prototype, {
           //go fetch the body.
           if (this.find_headline(headline.guid) !== undefined)
           {
-            /**/console.log("have headline for", this.getUrl(), headline.guid)
+/**/console.log("have headline for", this.getUrl(), headline.guid)
             continue;
           }
           headlines.push(headline);
@@ -250,9 +250,7 @@ Object.assign(NNTP_Feed.prototype, {
         const nheadlines = headlines.map(
           (val, index) =>
           {
-            let data = articles[index].join("\n");
-            //Should probably decode this as well.
-            data = htmlFormatConvert(data, false, "text/plain", "text/html");
+            let data = htmlFormatConvert(articles[index].join("\n"), false);
             data = data.replace(/^(>>>>.*)$/gm, "<font color='cyan'>$1</font>");
             data = data.replace(/^(> > > >.*)$/gm, "<font color='cyan'>$1</font>");
             data = data.replace(/^(>>>.*)$/gm, "<font color='red'>$1</font>");

--- a/source/content/inforss/modules/inforss_Utils.jsm
+++ b/source/content/inforss/modules/inforss_Utils.jsm
@@ -166,51 +166,26 @@ function format_as_hh_mm_ss(date)
   return As_HH_MM_SS.format(date);
 }
 
-//FIXME the only place that passes extra parameters is nntp feed. Given that,
-//perhaps we should drop all the parameters and give that its own function.
-/** HTML string conversion
+//FIXME It is not clear to me if this does anything useful, given the horrendous
+//efforts to maintain <s and >s
+/** HTML string conversion.
  *
  * @param {string} instr - String to convert.
- * @param {boolean} keep - Keep < and > if set.
- * @param {string} mimeTypeFrom - Mime type of string (defaults to text/html).
- * @param {string} mimeTypeTo - Mime type to convert to (defaults to
- *                 text/unicode.
  *
- * @returns {string} converted string
+ * @returns {string} Converted string.
  *
  */
-function htmlFormatConvert(instr, keep, mimeTypeFrom, mimeTypeTo)
+function htmlFormatConvert(instr, keep)
 {
   if (instr == null)
   {
     return ""; //Seriously - this happens
   }
 
-  //This is called from inforssNntp with keep false, converting from plain to
-  //html. Arguably it should have its own method.
-  if (keep === undefined)
-  {
-    keep = true;
-  }
-
-  if (mimeTypeFrom === undefined)
-  {
-    mimeTypeFrom = "text/html";
-  }
-
-  if (mimeTypeTo === undefined)
-  {
-    mimeTypeTo = "text/unicode";
-  }
-
   let str = instr;
-  if (keep)
-  {
-    str = str.replace(/</gi, "__LT__");
-    str = str.replace(/>/gi, "__GT__");
-  }
+  str = str.replace(/</gi, "__LT__");
+  str = str.replace(/>/gi, "__GT__");
 
-  //FIXME do I really need try/catch here?
   try
   {
     const fromString = new SupportsString();
@@ -220,10 +195,10 @@ function htmlFormatConvert(instr, keep, mimeTypeFrom, mimeTypeTo)
     //This API is almost completely undocumented, so I've no idea how to rework
     //it it into something useful.
     const converter = new FormatConverter();
-    converter.convert(mimeTypeFrom,
+    converter.convert("text/html",
                       fromString,
                       fromString.toString().length,
-                      mimeTypeTo,
+                      "text/unicode",
                       toString,
                       {});
     if (toString.value)
@@ -231,17 +206,15 @@ function htmlFormatConvert(instr, keep, mimeTypeFrom, mimeTypeTo)
       toString = toString.value.QueryInterface(
         Components.interfaces.nsISupportsString);
       let convertedString = toString.toString();
-      if (keep)
-      {
-        convertedString = convertedString.replace(/__LT__/gi, "<");
-        convertedString = convertedString.replace(/__GT__/gi, ">");
-      }
+      convertedString = convertedString.replace(/__LT__/gi, "<");
+      convertedString = convertedString.replace(/__GT__/gi, ">");
       return convertedString;
     }
   }
   catch (err)
   {
-    console.log("Unexpected error converting string", err);
+    console.log("Unexpected error converting string", instr);
+    console.log(err);
   }
 
   return instr;

--- a/source/content/inforss/modules/inforss_Utils.jsm
+++ b/source/content/inforss/modules/inforss_Utils.jsm
@@ -175,7 +175,7 @@ function format_as_hh_mm_ss(date)
  * @returns {string} Converted string.
  *
  */
-function htmlFormatConvert(instr, keep)
+function htmlFormatConvert(instr)
 {
   if (instr == null)
   {


### PR DESCRIPTION
nntp code was calling htmlformatconvert with wrong arguments (after seeing the trace spew out on an nntp feed!)

So fixed the arguments (mostly by removing them)

Also selects a sensible guid for nntp feeds.


