### PR TITLE
Grey out non-applicable options in options window

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,8 @@ After some configurable refactoring of the option class, the 'switch scrolling d
 
 Found fade was only working properly if you were doing right to left scrolling, so fixed that.
 
+Made the Basic/Headlines area tab grey out selections which were inappropriate. Also rearranged the tab a bit to make it clearer what options might be disabled/enabled. Fixes #46
+
 # Changes for v 2.3.1.0
 
 When checking some css validation warnings, I discovered that the advanced/report was meant to have shading on the lines. So fixed that.

--- a/option_window_source/Options/Basic/Headlines Area.xul
+++ b/option_window_source/Options/Basic/Headlines Area.xul
@@ -18,10 +18,11 @@
         </radiogroup>
       </hbox>
       <hbox>
+        <spacer class="inforss-spacer1"/>
         <label control="collapseBar"
                value="&inforss.collapse.nodata;:"
                tooltiptext="&inforss.collapse.nodata;"
-               class="inforss-label1"/>
+               class="inforss-label6"/>
         <radiogroup id="collapseBar"
                     orient="horizontal">
           <radio label="&inforss.on;"/>
@@ -125,18 +126,6 @@
       </hbox>
       <hbox>
         <spacer class="inforss-spacer1"/>
-        <label control="nextFeed"
-               value="&inforss.cycling.next;:"
-               tooltiptext="&inforss.cycling.next;"
-               class="inforss-label6"/>
-        <radiogroup id="nextFeed"
-                    orient="horizontal">
-          <radio label="&inforss.cycling.next.next;"/>
-          <radio label="&inforss.cycling.next.random;"/>
-        </radiogroup>
-      </hbox>
-      <hbox>
-        <spacer class="inforss-spacer1"/>
         <label control="cycleWithinGroup"
                value="&inforss.cycling.withingroup;:"
                tooltiptext="&inforss.cycling.withingroup;"
@@ -145,6 +134,17 @@
                     orient="horizontal">
           <radio label="&inforss.on;"/>
           <radio label="&inforss.off;"/>
+        </radiogroup>
+      </hbox>
+      <hbox>
+        <label control="nextFeed"
+               value="&inforss.cycling.next;:"
+               tooltiptext="&inforss.cycling.next;"
+               class="inforss-label1"/>
+        <radiogroup id="nextFeed"
+                    orient="horizontal">
+          <radio label="&inforss.cycling.next.next;"/>
+          <radio label="&inforss.cycling.next.random;"/>
         </radiogroup>
       </hbox>
     </vbox>

--- a/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
+++ b/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
@@ -250,7 +250,6 @@ Object.assign(Headlines_Area.prototype, {
   {
     const disabled =
       this._scrolling.selectedIndex === this._config.Static_Display;
-    //Which of these don't apply to fading?
     for (const setting of [
       "scrollingspeed1",
       "scrollingIncrement1",
@@ -260,6 +259,8 @@ Object.assign(Headlines_Area.prototype, {
     {
       this._document.getElementById(setting).disabled = disabled;
     }
+    this._document.getElementById("scrollingIncrement1").disabled =
+      this._scrolling.selectedIndex !== this._config.Scrolling_Display;
   },
 
 });

--- a/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
+++ b/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
@@ -52,19 +52,36 @@ const EXPORTED_SYMBOLS = [
 ];
 /* eslint-enable array-bracket-newline */
 
-const { Base } = Components.utils.import(
-  "chrome://inforss/content/windows/Options/inforss_Options_Base.jsm",
-  {}
+const { add_event_listeners } = Components.utils.import(
+  "chrome://inforss/content/modules/inforss_Utils.jsm", {}
 );
 
-/** Contains the code for the 'Basic' tab in the option screen
+const { Base } = Components.utils.import(
+  "chrome://inforss/content/windows/Options/inforss_Options_Base.jsm", {}
+);
+
+/**/const { console } = Components.utils.import(
+/**/  "resource://gre/modules/Console.jsm", {}
+/**/);
+
+/** Contains the code for the 'Basic' tab in the option screen.
  *
- * @param {XMLDocument} document - the options window this._document
- * @param {Options} options - main options window for some common code
+ * @param {Document} document - The options window this._document.
+ * @param {Options} options - Main options window class for some common code.
  */
 function Headlines_Area(document, options)
 {
   Base.call(this, document, options);
+
+  this._location = document.getElementById("linePosition");
+  this._collapse_bar = this._document.getElementById("collapseBar");
+  this._listeners = add_event_listeners(
+    this,
+    document,
+    [ this._location, "command", this._location_changed ],
+  );
+
+  Object.seal(this);
 }
 
 const Super = Base.prototype;
@@ -73,20 +90,22 @@ Headlines_Area.prototype.constructor = Headlines_Area;
 
 Object.assign(Headlines_Area.prototype, {
 
-  /** Config has been loaded
+  /** Config has been loaded.
    *
-   * @param {Config} config - new config
+   * @param {Config} config - New config.
    */
   config_loaded(config)
   {
     Super.config_loaded.call(this, config);
 
     //location
-    this._document.getElementById("linePosition").selectedIndex =
-      this._config.headline_bar_location;
+    this._location.selectedIndex = this._config.headline_bar_location;
+    this._location_changed();
+
     //collapse if no headline
     this._document.getElementById("collapseBar").selectedIndex =
       this._config.headline_bar_collapsed ? 0 : 1;
+
     //mousewheel scrolling
     this._document.getElementById("mouseWheelScroll").selectedIndex =
       this._config.headline_bar_mousewheel_scroll;
@@ -148,12 +167,10 @@ Object.assign(Headlines_Area.prototype, {
       this._config.headline_bar_show_home_button;
   },
 
-  /** Update configuration from tab */
+  /** Update configuration from tab. */
   update()
   {
-    this._config.headline_bar_location =
-      this._document.getElementById("linePosition").selectedIndex;
-    //collapse if no headline
+    this._config.headline_bar_location = this._location.selectedIndex;
     this._config.headline_bar_collapsed =
       this._document.getElementById("collapseBar").selectedIndex == 0;
     this._config.headline_bar_mousewheel_scroll =
@@ -208,6 +225,16 @@ Object.assign(Headlines_Area.prototype, {
       this._document.getElementById("filterIcon").checked;
     this._config.headline_bar_show_home_button =
       this._document.getElementById("homeIcon").checked;
+  },
+
+  /** Location radio button clicked.
+   *
+   * This is sometimes called as an event hander, but not always.
+   */
+  _location_changed()
+  {
+    this._collapse_bar.disabled =
+      this._location.selectedIndex != this._config.In_Status_Bar;
   },
 
 });

--- a/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
+++ b/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
@@ -60,9 +60,9 @@ const { Base } = Components.utils.import(
   "chrome://inforss/content/windows/Options/inforss_Options_Base.jsm", {}
 );
 
-/**/const { console } = Components.utils.import(
-/**/  "resource://gre/modules/Console.jsm", {}
-/**/);
+//const { console } = Components.utils.import(
+//  "resource://gre/modules/Console.jsm", {}
+//);
 
 /** Contains the code for the 'Basic' tab in the option screen.
  *
@@ -78,11 +78,14 @@ function Headlines_Area(document, options)
 
   this._scrolling = document.getElementById("scrolling");
 
+  this._cycling = document.getElementById("cycling");
+
   this._listeners = add_event_listeners(
     this,
     document,
     [ this._location, "command", this._location_changed ],
     [ this._scrolling, "command", this._scrolling_changed ],
+    [ this._cycling, "command", this._cycling_changed ],
   );
 
   Object.seal(this);
@@ -129,17 +132,18 @@ Object.assign(Headlines_Area.prototype, {
       this._config.headline_bar_scrolling_direction;
 
     //Cycling feed/group
-    this._document.getElementById("cycling").selectedIndex =
+    this._cycling.selectedIndex =
       this._config.headline_bar_cycle_feeds ? 0 : 1;
     //  Cycling delay
     this._document.getElementById("cyclingDelay1").value =
       this._config.headline_bar_cycle_interval;
-    //  Next feed/group
-    this._document.getElementById("nextFeed").selectedIndex =
-      this._config.headline_bar_cycle_type;
-    //  Cycling within group
+    //Cycling within group
     this._document.getElementById("cycleWithinGroup").selectedIndex =
       this._config.headline_bar_cycle_in_group ? 0 : 1;
+
+    //Next feed/group
+    this._document.getElementById("nextFeed").selectedIndex =
+      this._config.headline_bar_cycle_type;
 
     //----------Icons in the headline bar---------
     this._document.getElementById("readAllIcon").checked =
@@ -171,6 +175,7 @@ Object.assign(Headlines_Area.prototype, {
 
     this._location_changed();
     this._scrolling_changed();
+    this._cycling_changed();
   },
 
   /** Update configuration from tab. */
@@ -198,10 +203,11 @@ Object.assign(Headlines_Area.prototype, {
       this._document.getElementById("cycling").selectedIndex == 0;
     this._config.headline_bar_cycle_interval =
       this._document.getElementById("cyclingDelay1").value;
-    this._config.headline_bar_cycle_type =
-      this._document.getElementById("nextFeed").selectedIndex;
     this._config.headline_bar_cycle_in_group =
       this._document.getElementById("cycleWithinGroup").selectedIndex == 0;
+
+    this._config.headline_bar_cycle_type =
+      this._document.getElementById("nextFeed").selectedIndex;
 
     //Icons in the headline bar
     this._config.headline_bar_show_mark_all_as_read_button =
@@ -261,6 +267,19 @@ Object.assign(Headlines_Area.prototype, {
     }
     this._document.getElementById("scrollingIncrement1").disabled =
       this._scrolling.selectedIndex !== this._config.Scrolling_Display;
+  },
+
+  /** Cycling mode radio button updated.
+   *
+   * This is sometimes called as an event handler.
+   */
+  _cycling_changed()
+  {
+    const disabled = this._cycling.selectedIndex == 1;
+    for (const setting of [ "cyclingDelay1", "cycleWithinGroup" ])
+    {
+      this._document.getElementById(setting).disabled = disabled;
+    }
   },
 
 });

--- a/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
+++ b/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
@@ -74,11 +74,15 @@ function Headlines_Area(document, options)
   Base.call(this, document, options);
 
   this._location = document.getElementById("linePosition");
-  this._collapse_bar = this._document.getElementById("collapseBar");
+  this._collapse_bar = document.getElementById("collapseBar");
+
+  this._scrolling = document.getElementById("scrolling");
+
   this._listeners = add_event_listeners(
     this,
     document,
     [ this._location, "command", this._location_changed ],
+    [ this._scrolling, "command", this._scrolling_changed ],
   );
 
   Object.seal(this);
@@ -100,7 +104,6 @@ Object.assign(Headlines_Area.prototype, {
 
     //location
     this._location.selectedIndex = this._config.headline_bar_location;
-    this._location_changed();
 
     //collapse if no headline
     this._document.getElementById("collapseBar").selectedIndex =
@@ -109,10 +112,9 @@ Object.assign(Headlines_Area.prototype, {
     //mousewheel scrolling
     this._document.getElementById("mouseWheelScroll").selectedIndex =
       this._config.headline_bar_mousewheel_scroll;
+
     //scrolling headlines
-    //can be 0 (none), 1 (scroll), 2 (fade)
-    this._document.getElementById("scrolling").selectedIndex =
-      this._config.headline_bar_scroll_style;
+    this._scrolling.selectedIndex = this._config.headline_bar_scroll_style;
     //  speed
     this._document.getElementById("scrollingspeed1").value =
       this._config.headline_bar_scroll_speed;
@@ -125,6 +127,7 @@ Object.assign(Headlines_Area.prototype, {
     //  direction
     this._document.getElementById("scrollingdirection").selectedIndex =
       this._config.headline_bar_scrolling_direction;
+
     //Cycling feed/group
     this._document.getElementById("cycling").selectedIndex =
       this._config.headline_bar_cycle_feeds ? 0 : 1;
@@ -165,6 +168,9 @@ Object.assign(Headlines_Area.prototype, {
       this._config.headline_bar_show_quick_filter_button;
     this._document.getElementById("homeIcon").checked =
       this._config.headline_bar_show_home_button;
+
+    this._location_changed();
+    this._scrolling_changed();
   },
 
   /** Update configuration from tab. */
@@ -177,8 +183,7 @@ Object.assign(Headlines_Area.prototype, {
       this._document.getElementById("mouseWheelScroll").selectedIndex;
 
     //scrolling section
-    this._config.headline_bar_scroll_style =
-      this._document.getElementById("scrolling").selectedIndex;
+    this._config.headline_bar_scroll_style = this._scrolling.selectedIndex;
     this._config.headline_bar_scroll_speed =
       this._document.getElementById("scrollingspeed1").value;
     this._config.headline_bar_scroll_increment =
@@ -235,6 +240,26 @@ Object.assign(Headlines_Area.prototype, {
   {
     this._collapse_bar.disabled =
       this._location.selectedIndex != this._config.In_Status_Bar;
+  },
+
+  /** Scrolling mode radio button updated.
+   *
+   * This is sometimes called as an event handler.
+   */
+  _scrolling_changed()
+  {
+    const disabled =
+      this._scrolling.selectedIndex === this._config.Static_Display;
+    //Which of these don't apply to fading?
+    for (const setting of [
+      "scrollingspeed1",
+      "scrollingIncrement1",
+      "stopscrolling",
+      "scrollingdirection"
+    ])
+    {
+      this._document.getElementById(setting).disabled = disabled;
+    }
   },
 
 });

--- a/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
+++ b/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Area.jsm
@@ -229,7 +229,7 @@ Object.assign(Headlines_Area.prototype, {
 
   /** Location radio button clicked.
    *
-   * This is sometimes called as an event hander, but not always.
+   * This is sometimes called as an event handler.
    */
   _location_changed()
   {

--- a/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Style.jsm
+++ b/source/content/inforss/windows/Options/Basic/inforss_Options_Basic_Headlines_Style.jsm
@@ -62,10 +62,10 @@ const { Base } = Components.utils.import(
   {}
 );
 
-/** Contains the code for the 'Basic' tab in the option screen
+/** Contains the code for the 'Basic' tab in the option screen.
  *
- * @param {XMLDocument} document - the options window this._document
- * @param {Options} options - main options window for some common code
+ * @param {Document} document - The options window this._document.
+ * @param {Options} options - Main options window class for some common code.
  */
 function Headlines_Style(document, options)
 {
@@ -134,9 +134,9 @@ Headlines_Style.prototype.constructor = Headlines_Style;
 
 Object.assign(Headlines_Style.prototype, {
 
-  /** Config has been loaded
+  /** Config has been loaded.
    *
-   * @param {Config} config - new config
+   * @param {Config} config - New config.
    */
   config_loaded(config)
   {
@@ -249,7 +249,7 @@ Object.assign(Headlines_Style.prototype, {
     this._update_sample_headline_bar();
   },
 
-  /** Update configuration from tab */
+  /** Update configuration from tab. */
   update()
   {
     //headlines style
@@ -308,11 +308,11 @@ Object.assign(Headlines_Style.prototype, {
   },
 
   /** This updates the sample headline bar according to the currently selected
-   * options in the screen
+   * options in the screen.
    *
-   * ignored @param event - event triggering (or undef)
+   * This is sometimes called as an event handler.
    */
-  _update_sample_headline_bar(/*event*/)
+  _update_sample_headline_bar()
   {
     //---------------------headline style---------------------
 
@@ -362,9 +362,9 @@ Object.assign(Headlines_Style.prototype, {
     this._display_recent_style(sample_default.style.color);
   },
 
-  /** Update the recent sample headline style
+  /** Update the recent sample headline style.
    *
-   * @param {integer} old_text_colour - colour of old headlines text
+   * @param {number} old_text_colour - Colour of old headlines text.
    */
   _display_recent_style(old_text_colour)
   {
@@ -379,6 +379,8 @@ Object.assign(Headlines_Style.prototype, {
       "inherit" :
       this._recent_background_colour.value;
     recent.style.backgroundColor = background;
+    this._recent_background_colour.disabled =
+      this._recent_use_background_colour.selectedIndex == 0;
 
     const foregroundColor =
       this._recent_foreground_colour_mode.selectedIndex == 0 ?

--- a/source/content/inforss/windows/Options/inforss_Options_Base.jsm
+++ b/source/content/inforss/windows/Options/inforss_Options_Base.jsm
@@ -56,6 +56,10 @@ const { remove_event_listeners } = Components.utils.import(
   "chrome://inforss/content/modules/inforss_Utils.jsm", {}
 );
 
+//const { console } = Components.utils.import(
+//  "resource://gre/modules/Console.jsm", {}
+//);
+
 /** Base class for all options tabs.
  *
  * This contains a lot of boilerplate code for operations common to all tabs,
@@ -155,7 +159,7 @@ Base.prototype = {
 
   /** Update the toggle state for a feed.
    *
-   * @param {RSS} feed - feed that has changed
+   * @param {RSS} feed - Feed that has changed.
    */
   feed_active_state_changed(feed)
   {


### PR DESCRIPTION
This rearranges the Basic/Headlines area tab and disables selections which have become inapplicable as the result of another selection. The selections on the tab have been rearrange a bit to make it clearer which bits related to each other.

Fixes #46 